### PR TITLE
fix: 为 PasswordBox 和部分 TextBox 渲染方法添加像素对齐

### DIFF
--- a/src/managed/Jalium.UI.Controls/PasswordBox.cs
+++ b/src/managed/Jalium.UI.Controls/PasswordBox.cs
@@ -224,7 +224,8 @@ public class PasswordBox : Control
         var fontFamily = FontFamily ?? "Segoe UI";
         var fontSize = FontSize > 0 ? FontSize : 14;
         var fontMetrics = TextMeasurement.GetFontMetrics(fontFamily, fontSize);
-        var lineHeight = fontMetrics.LineHeight;
+        // Round lineHeight to ensure consistent sizing with rendering
+        var lineHeight = Math.Round(fontMetrics.LineHeight);
 
         // Measure the password character to get actual width
         var passwordCharStr = new string(PasswordChar, 1);
@@ -306,13 +307,18 @@ public class PasswordBox : Control
         var fontFamily = FontFamily ?? "Segoe UI";
         var fontSize = FontSize > 0 ? FontSize : 14;
         var fontMetrics = TextMeasurement.GetFontMetrics(fontFamily, fontSize);
-        var lineHeight = fontMetrics.LineHeight;
+        // Round lineHeight to avoid sub-pixel positioning issues
+        var lineHeight = Math.Round(fontMetrics.LineHeight);
 
         // Measure the password character to get actual width
         var passwordCharStr = new string(PasswordChar, 1);
         var passwordCharText = new FormattedText(passwordCharStr, fontFamily, fontSize);
         TextMeasurement.MeasureText(passwordCharText);
         var charWidth = passwordCharText.Width;
+
+        // Round to pixel boundaries to prevent sub-pixel jittering
+        var textX = Math.Round(contentRect.X);
+        var textY = Math.Round(contentRect.Y);
 
         // Draw masked password or placeholder
         if (string.IsNullOrEmpty(_password))
@@ -325,9 +331,9 @@ public class PasswordBox : Control
                 {
                     Foreground = placeholderBrush,
                     MaxTextWidth = contentRect.Width,
-                    MaxTextHeight = contentRect.Height
+                    MaxTextHeight = lineHeight
                 };
-                dc.DrawText(formattedPlaceholder, new Point(contentRect.X, contentRect.Y));
+                dc.DrawText(formattedPlaceholder, new Point(textX, textY));
             }
         }
         else
@@ -338,9 +344,9 @@ public class PasswordBox : Control
             {
                 Foreground = Foreground,
                 MaxTextWidth = contentRect.Width,
-                MaxTextHeight = contentRect.Height
+                MaxTextHeight = lineHeight
             };
-            dc.DrawText(formattedText, new Point(contentRect.X, contentRect.Y));
+            dc.DrawText(formattedText, new Point(textX, textY));
         }
 
         // Draw caret
@@ -362,12 +368,14 @@ public class PasswordBox : Control
         if (CaretBrush == null)
             return;
 
-        var caretX = contentRect.X + _caretIndex * charWidth;
+        // Round to pixel boundaries to prevent sub-pixel jittering
+        var caretX = Math.Round(contentRect.X + _caretIndex * charWidth);
+        var caretY = Math.Round(contentRect.Y);
         var caretPen = new Pen(CaretBrush, 1);
 
         dc.DrawLine(caretPen,
-            new Point(caretX, contentRect.Y),
-            new Point(caretX, contentRect.Y + lineHeight));
+            new Point(caretX, caretY),
+            new Point(caretX, caretY + lineHeight));
     }
 
     #endregion

--- a/src/managed/Jalium.UI.Controls/TextBox.cs
+++ b/src/managed/Jalium.UI.Controls/TextBox.cs
@@ -891,7 +891,8 @@ public class TextBox : TextBoxBase, IImeSupport
             {
                 var line = _lines[i];
                 var lineEnd = line.StartIndex + line.Length;
-                var y = contentRect.Y + i * lineHeight - _verticalOffset;
+                // Round to pixel boundaries to prevent sub-pixel jittering
+                var y = Math.Round(contentRect.Y + i * lineHeight - _verticalOffset);
 
                 // Skip lines outside visible area
                 if (y + lineHeight < contentRect.Y || y > contentRect.Y + contentRect.Height)
@@ -910,7 +911,7 @@ public class TextBox : TextBoxBase, IImeSupport
                         var textBefore = lineText.Substring(0, startInLine);
                         var errorText = lineText.Substring(startInLine, endInLine - startInLine);
 
-                        var startX = contentRect.X + MeasureTextWidth(textBefore) - _horizontalOffset;
+                        var startX = Math.Round(contentRect.X + MeasureTextWidth(textBefore) - _horizontalOffset);
                         var endX = startX + MeasureTextWidth(errorText);
                         var underlineY = y + lineHeight - 2;
 
@@ -1011,8 +1012,9 @@ public class TextBox : TextBoxBase, IImeSupport
         var lineText = GetLineTextInternal(lineIndex);
         var textBeforeCaret = lineText.Substring(0, Math.Min(columnIndex, lineText.Length));
 
-        var x = contentRect.X + MeasureTextWidth(textBeforeCaret) - _horizontalOffset;
-        var y = contentRect.Y + lineIndex * lineHeight - _verticalOffset;
+        // Round to pixel boundaries to prevent sub-pixel jittering
+        var x = Math.Round(contentRect.X + MeasureTextWidth(textBeforeCaret) - _horizontalOffset);
+        var y = Math.Round(contentRect.Y + lineIndex * lineHeight - _verticalOffset);
 
         // Draw composition background
         var compositionWidth = MeasureTextWidth(_imeCompositionString);


### PR DESCRIPTION
- PasswordBox: 添加 Math.Round 像素对齐防止文本和光标抖动
- TextBox DrawImeComposition: 添加像素对齐
- TextBox DrawSpellingErrors: 添加像素对齐