### PR TITLE
feat: 实现基于 ControlTemplate 的 Button 渲染

### DIFF
--- a/samples/Jalium.UI.Gallery/GalleryWindow.jalxaml.cs
+++ b/samples/Jalium.UI.Gallery/GalleryWindow.jalxaml.cs
@@ -81,6 +81,7 @@ public partial class GalleryWindow : Window
 
         // Navigate to home page
         NavigateToPage("home");
+        SystemBackdrop = WindowBackdropType.Mica;
     }
 
     private void AddNavigationItems()

--- a/src/managed/Jalium.UI.Controls/Application.cs
+++ b/src/managed/Jalium.UI.Controls/Application.cs
@@ -67,9 +67,12 @@ public partial class Application
 
     private static object? LookupApplicationResource(object resourceKey)
     {
-        if (_current?._resources != null && _current._resources.TryGetValue(resourceKey, out var value))
+        if (_current?._resources != null)
         {
-            return value;
+            if (_current._resources.TryGetValue(resourceKey, out var value))
+            {
+                return value;
+            }
         }
         return null;
     }

--- a/src/managed/Jalium.UI.Controls/Button.cs
+++ b/src/managed/Jalium.UI.Controls/Button.cs
@@ -1,10 +1,8 @@
-using Jalium.UI.Interop;
-using Jalium.UI.Media;
-
 namespace Jalium.UI.Controls;
 
 /// <summary>
 /// Represents a button control.
