### PR TITLE
feat: 实现 ResourceDictionary.MergedDictionaries 和 Source 属性加载

### DIFF
--- a/src/managed/Jalium.UI.Controls/Jalium.UI.Controls.csproj
+++ b/src/managed/Jalium.UI.Controls/Jalium.UI.Controls.csproj
@@ -13,11 +13,9 @@
     <ProjectReference Include="..\Jalium.UI.Interop\Jalium.UI.Interop.csproj" />
   </ItemGroup>
 
-  <!-- Embed theme files as resources -->
+  <!-- Embed theme files as resources (default naming: Jalium.UI.Controls.Themes.{path}.{filename}.jalxaml) -->
   <ItemGroup>
-    <EmbeddedResource Include="Themes\**\*.jalxaml">
-      <LogicalName>Jalium.UI.Controls.Themes.%(Filename)%(Extension)</LogicalName>
-    </EmbeddedResource>
+    <EmbeddedResource Include="Themes\**\*.jalxaml" />
   </ItemGroup>
 
 </Project>

--- a/src/managed/Jalium.UI.Controls/Themes/ThemeManager.cs
+++ b/src/managed/Jalium.UI.Controls/Themes/ThemeManager.cs
@@ -71,24 +71,40 @@ public static class ThemeManager
                 return null;
             }
 
-            // Get the Load(Stream) method
-            var loadMethod = xamlReaderType.GetMethod("Load", [typeof(Stream)]);
+            // Get the Load(Stream, string, Assembly) method for proper context
+            var loadMethod = xamlReaderType.GetMethod("Load", [typeof(Stream), typeof(string), typeof(Assembly)]);
             if (loadMethod == null)
             {
-                System.Diagnostics.Debug.WriteLine("Warning: XamlReader.Load(Stream) method not found.");
-                return null;
+                // Fallback to Load(Stream) if new overload not available
+                loadMethod = xamlReaderType.GetMethod("Load", [typeof(Stream)]);
+                if (loadMethod == null)
+                {
+                    System.Diagnostics.Debug.WriteLine("Warning: XamlReader.Load method not found.");
+                    return null;
+                }
+
+                // Get the theme stream
+                using var stream = GetGenericThemeStream();
+                if (stream == null)
+                {
+                    return null;
+                }
+
+                // Invoke XamlReader.Load(stream)
+                var result = loadMethod.Invoke(null, [stream]);
+                return result as ResourceDictionary;
             }
 
             // Get the theme stream
-            using var stream = GetGenericThemeStream();
-            if (stream == null)
+            using var themeStream = GetGenericThemeStream();
+            if (themeStream == null)
             {
                 return null;
             }
 