+/// Uses ControlTemplate for rendering - visual appearance is defined in Button.jalxaml.
 /// </summary>
 public class Button : ButtonBase
 {
@@ -44,112 +42,6 @@ public class Button : ButtonBase
     {
         get => (bool)(GetValue(IsCancelProperty) ?? false);
         set => SetValue(IsCancelProperty, value);
-    }
-
-    #endregion
-
-    #region Layout
-
-    /// <inheritdoc />
-    protected override Size MeasureOverride(Size availableSize)
-    {
-        // Measure content
-        var padding = Padding;
-        var border = BorderThickness;
-        var contentAvailable = new Size(
-            Math.Max(0, availableSize.Width - padding.TotalWidth - border.TotalWidth),
-            Math.Max(0, availableSize.Height - padding.TotalHeight - border.TotalHeight));
-
-        // Get content size
-        var contentSize = MeasureContent(contentAvailable);
-
-        return new Size(
-            contentSize.Width + padding.TotalWidth + border.TotalWidth,
-            contentSize.Height + padding.TotalHeight + border.TotalHeight);
-    }
-
-    private Size MeasureContent(Size availableSize)
-    {
-        if (Content is string text)
-        {
-            var fontFamily = FontFamily ?? "Segoe UI";
-            var fontSize = FontSize > 0 ? FontSize : 14;
-            var formattedText = new FormattedText(text, fontFamily, fontSize);
-            TextMeasurement.MeasureText(formattedText);
-            return new Size(formattedText.Width, formattedText.Height);
-        }
-
-        if (Content is UIElement element)
-        {
-            element.Measure(availableSize);
-            return element.DesiredSize;
-        }
-
-        return new Size(0, 0);
-    }
-
-    #endregion
-
-    #region Rendering
-
-    /// <inheritdoc />
-    protected override void OnRender(object drawingContext)
-    {
-        if (drawingContext is not DrawingContext dc)
-            return;
-
-        var rect = new Rect(RenderSize);
-        var cornerRadius = CornerRadius;
-        var hasCornerRadius = cornerRadius.TopLeft > 0 || cornerRadius.TopRight > 0 ||
-                              cornerRadius.BottomLeft > 0 || cornerRadius.BottomRight > 0;
-
-        // Use property values directly - styles and triggers handle state changes
-        var bgBrush = Background;
-        var borderBrush = BorderBrush;
-        var fgBrush = Foreground;
-
-        // Draw background
-        if (bgBrush != null)
-        {
-            if (hasCornerRadius)
-            {
-                dc.DrawRoundedRectangle(bgBrush, null, rect, cornerRadius.TopLeft, cornerRadius.TopLeft);
-            }
-            else
-            {
-                dc.DrawRectangle(bgBrush, null, rect);
-            }
-        }
-
-        // Draw border
-        if (borderBrush != null && BorderThickness.TotalWidth > 0)
-        {
-            var pen = new Pen(borderBrush, BorderThickness.Left);
-            if (hasCornerRadius)
-            {
-                dc.DrawRoundedRectangle(null, pen, rect, cornerRadius.TopLeft, cornerRadius.TopLeft);
-            }
-            else
-            {
-                dc.DrawRectangle(null, pen, rect);
-            }
-        }
-
-        // Draw content
-        if (Content is string text && fgBrush != null)
-        {
-            var formattedText = new FormattedText(text, FontFamily, FontSize)
-            {
-                Foreground = fgBrush
-            };
-
-            // Use proper text measurement for centering
-            TextMeasurement.MeasureText(formattedText);
-            var textX = (rect.Width - formattedText.Width) / 2;
-            var textY = (rect.Height - formattedText.Height) / 2;
-
-            dc.DrawText(formattedText, new Point(textX, textY));
-        }
     }
 
     #endregion

--- a/src/managed/Jalium.UI.Controls/ButtonBase.cs
+++ b/src/managed/Jalium.UI.Controls/ButtonBase.cs
@@ -76,6 +76,8 @@ public abstract class ButtonBase : ContentControl
     /// </summary>
     protected ButtonBase()
     {
+        // Use ControlTemplate for visual appearance instead of direct content
+        UseTemplateContentManagement();
         Focusable = true;
 
         // Register mouse event handlers

--- a/src/managed/Jalium.UI.Controls/ContentControl.cs
+++ b/src/managed/Jalium.UI.Controls/ContentControl.cs
@@ -2,10 +2,13 @@ namespace Jalium.UI.Controls;
 
 /// <summary>
 /// Base class for content controls.
+/// Uses direct content management by default. Controls with ControlTemplate (like Button)
+/// rely on the template's ContentPresenter to display content instead.
 /// </summary>
 public class ContentControl : Control
 {
     private UIElement? _contentElement;
+    private bool _usesDirectContent = true; // Default to direct content management
 
     /// <summary>
     /// Identifies the Content dependency property.
@@ -39,6 +42,26 @@ public class ContentControl : Control
         set => SetValue(ContentTemplateProperty, value);
     }
 
+    /// <summary>
+    /// Gets the content element for direct content management.
+    /// </summary>
+    protected UIElement? ContentElement => _contentElement;
+
+    /// <summary>
+    /// Disables direct content management. Call this in the constructor of controls
+    /// that use ControlTemplate with ContentPresenter (e.g., Button).
+    /// </summary>
+    protected void UseTemplateContentManagement()
+    {
+        _usesDirectContent = false;
+    }
+
+    /// <summary>
+    /// Gets whether this control uses direct content management.
+    /// Returns true for most controls; false for controls using ControlTemplate.
+    /// </summary>
+    protected bool UsesDirectContent => _usesDirectContent;
+
     private static void OnContentChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
         if (d is ContentControl control)
@@ -61,78 +84,108 @@ public class ContentControl : Control
     /// </summary>
     protected virtual void OnContentChanged(object? oldContent, object? newContent)
     {
-        // Remove old content from visual tree
-        if (_contentElement != null)
+        if (_usesDirectContent)
         {
-            RemoveVisualChild(_contentElement);
-            _contentElement = null;
-        }
+            // Direct content management
+            if (_contentElement != null)
+            {
+                RemoveVisualChild(_contentElement);
+                _contentElement = null;
+            }
 
-        // Add new content to visual tree if it's a UIElement
-        if (newContent is UIElement newElement)
-        {
-            _contentElement = newElement;
-            AddVisualChild(newElement);
+            if (newContent is UIElement newElement)
+            {
+                _contentElement = newElement;
+                AddVisualChild(newElement);
+            }
         }
 
         InvalidateMeasure();
     }
 
-    /// <summary>
-    /// Gets the content element if it's a UIElement.
-    /// </summary>
-    protected UIElement? ContentElement => _contentElement;
+    #region Visual Children
 
     /// <inheritdoc />
-    public override int VisualChildrenCount => _contentElement != null ? 1 : 0;
+    public override int VisualChildrenCount
+    {
+        get
+        {
+            if (_usesDirectContent)
+            {
+                return _contentElement != null ? 1 : 0;
+            }
+            // Template-based: use Control's implementation
+            return base.VisualChildrenCount;
+        }
+    }
 
     /// <inheritdoc />
     public override Visual? GetVisualChild(int index)
     {
-        if (index == 0 && _contentElement != null)
-            return _contentElement;
-        throw new ArgumentOutOfRangeException(nameof(index));
+        if (_usesDirectContent)
+        {
+            if (index == 0 && _contentElement != null)
+            {
+                return _contentElement;
+            }
+            throw new ArgumentOutOfRangeException(nameof(index));
+        }
+        // Template-based: use Control's implementation
+        return base.GetVisualChild(index);
     }
+
+    #endregion
+
+    #region Layout
 
     /// <inheritdoc />
     protected override Size MeasureOverride(Size availableSize)
     {
-        if (_contentElement != null)
+        if (_usesDirectContent)
         {
-            var padding = Padding;
-            var border = BorderThickness;
-            var contentAvailable = new Size(
-                Math.Max(0, availableSize.Width - padding.TotalWidth - border.TotalWidth),
-                Math.Max(0, availableSize.Height - padding.TotalHeight - border.TotalHeight));
+            if (_contentElement != null)
+            {
+                var padding = Padding;
+                var border = BorderThickness;
+                var contentAvailable = new Size(
+                    Math.Max(0, availableSize.Width - padding.TotalWidth - border.TotalWidth),
+                    Math.Max(0, availableSize.Height - padding.TotalHeight - border.TotalHeight));
 
-            _contentElement.Measure(contentAvailable);
+                _contentElement.Measure(contentAvailable);
 
-            return new Size(
-                _contentElement.DesiredSize.Width + padding.TotalWidth + border.TotalWidth,
-                _contentElement.DesiredSize.Height + padding.TotalHeight + border.TotalHeight);
+                return new Size(
+                    _contentElement.DesiredSize.Width + padding.TotalWidth + border.TotalWidth,
+                    _contentElement.DesiredSize.Height + padding.TotalHeight + border.TotalHeight);
+            }
+            return Size.Empty;
         }
-
+        // Template-based: use Control's implementation
         return base.MeasureOverride(availableSize);
     }
 
     /// <inheritdoc />
     protected override Size ArrangeOverride(Size finalSize)
     {
-        if (_contentElement is FrameworkElement fe)
+        if (_usesDirectContent)
         {
-            var padding = Padding;
-            var border = BorderThickness;
+            if (_contentElement is FrameworkElement fe)
+            {
+                var padding = Padding;
+                var border = BorderThickness;
 
-            var contentRect = new Rect(
-                padding.Left + border.Left,
-                padding.Top + border.Top,
-                Math.Max(0, finalSize.Width - padding.TotalWidth - border.TotalWidth),
-                Math.Max(0, finalSize.Height - padding.TotalHeight - border.TotalHeight));
+                var contentRect = new Rect(
+                    padding.Left + border.Left,
+                    padding.Top + border.Top,
+                    Math.Max(0, finalSize.Width - padding.TotalWidth - border.TotalWidth),
+                    Math.Max(0, finalSize.Height - padding.TotalHeight - border.TotalHeight));
 
-            fe.Arrange(contentRect);
-            // Note: Do NOT call SetVisualBounds here - ArrangeCore already handles margin
+                fe.Arrange(contentRect);
+            }
+            return finalSize;
         }
-
-        return finalSize;
+        // Template-based: use Control's implementation
+        return base.ArrangeOverride(finalSize);
     }
+
+    #endregion
 }

--- a/src/managed/Jalium.UI.Controls/ContentPresenter.cs
+++ b/src/managed/Jalium.UI.Controls/ContentPresenter.cs
@@ -156,12 +156,12 @@ public class ContentPresenter : FrameworkElement
     #region Template Binding
 
     /// <inheritdoc />
-    protected override void OnVisualParentChanged(Visual? oldParent)
+    protected override void OnTemplatedParentChanged(FrameworkElement? oldParent, FrameworkElement? newParent)
     {
-        base.OnVisualParentChanged(oldParent);
+        base.OnTemplatedParentChanged(oldParent, newParent);
 
-        // When added to the visual tree, try to set up template bindings
-        if (!_templateBindingsApplied && TemplatedParent != null)
+        // When TemplatedParent is set, apply template bindings
+        if (!_templateBindingsApplied && newParent != null)
         {
             ApplyTemplateBindings();
         }
@@ -182,7 +182,7 @@ public class ContentPresenter : FrameworkElement
         // Find the property on the templated parent
         var parentType = TemplatedParent.GetType();
 
-        // Try to find Content property
+        // Try to find Content property and bind it
         var contentPropInfo = parentType.GetProperty(contentSource);
         if (contentPropInfo != null)
         {
@@ -205,6 +205,22 @@ public class ContentPresenter : FrameworkElement
             {
                 this.SetTemplateBinding(ContentTemplateProperty, templateDp);
             }
+        }
+
+        // Bind HorizontalContentAlignment -> HorizontalAlignment
+        var hcaDpField = parentType.GetField("HorizontalContentAlignmentProperty",
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.FlattenHierarchy);
+        if (hcaDpField?.GetValue(null) is DependencyProperty hcaDp)
+        {
+            this.SetTemplateBinding(HorizontalAlignmentProperty, hcaDp);
+        }
+
+        // Bind VerticalContentAlignment -> VerticalAlignment
+        var vcaDpField = parentType.GetField("VerticalContentAlignmentProperty",
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.FlattenHierarchy);
+        if (vcaDpField?.GetValue(null) is DependencyProperty vcaDp)
+        {
+            this.SetTemplateBinding(VerticalAlignmentProperty, vcaDp);
         }
     }
 
@@ -268,6 +284,23 @@ public class DataTemplate
     public bool IsSealed => _isSealed;
 
     /// <summary>
+    /// Gets or sets the raw XAML content for this template.
+    /// This is set by the XAML parser and used by LoadContent() to create the visual tree.
+    /// </summary>
+    internal string? VisualTreeXaml { get; set; }
+
+    /// <summary>
+    /// Gets or sets the assembly context for parsing the XAML content.
+    /// </summary>
+    internal System.Reflection.Assembly? SourceAssembly { get; set; }
+
+    /// <summary>
+    /// Gets or sets a callback used by LoadContent to parse XAML.
+    /// This allows the Controls assembly to remain independent of the Xaml assembly.
+    /// </summary>
+    public static Func<string, System.Reflection.Assembly?, FrameworkElement?>? XamlParser { get; set; }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="DataTemplate"/> class.
     /// </summary>
     public DataTemplate()
@@ -309,6 +342,18 @@ public class DataTemplate
     /// <returns>The root element of the visual tree.</returns>
     public FrameworkElement? LoadContent()
     {
-        return _visualTree?.Invoke();
+        // If we have a factory function, use it
+        if (_visualTree != null)
+        {
+            return _visualTree.Invoke();
+        }
+
+        // If we have stored XAML content, parse it
+        if (!string.IsNullOrEmpty(VisualTreeXaml) && XamlParser != null)
+        {
+            return XamlParser(VisualTreeXaml, SourceAssembly);
+        }
+
+        return null;
     }
 }