-            // Invoke XamlReader.Load(stream)
-            var result = loadMethod.Invoke(null, [stream]);
-            return result as ResourceDictionary;
+            // Invoke XamlReader.Load(stream, resourceName, assembly) with proper context
+            var themeResult = loadMethod.Invoke(null, [themeStream, "Themes/Generic.jalxaml", ControlsAssembly]);
+            return themeResult as ResourceDictionary;
         }
         catch (Exception ex)
         {

--- a/src/managed/Jalium.UI.Core/Jalium.UI.Core.csproj
+++ b/src/managed/Jalium.UI.Core/Jalium.UI.Core.csproj
@@ -10,6 +10,7 @@
     <InternalsVisibleTo Include="Jalium.UI.Input" />
     <InternalsVisibleTo Include="Jalium.UI.Controls" />
     <InternalsVisibleTo Include="Jalium.UI.Interop" />
+    <InternalsVisibleTo Include="Jalium.UI.Xaml" />
   </ItemGroup>
 
 </Project>

--- a/src/managed/Jalium.UI.Core/ResourceDictionary.cs
+++ b/src/managed/Jalium.UI.Core/ResourceDictionary.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 
 namespace Jalium.UI;
 
@@ -11,11 +12,63 @@ public class ResourceDictionary : IDictionary<object, object?>, IDictionary
 {
     private readonly Dictionary<object, object?> _innerDictionary = new();
     private readonly List<ResourceDictionary> _mergedDictionaries = new();
+    private Uri? _source;
 
     /// <summary>
     /// Gets a collection of merged dictionaries.
     /// </summary>
     public IList<ResourceDictionary> MergedDictionaries => _mergedDictionaries;
+
+    /// <summary>
+    /// Gets or sets the uniform resource identifier (URI) to load resources from.
+    /// When set, the dictionary loads resources from the specified location.
+    /// </summary>
+    /// <remarks>
+    /// The Source property is used to load resources from an external XAML file.
+    /// Relative paths are resolved against the BaseUri of the parent dictionary.
+    /// The actual loading is performed by the XAML parser during parsing.
+    /// </remarks>
+    public Uri? Source
+    {
+        get => _source;
+        set => _source = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the base URI for resolving relative Source paths.
+    /// This is typically set by the XAML parser during loading.
+    /// </summary>
+    internal Uri? BaseUri { get; set; }
+
+    /// <summary>
+    /// Gets or sets the assembly used for loading embedded resources.
+    /// This is typically set by the XAML parser during loading.
+    /// </summary>
+    internal Assembly? SourceAssembly { get; set; }
+
+    /// <summary>
+    /// Gets or sets a callback used by the XAML parser to load ResourceDictionary from Source.
+    /// This allows the Core assembly to remain independent of the Xaml assembly.
+    /// </summary>
+    public static Func<ResourceDictionary, Uri, Assembly?, ResourceDictionary?>? SourceLoader { get; set; }
+
+    /// <summary>
+    /// Copies all resources from another dictionary into this one.
+    /// </summary>
+    /// <param name="source">The source dictionary to copy from.</param>
+    internal void CopyFrom(ResourceDictionary source)
+    {
+        foreach (var kvp in source._innerDictionary)
+        {
+            _innerDictionary[kvp.Key] = kvp.Value;
+        }
+
+        // Also copy merged dictionaries
+        foreach (var merged in source._mergedDictionaries)
+        {
+            _mergedDictionaries.Add(merged);
+        }
+    }
 
     /// <summary>
     /// Gets the number of items in this dictionary (not including merged dictionaries).

--- a/src/managed/Jalium.UI.Xaml/XamlReader.cs
+++ b/src/managed/Jalium.UI.Xaml/XamlReader.cs
@@ -45,6 +45,34 @@ public static class XamlReader
     }
 
     /// <summary>
+    /// Reads XAML from a stream and creates an object tree with assembly context.
+    /// </summary>
+    /// <param name="stream">The stream containing XAML.</param>
+    /// <param name="resourceName">The embedded resource name (used for resolving relative paths).</param>
+    /// <param name="sourceAssembly">The assembly containing the resource.</param>
+    /// <returns>The root of the created object tree.</returns>
+    public static object Load(Stream stream, string resourceName, Assembly sourceAssembly)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        ArgumentNullException.ThrowIfNull(resourceName);
+        ArgumentNullException.ThrowIfNull(sourceAssembly);
+
+        using var textReader = new StreamReader(stream);
+        var settings = new XmlReaderSettings
+        {
+            IgnoreComments = true,
+            IgnoreWhitespace = true,
+            IgnoreProcessingInstructions = true
+        };
+
+        // Create base URI from resource name (use file-like path for relative resolution)
+        var baseUri = new Uri($"resource:///{sourceAssembly.GetName().Name}/{resourceName}", UriKind.Absolute);
+
+        using var xmlReader = XmlReader.Create(textReader, settings);
+        return LoadInternal(xmlReader, null, baseUri, sourceAssembly);
+    }
+
+    /// <summary>
     /// Reads XAML from a text reader and creates an object tree.
     /// </summary>
     /// <param name="reader">The text reader containing XAML.</param>
@@ -61,7 +89,7 @@ public static class XamlReader
         };
 
         using var xmlReader = XmlReader.Create(reader, settings);
-        return LoadInternal(xmlReader, null);
+        return LoadInternal(xmlReader, null, null, null);
     }
 
     /// <summary>
@@ -94,8 +122,11 @@ public static class XamlReader
                 IgnoreProcessingInstructions = true
             };
 
+            // Create base URI from resource name (use file-like path for relative resolution)
+            var baseUri = new Uri($"resource:///{assembly.GetName().Name}/{resourceName}", UriKind.Absolute);
+
             using var xmlReader = XmlReader.Create(textReader, settings);
-            LoadInternal(xmlReader, component);
+            LoadInternal(xmlReader, component, baseUri, assembly);
         }
     }
 
@@ -118,9 +149,14 @@ public static class XamlReader
         return stream;
     }
 
-    private static object LoadInternal(XmlReader reader, object? existingInstance)
+    private static object LoadInternal(XmlReader reader, object? existingInstance, Uri? baseUri, Assembly? sourceAssembly, ResourceDictionary? parentResourceDictionary = null)
     {
-        var context = new XamlParserContext();
+        var context = new XamlParserContext
+        {
+            BaseUri = baseUri,
+            SourceAssembly = sourceAssembly,
+            ParentResourceDictionary = parentResourceDictionary
+        };
 
         while (reader.Read())
         {
@@ -493,6 +529,166 @@ public static class XamlReader
         }
     }
 
+    /// <summary>
+    /// Handles the Source property on ResourceDictionary by loading the external XAML file.
+    /// </summary>
+    private static void HandleResourceDictionarySource(ResourceDictionary resourceDict, string sourceValue, XamlParserContext context)
+    {
+        // Create URI from source value
+        Uri sourceUri;
+        if (Uri.TryCreate(sourceValue, UriKind.Absolute, out var absoluteUri))
+        {
+            sourceUri = absoluteUri;
+        }
+        else
+        {
+            // Relative URI - resolve against BaseUri
+            if (context.BaseUri != null)
+            {
+                // For pack:// URIs, we need to handle the path resolution differently
+                var baseUriString = context.BaseUri.ToString();
+                var lastSlash = baseUriString.LastIndexOf('/');
+                if (lastSlash >= 0)
+                {
+                    var basePath = baseUriString.Substring(0, lastSlash + 1);
+                    sourceUri = new Uri(basePath + sourceValue, UriKind.Absolute);
+                }
+                else
+                {
+                    sourceUri = new Uri(context.BaseUri, sourceValue);
+                }
+            }
+            else
+            {
+                sourceUri = new Uri(sourceValue, UriKind.Relative);
+            }
+        }
+
+        // Store the Source URI on the ResourceDictionary
+        resourceDict.Source = sourceUri;
+        resourceDict.BaseUri = context.BaseUri;
+        resourceDict.SourceAssembly = context.SourceAssembly;
+
+        // Find the parent ResourceDictionary (the one that will contain this in MergedDictionaries)
+        // The parent is needed so child XAML can reference resources from sibling dictionaries
+        var parentDict = context.FindParentResourceDictionary(resourceDict);
+
+        // Use the SourceLoader callback to load the external XAML
+        if (ResourceDictionary.SourceLoader != null)
+        {
+            var loadedDict = ResourceDictionary.SourceLoader(resourceDict, sourceUri, context.SourceAssembly);
+            if (loadedDict != null)
+            {
+                // Copy the loaded content into the current ResourceDictionary
+                resourceDict.CopyFrom(loadedDict);
+            }
+        }
+        else
+        {
+            // No SourceLoader registered - try to load directly
+            LoadResourceDictionaryFromUri(resourceDict, sourceUri, context, parentDict);
+        }
+    }
+
+    /// <summary>
+    /// Loads a ResourceDictionary from a URI using embedded resources.
+    /// </summary>
+    private static void LoadResourceDictionaryFromUri(ResourceDictionary resourceDict, Uri sourceUri, XamlParserContext context, ResourceDictionary? parentDict = null)
+    {
+        var assembly = context.SourceAssembly;
+
+        // Convert URI to resource name
+        string resourceName;
+        var uriString = sourceUri.ToString();
+
+        // Handle resource:// URIs (our custom scheme)
+        if (uriString.StartsWith("resource:///"))
+        {
+            var path = uriString.Substring("resource:///".Length);
+            // Extract assembly name and resource path (format: AssemblyName/path/to/resource)
+            var firstSlash = path.IndexOf('/');
+            if (firstSlash >= 0)
+            {
+                var assemblyName = path.Substring(0, firstSlash);
+                resourceName = path.Substring(firstSlash + 1);
+
+                // Try to find the assembly
+                var loadedAssembly = AppDomain.CurrentDomain.GetAssemblies()
+                    .FirstOrDefault(a => a.GetName().Name == assemblyName);
+                if (loadedAssembly != null)
+                {
+                    assembly = loadedAssembly;
+                }
+            }
+            else
+            {
+                resourceName = path;
+            }
+        }
+        else if (sourceUri.IsAbsoluteUri)
+        {
+            resourceName = sourceUri.LocalPath.TrimStart('/');
+        }
+        else
+        {
+            resourceName = uriString;
+        }
+
+        // If assembly is still null, try to get it from the ResourceDictionary or find by convention
+        if (assembly == null)
+        {
+            // Try to get from the ResourceDictionary's stored assembly
+            assembly = resourceDict.SourceAssembly;
+        }
+
+        if (assembly == null)
+        {
+            // Try to find Jalium.UI.Controls assembly as fallback for theme resources
+            assembly = AppDomain.CurrentDomain.GetAssemblies()
+                .FirstOrDefault(a => a.GetName().Name == "Jalium.UI.Controls");
+        }
+
+        if (assembly == null)
+        {
+            throw new XamlParseException($"Cannot load ResourceDictionary from '{sourceUri}': no source assembly available.");
+        }
+
+        // Normalize the resource name (replace slashes with dots for embedded resources)
+        var normalizedResourceName = resourceName.Replace('/', '.').Replace('\\', '.');
+
+        // Try to load the embedded resource
+        var stream = GetResourceStream(normalizedResourceName, assembly);
+        if (stream == null)
+        {
+            // Try with the original path format
+            stream = GetResourceStream(resourceName, assembly);
+        }
+
+        if (stream == null)
+        {
+            throw new XamlParseException($"Cannot find embedded resource '{resourceName}' in assembly '{assembly.GetName().Name}'.");
+        }
+
+        using (stream)
+        using (var textReader = new StreamReader(stream))
+        {
+            var settings = new XmlReaderSettings
+            {
+                IgnoreComments = true,
+                IgnoreWhitespace = true,
+                IgnoreProcessingInstructions = true
+            };
+
+            // Create new context with updated BaseUri for the loaded file
+            // Pass the parent dictionary so child XAML can reference resources from sibling dictionaries
+            using var xmlReader = XmlReader.Create(textReader, settings);
+            var loadedDict = (ResourceDictionary)LoadInternal(xmlReader, null, sourceUri, assembly, parentDict);
+
+            // Copy the loaded content into the current ResourceDictionary
+            resourceDict.CopyFrom(loadedDict);
+        }
+    }
+
     [UnconditionalSuppressMessage("AOT", "IL2070:Target method argument",
         Justification = "Types are registered in XamlTypeRegistry with DynamicallyAccessedMembers")]
     private static void SetProperty(object instance, string propertyName, object? value, XamlParserContext context)