--- a/src/managed/Jalium.UI.Controls/Jalium.UI.Controls.csproj
+++ b/src/managed/Jalium.UI.Controls/Jalium.UI.Controls.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Jalium.UI.Xaml" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Jalium.UI.Core\Jalium.UI.Core.csproj" />
     <ProjectReference Include="..\Jalium.UI.Media\Jalium.UI.Media.csproj" />
     <ProjectReference Include="..\Jalium.UI.Input\Jalium.UI.Input.csproj" />

--- a/src/managed/Jalium.UI.Controls/ListBox.cs
+++ b/src/managed/Jalium.UI.Controls/ListBox.cs
@@ -1,6 +1,4 @@
 using Jalium.UI.Input;
-using Jalium.UI.Interop;
-using Jalium.UI.Media;
 
 namespace Jalium.UI.Controls;
 
@@ -214,9 +212,6 @@ public class ListBoxItem : ContentControl
     /// </summary>
     internal ListBox? ParentListBox { get; set; }
 
-    private bool _isPressed;
-    private bool _isMouseOver;
-
     #endregion
 
     #region Constructor
@@ -232,9 +227,7 @@ public class ListBoxItem : ContentControl
 
         // Register input event handlers
         AddHandler(MouseDownEvent, new RoutedEventHandler(OnMouseDownHandler));
-        AddHandler(MouseUpEvent, new RoutedEventHandler(OnMouseUpHandler));
         AddHandler(MouseEnterEvent, new RoutedEventHandler(OnMouseEnterHandler));
-        AddHandler(MouseLeaveEvent, new RoutedEventHandler(OnMouseLeaveHandler));
     }
 
     #endregion
@@ -247,83 +240,19 @@ public class ListBoxItem : ContentControl
 
         if (e is MouseButtonEventArgs mouseArgs && mouseArgs.ChangedButton == MouseButton.Left)
         {
-            _isPressed = true;
             Focus();
             // Select immediately on mouse down (standard ListBox behavior)
             ParentListBox?.SelectItem(this);
-            InvalidateVisual();
-            e.Handled = true;
-        }
-    }
-
-    private void OnMouseUpHandler(object sender, RoutedEventArgs e)
-    {
-        if (!IsEnabled) return;
-
-        if (e is MouseButtonEventArgs mouseArgs && mouseArgs.ChangedButton == MouseButton.Left)
-        {
-            _isPressed = false;
-            InvalidateVisual();
             e.Handled = true;
         }
     }
 
     private void OnMouseEnterHandler(object sender, RoutedEventArgs e)
     {
-        _isMouseOver = true;
         // If left mouse button is down while entering, select this item (drag selection)
         if (e is MouseEventArgs mouseArgs && mouseArgs.LeftButton == MouseButtonState.Pressed)
         {
             ParentListBox?.SelectItem(this);
-        }
-        InvalidateVisual();
-    }
-
-    private void OnMouseLeaveHandler(object sender, RoutedEventArgs e)
-    {
-        _isMouseOver = false;
-        InvalidateVisual();
-    }
-
-    #endregion
-
-    #region Rendering
-
-    /// <inheritdoc />
-    protected override void OnRender(object drawingContext)
-    {
-        if (drawingContext is not DrawingContext dc)
-            return;
-
-        var bounds = new Rect(0, 0, RenderSize.Width, RenderSize.Height);
-
-        // Use property values - styles and triggers handle state changes
-        var bgBrush = Background;
-        var fgBrush = Foreground;
-
-        // Draw background
-        if (bgBrush != null)
-        {
-            dc.DrawRectangle(bgBrush, null, bounds);
-        }
-
-        // Draw content text
-        var contentText = Content?.ToString() ?? "";
-        if (!string.IsNullOrEmpty(contentText) && fgBrush != null)
-        {
-            var fontFamily = FontFamily ?? "Segoe UI";
-            var fontSize = FontSize > 0 ? FontSize : 14;
-            var fontMetrics = TextMeasurement.GetFontMetrics(fontFamily, fontSize);
-
-            var formattedText = new FormattedText(contentText, fontFamily, fontSize)
-            {
-                Foreground = fgBrush,
-                MaxTextWidth = Math.Max(0, bounds.Width - Padding.Left - Padding.Right),
-                MaxTextHeight = Math.Max(0, bounds.Height - Padding.Top - Padding.Bottom)
-            };
-
-            var textY = (bounds.Height - fontMetrics.LineHeight) / 2;
-            dc.DrawText(formattedText, new Point(Padding.Left, textY));
         }
     }
 
@@ -333,10 +262,7 @@ public class ListBoxItem : ContentControl
 
     private static void OnIsSelectedChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
-        if (d is ListBoxItem item)
-        {
-            item.InvalidateVisual();
-        }
+        // Triggers handle visual changes now
     }
 
     #endregion

--- a/src/managed/Jalium.UI.Controls/Themes/Controls/Button.jalxaml
+++ b/src/managed/Jalium.UI.Controls/Themes/Controls/Button.jalxaml
@@ -15,6 +15,22 @@
         <Setter Property="FontSize" Value="14" />
         <Setter Property="MinWidth" Value="60" />
         <Setter Property="MinHeight" Value="32" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="Template">
+            <ControlTemplate TargetType="Button">
+                <Border Name="BackgroundBorder"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        CornerRadius="{TemplateBinding CornerRadius}"
+                        Padding="{TemplateBinding Padding}">
+                    <ContentPresenter
+                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+                </Border>
+            </ControlTemplate>
+        </Setter>
 
         <Style.Triggers>
             <PropertyTrigger Property="IsMouseOver" Value="True">
@@ -43,6 +59,22 @@
         <Setter Property="Padding" Value="8,4,8,4" />
         <Setter Property="CornerRadius" Value="4" />
         <Setter Property="FontSize" Value="14" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="Template">
+            <ControlTemplate TargetType="RepeatButton">
+                <Border Name="BackgroundBorder"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        CornerRadius="{TemplateBinding CornerRadius}"
+                        Padding="{TemplateBinding Padding}">
+                    <ContentPresenter
+                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+                </Border>
+            </ControlTemplate>
+        </Setter>
 
         <Style.Triggers>
             <PropertyTrigger Property="IsMouseOver" Value="True">

--- a/src/managed/Jalium.UI.Controls/Themes/Controls/SelectionControls.jalxaml
+++ b/src/managed/Jalium.UI.Controls/Themes/Controls/SelectionControls.jalxaml
@@ -37,6 +37,19 @@
         <Setter Property="BorderBrush" Value="{StaticResource ControlBorder}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="CornerRadius" Value="4" />
+        <Setter Property="Template">
+            <ControlTemplate TargetType="ListBox">
+                <Border Name="OuterBorder"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        CornerRadius="{TemplateBinding CornerRadius}">
+                    <ScrollViewer>
+                        <StackPanel Name="ItemsHost" />
+                    </ScrollViewer>
+                </Border>
+            </ControlTemplate>
+        </Setter>
     </Style>
 
     <!-- ============================================== -->
@@ -46,6 +59,15 @@
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="Foreground" Value="{StaticResource TextPrimary}" />
         <Setter Property="Padding" Value="8,6,8,6" />
+        <Setter Property="Template">
+            <ControlTemplate TargetType="ListBoxItem">
+                <Border Name="BackgroundBorder"
+                        Background="{TemplateBinding Background}"
+                        Padding="{TemplateBinding Padding}">
+                    <ContentPresenter VerticalAlignment="Center" />
+                </Border>
+            </ControlTemplate>
+        </Setter>
 
         <Style.Triggers>
             <PropertyTrigger Property="IsMouseOver" Value="True">

--- a/src/managed/Jalium.UI.Controls/Themes/ThemeManager.cs
+++ b/src/managed/Jalium.UI.Controls/Themes/ThemeManager.cs
@@ -26,12 +26,34 @@ public static class ThemeManager
 
         ArgumentNullException.ThrowIfNull(app);
 