@@ -508,6 +704,13 @@ public static class XamlReader
 
         if (!property.CanWrite)
         {
+            return;
+        }
+
+        // Special handling for ResourceDictionary.Source
+        if (instance is ResourceDictionary resourceDict && propertyName == "Source" && value is string sourceValue)
+        {
+            HandleResourceDictionarySource(resourceDict, sourceValue, context);
             return;
         }
 
@@ -779,6 +982,23 @@ internal class XamlParserContext : IAmbientResourceProvider
     private string? _currentResourceKey;
 
     /// <summary>
+    /// Gets or sets the base URI for resolving relative Source paths.
+    /// </summary>
+    public Uri? BaseUri { get; set; }
+
+    /// <summary>
+    /// Gets or sets the assembly used for loading embedded resources.
+    /// </summary>
+    public Assembly? SourceAssembly { get; set; }
+
+    /// <summary>
+    /// Gets or sets the parent ResourceDictionary for ambient resource lookup.
+    /// This is used when loading child ResourceDictionaries (via Source) to allow
+    /// them to reference resources from already-loaded sibling dictionaries.
+    /// </summary>
+    public ResourceDictionary? ParentResourceDictionary { get; set; }
+
+    /// <summary>
     /// Sets the current resource key (from x:Key attribute).
     /// </summary>
     public void SetCurrentResourceKey(string key) => _currentResourceKey = key;
@@ -794,7 +1014,7 @@ internal class XamlParserContext : IAmbientResourceProvider
     public void ClearCurrentResourceKey() => _currentResourceKey = null;
 
     /// <summary>
-    /// Tries to find a resource by key in the ambient resource dictionaries (parent stack).
+    /// Tries to find a resource by key in the ambient resource dictionaries (parent stack and parent dictionary).
     /// </summary>
     public bool TryGetResource(object key, out object? value)
     {
@@ -805,6 +1025,14 @@ internal class XamlParserContext : IAmbientResourceProvider
             {
                 return true;
             }
+        }
+
+        // Search through the parent ResourceDictionary's MergedDictionaries
+        // This allows child XAML files to reference resources from sibling dictionaries
+        // that were loaded earlier (e.g., Button.jalxaml can reference Colors.jalxaml resources)
+        if (ParentResourceDictionary != null && ParentResourceDictionary.TryGetValue(key, out value))
+        {
+            return true;
         }
 
         value = null;
@@ -832,6 +1060,29 @@ internal class XamlParserContext : IAmbientResourceProvider
                 return typed;
         }
         return null;
+    }
+
+    /// <summary>
+    /// Finds the parent ResourceDictionary that will contain the specified child dictionary.
+    /// This skips the child itself in the parent stack.
+    /// </summary>
+    public ResourceDictionary? FindParentResourceDictionary(ResourceDictionary child)
+    {
+        bool foundChild = false;
+        foreach (var parent in _parentStack)
+        {
+            if (parent == child)
+            {
+                foundChild = true;
+                continue;
+            }
+            if (foundChild && parent is ResourceDictionary rd)
+            {
+                return rd;
+            }
+        }
+        // If the child wasn't found, just return the first ResourceDictionary
+        return FindParent<ResourceDictionary>();
     }
 
     /// <summary>


### PR DESCRIPTION
- 添加 ResourceDictionary.Source 属性用于加载外部 XAML 文件
- 添加 XamlReader.Load(Stream, string, Assembly) 重载支持资源上下文
- 实现 resource:// URI 方案用于相对路径解析
- 修复 StaticResource 查找，支持跨 MergedDictionaries 引用
- 修复嵌入资源命名以保留目录结构
- 添加 InternalsVisibleTo 允许 Xaml 项目访问 Core 内部成员