+        System.Diagnostics.Debug.WriteLine("[ThemeManager.Initialize] Loading Generic theme...");
+        Console.WriteLine("[ThemeManager.Initialize] Loading Generic theme...");
+
         // Try to load the Generic theme using XamlReader via reflection
         // This avoids circular dependency between Controls and Xaml projects
         var theme = LoadGenericThemeViaReflection();
         if (theme != null)
         {
             app.Resources.MergedDictionaries.Add(theme);
+            System.Diagnostics.Debug.WriteLine($"[ThemeManager.Initialize] Theme loaded. Resources: {theme.Count}, MergedDicts: {theme.MergedDictionaries.Count}");
+            Console.WriteLine($"[ThemeManager.Initialize] Theme loaded. Resources: {theme.Count}, MergedDicts: {theme.MergedDictionaries.Count}");
+
+            // Debug: Check for Button style specifically
+            if (theme.TryGetValue(typeof(Button), out var buttonStyle))
+            {
+                System.Diagnostics.Debug.WriteLine($"[ThemeManager.Initialize] Found Button style: {buttonStyle?.GetType().Name}");
+                Console.WriteLine($"[ThemeManager.Initialize] Found Button style: {buttonStyle?.GetType().Name}");
+            }
+            else
+            {
+                System.Diagnostics.Debug.WriteLine("[ThemeManager.Initialize] WARNING: Button style NOT found in theme!");
+                Console.WriteLine("[ThemeManager.Initialize] WARNING: Button style NOT found in theme!");
+            }
+        }
+        else
+        {
+            System.Diagnostics.Debug.WriteLine("[ThemeManager.Initialize] WARNING: Theme loading returned null!");
+            Console.WriteLine("[ThemeManager.Initialize] WARNING: Theme loading returned null!");
         }
 
         _initialized = true;

--- a/src/managed/Jalium.UI.Core/ControlTemplate.cs
+++ b/src/managed/Jalium.UI.Core/ControlTemplate.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+
 namespace Jalium.UI;
 
 /// <summary>
@@ -22,6 +24,23 @@ public class ControlTemplate
     /// Gets a value that indicates whether the template is read-only.
     /// </summary>
     public bool IsSealed => _isSealed;
+
+    /// <summary>
+    /// Gets or sets the raw XAML content for this template.
+    /// This is set by the XAML parser and used by LoadContent() to create the visual tree.
+    /// </summary>
+    internal string? VisualTreeXaml { get; set; }
+
+    /// <summary>
+    /// Gets or sets the assembly context for parsing the XAML content.
+    /// </summary>
+    internal Assembly? SourceAssembly { get; set; }
+
+    /// <summary>
+    /// Gets or sets a callback used by LoadContent to parse XAML.
+    /// This allows the Core assembly to remain independent of the Xaml assembly.
+    /// </summary>
+    public static Func<string, Assembly?, FrameworkElement?>? XamlParser { get; set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ControlTemplate"/> class.
@@ -65,7 +84,19 @@ public class ControlTemplate
     /// <returns>The root element of the visual tree, or null if no visual tree is defined.</returns>
     public FrameworkElement? LoadContent()
     {
-        return _visualTree?.Invoke();
+        // If we have a factory function, use it
+        if (_visualTree != null)
+        {
+            return _visualTree.Invoke();
+        }
+
+        // If we have stored XAML content, parse it
+        if (!string.IsNullOrEmpty(VisualTreeXaml) && XamlParser != null)
+        {
+            return XamlParser(VisualTreeXaml, SourceAssembly);
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/src/managed/Jalium.UI.Core/DependencyObject.cs
+++ b/src/managed/Jalium.UI.Core/DependencyObject.cs
@@ -154,6 +154,27 @@ public class DependencyObject : DispatcherObject
     }
 
     /// <summary>
+    /// Reactivates all bindings on this object.
+    /// This is called when the TemplatedParent is set to allow deferred template bindings to resolve.
+    /// </summary>
+    internal void ReactivateBindings()
+    {
+        foreach (var expression in _bindings.Values)
+        {
+            // Only reactivate if not already active (deferred bindings that couldn't activate earlier)
+            if (!expression.IsActive)
+            {
+                expression.Activate();
+            }
+            else
+            {
+                // For already active bindings, update the target to get latest value
+                expression.UpdateTarget();
+            }
+        }
+    }
+
+    /// <summary>
     /// Clears the local value of a dependency property.
     /// </summary>
     /// <param name="dp">The dependency property to clear.</param>

--- a/src/managed/Jalium.UI.Core/FrameworkElement.cs
+++ b/src/managed/Jalium.UI.Core/FrameworkElement.cs
@@ -144,7 +144,30 @@ public class FrameworkElement : UIElement
     /// </summary>
     internal void SetTemplatedParent(FrameworkElement? parent)
     {
+        var oldParent = _templatedParent;
         _templatedParent = parent;
+
+        // Notify derived classes that TemplatedParent has changed
+        if (oldParent != parent)
+        {
+            OnTemplatedParentChanged(oldParent, parent);
+        }
+
+        // Reactivate bindings now that TemplatedParent is set.
+        // This allows deferred template bindings (TemplateBinding) to resolve.
+        if (parent != null)
+        {
+            ReactivateBindings();
+        }
+    }
+
+    /// <summary>
+    /// Called when the TemplatedParent property changes.
+    /// </summary>
+    /// <param name="oldParent">The old templated parent.</param>
+    /// <param name="newParent">The new templated parent.</param>
+    protected virtual void OnTemplatedParentChanged(FrameworkElement? oldParent, FrameworkElement? newParent)
+    {
     }
 
     /// <summary>
@@ -525,9 +548,24 @@ public class FrameworkElement : UIElement
         var marginHeight = margin.Top + margin.Bottom;
 
         // Calculate available size for content
-        var arrangeSize = new Size(
-            Math.Max(0, finalRect.Width - marginWidth),
-            Math.Max(0, finalRect.Height - marginHeight));
+        var availableWidth = Math.Max(0, finalRect.Width - marginWidth);
+        var availableHeight = Math.Max(0, finalRect.Height - marginHeight);
+
+        // Get the desired size (set during Measure)
+        var desiredWidth = DesiredSize.Width - marginWidth;
+        var desiredHeight = DesiredSize.Height - marginHeight;
+
+        // Determine arrange size based on alignment
+        // When alignment is Stretch, use available size; otherwise use desired size (clamped to available)
+        var arrangeWidth = HorizontalAlignment == HorizontalAlignment.Stretch
+            ? availableWidth
+            : Math.Min(desiredWidth, availableWidth);
+
+        var arrangeHeight = VerticalAlignment == VerticalAlignment.Stretch
+            ? availableHeight
+            : Math.Min(desiredHeight, availableHeight);
+
+        var arrangeSize = new Size(arrangeWidth, arrangeHeight);
 
         // Apply explicit size constraints
         if (!double.IsNaN(Width))
@@ -552,7 +590,7 @@ public class FrameworkElement : UIElement
         var y = finalRect.Y + margin.Top;
 
         // Horizontal alignment
-        var extraWidth = finalRect.Width - marginWidth - renderSize.Width;
+        var extraWidth = availableWidth - renderSize.Width;
         if (extraWidth > 0)
         {
             switch (HorizontalAlignment)
@@ -567,7 +605,7 @@ public class FrameworkElement : UIElement
         }
 
         // Vertical alignment
-        var extraHeight = finalRect.Height - marginHeight - renderSize.Height;
+        var extraHeight = availableHeight - renderSize.Height;
         if (extraHeight > 0)
         {
             switch (VerticalAlignment)

--- a/src/managed/Jalium.UI.Core/ResourceDictionary.cs
+++ b/src/managed/Jalium.UI.Core/ResourceDictionary.cs
@@ -284,7 +284,12 @@ public static class ResourceLookup
         }
 
         // Check application resources via callback
-        return ApplicationResourceLookup?.Invoke(resourceKey);
+        if (ApplicationResourceLookup != null)
+        {
+            return ApplicationResourceLookup.Invoke(resourceKey);
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/src/managed/Jalium.UI.Core/Style.cs
+++ b/src/managed/Jalium.UI.Core/Style.cs
@@ -118,6 +118,7 @@ public class Style
 /// <summary>
 /// Represents a setter that sets a property value.
 /// </summary>
+[ContentProperty("Value")]
 public class Setter
 {
     /// <summary>
@@ -158,7 +159,8 @@ public class Setter
     /// </summary>
     internal void Apply(FrameworkElement element)
     {
-        if (Property == null) return;
+        if (Property == null)
+            return;
 
         var target = GetTarget(element);
         if (target != null)

--- a/src/managed/Jalium.UI.Xaml/MarkupExtension.cs
+++ b/src/managed/Jalium.UI.Xaml/MarkupExtension.cs
@@ -318,6 +318,198 @@ public class TypeExtension : MarkupExtension
 }
 
 /// <summary>
+/// XAML markup extension for TemplateBinding.
+/// Binds a property in a control template to a property on the templated parent.
+/// </summary>
+public class TemplateBindingExtension : MarkupExtension
+{
+    /// <summary>
+    /// Gets or sets the name of the property on the templated parent to bind to.
+    /// </summary>
+    public string? Property { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TemplateBindingExtension"/> class.
+    /// </summary>
+    public TemplateBindingExtension()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TemplateBindingExtension"/> class with the specified property name.
+    /// </summary>
+    /// <param name="property">The name of the property to bind to.</param>
+    public TemplateBindingExtension(string property)
+    {
+        Property = property;
+    }
+
+    /// <inheritdoc />
+    public override object? ProvideValue(IServiceProvider serviceProvider)
+    {
+        if (string.IsNullOrEmpty(Property))
+            return null;
+
+        var provideValueTarget = serviceProvider?.GetService(typeof(IProvideValueTarget)) as IProvideValueTarget;
+        var targetObject = provideValueTarget?.TargetObject;
+        var targetProperty = provideValueTarget?.TargetProperty as DependencyProperty;
+
+        if (targetObject is not DependencyObject depObj || targetProperty == null)
+            return null;
+
+        // Create a deferred template binding that will be resolved when TemplatedParent is set
+        // The binding stores the property name and resolves it against the TemplatedParent type
+        var binding = new DeferredTemplateBinding(Property);
+        depObj.SetBinding(targetProperty, binding);
+
+        // Return the binding expression (though SetBinding already applied it)
+        return null;
+    }
+}
+
+/// <summary>
+/// A deferred template binding that resolves the property name when the TemplatedParent is available.
+/// </summary>
+public class DeferredTemplateBinding : BindingBase
+{
+    /// <summary>
+    /// Gets the property name to bind to on the templated parent.
+    /// </summary>
+    public string PropertyName { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeferredTemplateBinding"/> class.
+    /// </summary>
+    /// <param name="propertyName">The property name to bind to.</param>
+    public DeferredTemplateBinding(string propertyName)
+    {
+        PropertyName = propertyName;
+    }
+
+    /// <inheritdoc />
+    internal override BindingExpressionBase CreateBindingExpression(DependencyObject target, DependencyProperty targetProperty)
+    {
+        return new DeferredTemplateBindingExpression(this, target, targetProperty);
+    }
+}
+
+/// <summary>
+/// Binding expression for a deferred template binding.
+/// Resolves the property name against the TemplatedParent's type when activated.
+/// </summary>
+internal class DeferredTemplateBindingExpression : BindingExpressionBase
+{
+    private readonly DeferredTemplateBinding _binding;
+    private FrameworkElement? _templatedParent;
+    private DependencyProperty? _sourceProperty;
+
+    public DeferredTemplateBindingExpression(DeferredTemplateBinding binding, DependencyObject target, DependencyProperty targetProperty)
+        : base(target, targetProperty)
+    {
+        _binding = binding;
+    }
+
+    internal override void Activate()
+    {
+        if (IsActive)
+            return;
+
+        // Find the templated parent
+        _templatedParent = FindTemplatedParent(Target);
+        if (_templatedParent == null)
+        {
+            // TemplatedParent not set yet - leave IsActive=false so we can retry later
+            return;
+        }
+
+        // Resolve the property name against the templated parent's type
+        _sourceProperty = ResolveDependencyProperty(_templatedParent.GetType(), _binding.PropertyName);
+        if (_sourceProperty == null)
+        {
+            return;
+        }
+
+        // Only set IsActive=true after successfully resolving everything
+        IsActive = true;
+
+        // Subscribe to property changes on the templated parent
+        _templatedParent.PropertyChangedInternal += OnTemplatedParentPropertyChanged;
+
+        // Initial value transfer
+        TransferValue();
+    }
+
+    internal override void Deactivate()
+    {
+        if (!IsActive)
+            return;
+
+        IsActive = false;
+
+        if (_templatedParent != null)
+        {
+            _templatedParent.PropertyChangedInternal -= OnTemplatedParentPropertyChanged;
+            _templatedParent = null;
+        }
+    }
+
+    public override void UpdateSource()
+    {
+        // TemplateBinding is OneWay, so UpdateSource does nothing
+    }
+
+    public override void UpdateTarget()
+    {
+        TransferValue();
+    }
+
+    private void OnTemplatedParentPropertyChanged(DependencyProperty dp, object? oldValue, object? newValue)
+    {
+        if (dp == _sourceProperty)
+        {
+            TransferValue();
+        }
+    }
+
+    private void TransferValue()
+    {
+        if (_templatedParent == null || _sourceProperty == null)
+            return;
+
+        var value = _templatedParent.GetValue(_sourceProperty);
+        Target.SetValue(TargetProperty, value);
+    }
+
+    private static FrameworkElement? FindTemplatedParent(DependencyObject target)
+    {
+        if (target is FrameworkElement fe)
+        {
+            return fe.TemplatedParent;
+        }
+        return null;
+    }
+
+    private static DependencyProperty? ResolveDependencyProperty(Type type, string propertyName)
+    {
+        // Search for the DependencyProperty field
+        var dpFieldName = propertyName + "Property";
+        var currentType = type;
+
+        while (currentType != null)
+        {
+            var field = currentType.GetField(dpFieldName, BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
+            if (field != null)
+            {
+                return field.GetValue(null) as DependencyProperty;
+            }
+            currentType = currentType.BaseType;
+        }
+
+        return null;
+    }
+}
+
+/// <summary>
 /// Parser for markup extension syntax (e.g., "{Binding Path=Name}").
 /// </summary>
 internal static class MarkupExtensionParser
@@ -398,6 +590,7 @@ internal static class MarkupExtensionParser
         {
             "binding" => CreateBindingExtension(parameters),
             "staticresource" => CreateStaticResourceExtension(parameters),
+            "templatebinding" => CreateTemplateBindingExtension(parameters),
             "null" => new NullExtension(),
             "type" => CreateTypeExtension(parameters),
             _ => null
@@ -476,6 +669,12 @@ internal static class MarkupExtensionParser
     {
         var typeName = parameters.Trim();
         return new TypeExtension(typeName);
+    }
+
+    private static TemplateBindingExtension CreateTemplateBindingExtension(string parameters)
+    {
+        var propertyName = parameters.Trim();
+        return new TemplateBindingExtension(propertyName);
     }
 
     private static List<string> SplitParameters(string parameters)

--- a/src/managed/Jalium.UI.Xaml/XamlReader.cs
+++ b/src/managed/Jalium.UI.Xaml/XamlReader.cs
@@ -3,6 +3,8 @@ using System.Reflection;
 using System.Xml;
 using Jalium.UI;
 using Jalium.UI.Controls;
+using Jalium.UI.Controls.Primitives;
+using Jalium.UI.Controls.Shapes;
 using Jalium.UI.Media;
 
 namespace Jalium.UI.Markup;
@@ -244,8 +246,18 @@ public static class XamlReader
                 ParseAttributes(reader, instance, context);
             }
 
-            // Parse child content
-            if (!reader.IsEmptyElement)
+            // Special handling for ControlTemplate - capture inner XML for deferred parsing
+            if (instance is ControlTemplate controlTemplate && !reader.IsEmptyElement)
+            {
+                ParseControlTemplateContent(reader, controlTemplate, context);
+            }
+            // Special handling for DataTemplate - capture inner XML for deferred parsing
+            else if (instance is DataTemplate dataTemplate && !reader.IsEmptyElement)
+            {
+                ParseDataTemplateContent(reader, dataTemplate, context);
+            }
+            // Parse child content normally
+            else if (!reader.IsEmptyElement)
             {
                 ParseContent(reader, instance, context);
             }
@@ -527,6 +539,205 @@ public static class XamlReader
             var addMethod = collection.GetType().GetMethod("Add");
             addMethod?.Invoke(collection, [item]);
         }
+    }
+
+    /// <summary>
+    /// Parses ControlTemplate content, capturing the visual tree XAML for deferred parsing.
+    /// </summary>
+    private static void ParseControlTemplateContent(XmlReader reader, ControlTemplate template, XamlParserContext context)
+    {
+        int depth = reader.Depth;
+        var visualTreeXaml = new System.Text.StringBuilder();
+        bool hasVisualTree = false;
+        bool skipRead = false; // Flag to skip Read() after ReadOuterXml()
+
+        while (skipRead || reader.Read())
+        {
+            skipRead = false;
+
+            // Check for end of ControlTemplate
+            if (reader.NodeType == XmlNodeType.EndElement && reader.Depth == depth)
+            {
+                break;
+            }
+
+            // Skip whitespace and other non-element content
+            if (reader.NodeType != XmlNodeType.Element)
+            {
+                continue;
+            }
+
+            // Check if this is a property element (e.g., ControlTemplate.Triggers)
+            if (reader.LocalName.Contains('.'))
+            {
+                var parts = reader.LocalName.Split('.');
+                if (parts.Length == 2 && parts[1] == "Triggers")
+                {
+                    // Parse triggers normally
+                    ParseControlTemplateTriggers(reader, template, context);
+                }
+                else
+                {
+                    // Skip unknown property elements
+                    SkipElement(reader);
+                }
+            }
+            else if (!hasVisualTree)
+            {
+                // First non-property child is the visual tree root
+                // Capture it as XML for deferred parsing
+                visualTreeXaml.Append(reader.ReadOuterXml());
+                hasVisualTree = true;
+
+                // ReadOuterXml advances the reader past this element to the next node
+                // We need to process the current node without calling Read() again
+                skipRead = true;
+            }
+            else
+            {
+                // Only one visual tree root is allowed
+                throw new XamlParseException("ControlTemplate can only have one visual tree root element.");
+            }
+        }
+
+        // Store the captured XAML for deferred parsing
+        if (hasVisualTree)
+        {
+            template.VisualTreeXaml = visualTreeXaml.ToString();
+            template.SourceAssembly = context.SourceAssembly;
+
+            // Register the XAML parser callback if not already set
+            if (ControlTemplate.XamlParser == null)
+            {
+                ControlTemplate.XamlParser = ParseTemplateXaml;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Parses the Triggers property element of a ControlTemplate.
+    /// </summary>
+    private static void ParseControlTemplateTriggers(XmlReader reader, ControlTemplate template, XamlParserContext context)
+    {
+        int depth = reader.Depth;
+        var isEmpty = reader.IsEmptyElement;
+
+        if (isEmpty) return;
+
+        while (reader.Read())
+        {
+            if (reader.NodeType == XmlNodeType.EndElement && reader.Depth == depth)
+            {
+                break;
+            }
+
+            if (reader.NodeType == XmlNodeType.Element)
+            {
+                var trigger = ParseElement(reader, context);
+                if (trigger is Trigger t)
+                {
+                    template.Triggers.Add(t);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Parses DataTemplate content, capturing the visual tree XAML for deferred parsing.
+    /// </summary>
+    private static void ParseDataTemplateContent(XmlReader reader, DataTemplate template, XamlParserContext context)
+    {
+        int depth = reader.Depth;
+        var visualTreeXaml = new System.Text.StringBuilder();
+        bool hasVisualTree = false;
+
+        while (reader.Read())
+        {
+            if (reader.NodeType == XmlNodeType.EndElement && reader.Depth == depth)
+            {
+                break;
+            }
+
+            switch (reader.NodeType)
+            {
+                case XmlNodeType.Element:
+                    if (!hasVisualTree)
+                    {
+                        // Capture the visual tree as XML
+                        visualTreeXaml.Append(reader.ReadOuterXml());
+                        hasVisualTree = true;
+                    }
+                    else
+                    {
+                        throw new XamlParseException("DataTemplate can only have one visual tree root element.");
+                    }
+                    break;
+            }
+        }
+
+        // Store the captured XAML for deferred parsing
+        if (hasVisualTree)
+        {
+            template.VisualTreeXaml = visualTreeXaml.ToString();
+            template.SourceAssembly = context.SourceAssembly;
+
+            // Register the XAML parser callback if not already set
+            if (DataTemplate.XamlParser == null)
+            {
+                DataTemplate.XamlParser = ParseTemplateXaml;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Skips the current element and all its content.
+    /// </summary>
+    private static void SkipElement(XmlReader reader)
+    {
+        if (reader.IsEmptyElement) return;
+
+        int depth = reader.Depth;
+        while (reader.Read())
+        {
+            if (reader.NodeType == XmlNodeType.EndElement && reader.Depth == depth)
+            {
+                break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Parses template XAML content and returns the root element.
+    /// </summary>
+    private static FrameworkElement? ParseTemplateXaml(string xaml, Assembly? sourceAssembly)
+    {
+        if (string.IsNullOrEmpty(xaml))
+            return null;
+
+        using var stringReader = new StringReader(xaml);
+        var settings = new XmlReaderSettings
+        {
+            IgnoreComments = true,
+            IgnoreWhitespace = true,
+            IgnoreProcessingInstructions = true
+        };
+
+        using var xmlReader = XmlReader.Create(stringReader, settings);
+        var context = new XamlParserContext
+        {
+            SourceAssembly = sourceAssembly
+        };
+
+        while (xmlReader.Read())
+        {
+            if (xmlReader.NodeType == XmlNodeType.Element)
+            {
+                var result = ParseElement(xmlReader, context);
+                return result as FrameworkElement;
+            }
+        }
+
+        return null;
     }
 
     /// <summary>
@@ -1224,6 +1435,7 @@ public static class XamlTypeRegistry
         RegisterCoreTypes(types);
         RegisterControlTypes(types);
         RegisterMediaTypes(types);
+        RegisterShapeTypes(types);
 
         return types;
     }
@@ -1242,6 +1454,8 @@ public static class XamlTypeRegistry
         Register<PropertyTrigger>(types);
         Register<DataTrigger>(types);
         Register<EventTrigger>(types);
+        Register<ControlTemplate>(types);
+        Register<DataTemplate>(types);
         Register<ResourceDictionary>(types);
         Register<Binding>(types);
         Register<BindingBase>(types);
@@ -1295,6 +1509,14 @@ public static class XamlTypeRegistry
         Register<TitleBarButton>(types);
         Register<RowDefinition>(types);
         Register<ColumnDefinition>(types);
+        Register<RepeatButton>(types);
+        Register<ToggleSwitch>(types);
+        Register<AutoCompleteBox>(types);
+        Register<HyperlinkButton>(types);
+        Register<Label>(types);
+
+        // Jalium.UI.Controls.Primitives namespace
+        Register<BulletDecorator>(types);
     }
 
     private static void RegisterMediaTypes(Dictionary<string, Type> types)
@@ -1315,6 +1537,15 @@ public static class XamlTypeRegistry
         Register<RectangleGeometry>(types);
         Register<EllipseGeometry>(types);
         Register<PathGeometry>(types);
+    }
+
+    private static void RegisterShapeTypes(Dictionary<string, Type> types)
+    {
+        // Jalium.UI.Controls.Shapes namespace
+        Register<Shape>(types);
+        Register<Ellipse>(types);
+        Register<Rectangle>(types);
+        Register<Jalium.UI.Controls.Shapes.Path>(types);
     }
 
     private static void Register<[DynamicallyAccessedMembers(


### PR DESCRIPTION
- ContentControl: 支持双模式内容管理（直接内容 vs 模板内容）
- ContentPresenter: 添加 OnTemplatedParentChanged 回调以正确设置模板绑定
- ContentPresenter: 自动绑定 HorizontalContentAlignment/VerticalContentAlignment
- FrameworkElement: 添加 OnTemplatedParentChanged 虚方法
- FrameworkElement: 修复 ArrangeCore 中非 Stretch 对齐的处理
- ButtonBase: 切换到使用 ControlTemplate 进行视觉呈现
- MarkupExtension: 添加 DeferredTemplateBinding 支持延迟模板绑定