### PR TITLE
feat: 实现 InkCanvas 控件及 9 种画笔类型

### DIFF
--- a/samples/Jalium.UI.Gallery/GalleryWindow.jalxaml.cs
+++ b/samples/Jalium.UI.Gallery/GalleryWindow.jalxaml.cs
@@ -68,7 +68,27 @@ public partial class GalleryWindow : Window
         { "shadereffects", () => new ShaderEffectsPage() },
         { "navigationdemo", () => new NavigationDemoPage() },
         { "printing", () => new PrintingPage() },
-        { "shellintegration", () => new ShellIntegrationPage() }
+        { "shellintegration", () => new ShellIntegrationPage() },
+        // New control pages
+        { "menu", () => new MenuPage() },
+        { "contextmenu", () => new ContextMenuPage() },
+        { "toolbar", () => new ToolBarPage() },
+        { "tooltip", () => new ToolTipPage() },
+        { "popup", () => new PopupPage() },
+        { "expander", () => new ExpanderPage() },
+        { "datepicker", () => new DatePickerPage() },
+        { "timepicker", () => new TimePickerPage() },
+        { "colorpicker", () => new ColorPickerPage() },
+        { "richtextbox", () => new RichTextBoxPage() },
+        { "shapes", () => new ShapesPage() },
+        { "frame", () => new FramePage() },
+        { "viewbox", () => new ViewboxPage() },
+        { "listview", () => new ListViewPage() },
+        { "mediaelement", () => new MediaElementPage() },
+        { "dialogs", () => new DialogsPage() },
+        { "toastnotification", () => new ToastNotificationPage() },
+        { "splitter", () => new SplitterPage() },
+        { "inkcanvas", () => new InkCanvasPage() }
     };
 
     public GalleryWindow()
@@ -117,6 +137,7 @@ public partial class GalleryWindow : Window
         var textGroup = AddGroupItem("Text", "text");
         AddChildItem(textGroup, "TextBlock", "textblock");
         AddChildItem(textGroup, "Label", "label");
+        AddChildItem(textGroup, "RichTextBox", "richtextbox");
 
         // Data (expandable group) - data binding features
         var dataGroup = AddGroupItem("Data");
@@ -134,18 +155,28 @@ public partial class GalleryWindow : Window
         AddChildItem(layoutGroup, "Expander", "expander");
         AddChildItem(layoutGroup, "GroupBox", "groupbox");
         AddChildItem(layoutGroup, "Separator", "separator");
+        AddChildItem(layoutGroup, "Viewbox", "viewbox");
+        AddChildItem(layoutGroup, "Splitter", "splitter");
 
         // Navigation (expandable group) - clicking group navigates to category overview
         var navigationGroup = AddGroupItem("Navigation", "navigation");
         AddChildItem(navigationGroup, "TabControl", "tabcontrol");
+        AddChildItem(navigationGroup, "Frame", "frame");
+        AddChildItem(navigationGroup, "Menu", "menu");
+        AddChildItem(navigationGroup, "ContextMenu", "contextmenu");
+        AddChildItem(navigationGroup, "ToolBar", "toolbar");
 
         // Media (expandable group) - clicking group navigates to category overview
         var mediaGroup = AddGroupItem("Media", "media");
         AddChildItem(mediaGroup, "Image", "image");
+        AddChildItem(mediaGroup, "MediaElement", "mediaelement");
+        AddChildItem(mediaGroup, "Shapes", "shapes");
+        AddChildItem(mediaGroup, "InkCanvas", "inkcanvas");
 
         // Collections (expandable group) - clicking group navigates to category overview
         var collectionsGroup = AddGroupItem("Collections", "collections");
         AddChildItem(collectionsGroup, "ListBox", "listbox");
+        AddChildItem(collectionsGroup, "ListView", "listview");
         AddChildItem(collectionsGroup, "TreeView", "treeview");
         AddChildItem(collectionsGroup, "DataGrid", "datagrid");
         AddChildItem(collectionsGroup, "Calendar", "calendar");
@@ -153,17 +184,28 @@ public partial class GalleryWindow : Window
         // Date & Time (expandable group)
         var dateTimeGroup = AddGroupItem("Date & Time");
         AddChildItem(dateTimeGroup, "DatePicker", "datepicker");
+        AddChildItem(dateTimeGroup, "TimePicker", "timepicker");
         AddChildItem(dateTimeGroup, "Calendar", "calendar");
 
         // Pickers (expandable group)
         var pickersGroup = AddGroupItem("Pickers");
         AddChildItem(pickersGroup, "ColorPicker", "colorpicker");
 
+        // Overlays (expandable group)
+        var overlaysGroup = AddGroupItem("Overlays");
+        AddChildItem(overlaysGroup, "Popup", "popup");
+        AddChildItem(overlaysGroup, "ToolTip", "tooltip");
+        AddChildItem(overlaysGroup, "ToastNotification", "toastnotification");
+
         // Status & Info (expandable group)
         var statusGroup = AddGroupItem("Status & Info");
         AddChildItem(statusGroup, "StatusBar", "statusbar");
         AddChildItem(statusGroup, "InfoBar", "infobar");
         AddChildItem(statusGroup, "Thumb", "thumb");
+
+        // Dialogs (expandable group)
+        var dialogsGroup = AddGroupItem("Dialogs");
+        AddChildItem(dialogsGroup, "File Dialogs", "dialogs");
 
         // Effects (expandable group)
         var effectsGroup = AddGroupItem("Effects");

--- a/samples/Jalium.UI.Gallery/Views/InkCanvasPage.jalxaml
+++ b/samples/Jalium.UI.Gallery/Views/InkCanvasPage.jalxaml
@@ -1,0 +1,238 @@
+<Page xmlns="http://schemas.jalium.ui/2024"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      x:Class="Jalium.UI.Gallery.Views.InkCanvasPage"
+      Title="InkCanvas">
+
+    <StackPanel Orientation="Vertical">
+        <!-- Page Title -->
+        <TextBlock Text="InkCanvas"
+                   FontSize="32"
+                   Foreground="#FFFFFF"
+                   Margin="0,0,0,8"/>
+
+        <!-- Description -->
+        <TextBlock Text="A control that provides an area for ink collection and display."
+                   FontSize="14"
+                   Foreground="#888888"
+                   Margin="0,0,0,24"/>
+
+        <!-- Basic Drawing Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Basic Drawing"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Draw with your mouse. Use the buttons below to change modes."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="0"
+                        Margin="0,0,0,16">
+                    <InkCanvas x:Name="MainInkCanvas"
+                               Width="600"
+                               Height="300"
+                               Background="#FFFFFF"
+                               EditingMode="Ink"/>
+                </Border>
+
+                <!-- Control Buttons -->
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,16">
+                    <Button x:Name="InkModeButton" Content="Draw" Margin="0,0,8,0"/>
+                    <Button x:Name="EraseModeButton" Content="Erase" Margin="0,0,8,0"/>
+                    <Button x:Name="ClearButton" Content="Clear All" Margin="0,0,8,0"/>
+                </StackPanel>
+
+                <!-- Status -->
+                <TextBlock x:Name="StatusText"
+                           Text="Mode: Ink"
+                           FontSize="12"
+                           Foreground="#888888"/>
+            </StackPanel>
+        </Border>
+
+        <!-- Color Selection Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Stroke Color"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Select a color for drawing."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <StackPanel Orientation="Horizontal">
+                    <Button x:Name="BlackColorButton" Width="40" Height="40" Background="#000000" Margin="0,0,8,0"/>
+                    <Button x:Name="RedColorButton" Width="40" Height="40" Background="#E81123" Margin="0,0,8,0"/>
+                    <Button x:Name="BlueColorButton" Width="40" Height="40" Background="#0078D4" Margin="0,0,8,0"/>
+                    <Button x:Name="GreenColorButton" Width="40" Height="40" Background="#00CC6A" Margin="0,0,8,0"/>
+                    <Button x:Name="OrangeColorButton" Width="40" Height="40" Background="#F7630C" Margin="0,0,8,0"/>
+                    <Button x:Name="PurpleColorButton" Width="40" Height="40" Background="#886CE4" Margin="0,0,8,0"/>
+                </StackPanel>
+            </StackPanel>
+        </Border>
+
+        <!-- Stroke Width Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Stroke Width"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Adjust the width of the stroke."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <StackPanel Orientation="Horizontal">
+                    <Slider x:Name="WidthSlider"
+                            Width="300"
+                            Minimum="1"
+                            Maximum="20"
+                            Value="2"
+                            Margin="0,0,16,0"/>
+                    <TextBlock x:Name="WidthText"
+                               Text="Width: 2"
+                               Foreground="#FFFFFF"
+                               VerticalAlignment="Center"/>
+                </StackPanel>
+            </StackPanel>
+        </Border>
+
+        <!-- Highlighter Mode Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Highlighter Mode"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Toggle highlighter mode for semi-transparent strokes."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <CheckBox x:Name="HighlighterCheckBox" Content="Enable Highlighter"/>
+            </StackPanel>
+        </Border>
+
+        <!-- Brush Type Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Brush Type"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Select the brush type for drawing."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                    <Button x:Name="RoundBrushButton" Content="圆笔" Width="80" Margin="0,0,8,0"/>
+                    <Button x:Name="CalligraphyBrushButton" Content="毛笔" Width="80" Margin="0,0,8,0"/>
+                    <Button x:Name="PenBrushButton" Content="书写笔" Width="80" Margin="0,0,8,0"/>
+                    <Button x:Name="AirbrushButton" Content="喷枪" Width="80" Margin="0,0,8,0"/>
+                    <Button x:Name="OilBrushButton" Content="油画笔" Width="80" Margin="0,0,8,0"/>
+                </StackPanel>
+
+                <StackPanel Orientation="Horizontal">
+                    <Button x:Name="CrayonBrushButton" Content="蜡笔" Width="80" Margin="0,0,8,0"/>
+                    <Button x:Name="MarkerBrushButton" Content="记号笔" Width="80" Margin="0,0,8,0"/>
+                    <Button x:Name="PencilBrushButton" Content="铅笔" Width="80" Margin="0,0,8,0"/>
+                    <Button x:Name="WatercolorBrushButton" Content="水彩笔" Width="80" Margin="0,0,8,0"/>
+                </StackPanel>
+
+                <TextBlock x:Name="BrushTypeStatusText"
+                           Text="Brush Type: 圆笔"
+                           FontSize="12"
+                           Foreground="#888888"
+                           Margin="0,8,0,0"/>
+            </StackPanel>
+        </Border>
+
+        <!-- Taper Mode Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Taper Mode"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Select the taper style for new strokes."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <StackPanel Orientation="Horizontal">
+                    <Button x:Name="AnimNoneButton" Content="Normal" Margin="0,0,8,0"/>
+                    <Button x:Name="AnimGrowInButton" Content="Tapered Start" Margin="0,0,8,0"/>
+                    <Button x:Name="AnimShrinkOutButton" Content="Tapered End" Margin="0,0,8,0"/>
+                </StackPanel>
+
+                <TextBlock x:Name="AnimationStatusText"
+                           Text="Taper: Normal"
+                           FontSize="12"
+                           Foreground="#888888"
+                           Margin="0,8,0,0"/>
+            </StackPanel>
+        </Border>
+
+        <!-- Stroke Info Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Stroke Information"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Shows information about the strokes on the canvas."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <TextBlock x:Name="StrokeCountText"
+                           Text="Strokes: 0"
+                           FontSize="14"
+                           Foreground="#FFFFFF"/>
+            </StackPanel>
+        </Border>
+    </StackPanel>
+</Page>

--- a/samples/Jalium.UI.Gallery/Views/InkCanvasPage.jalxaml.cs
+++ b/samples/Jalium.UI.Gallery/Views/InkCanvasPage.jalxaml.cs
@@ -1,0 +1,246 @@
+using Jalium.UI.Controls;
+using Jalium.UI.Controls.Ink;
+using Jalium.UI.Media;
+
+namespace Jalium.UI.Gallery.Views;
+
+/// <summary>
+/// Code-behind for InkCanvasPage.jalxaml demonstrating InkCanvas control functionality.
+/// </summary>
+public partial class InkCanvasPage : Page
+{
+    public InkCanvasPage()
+    {
+        InitializeComponent();
+        SetupEventHandlers();
+    }
+
+    private void SetupEventHandlers()
+    {
+        // Mode buttons
+        if (InkModeButton != null)
+            InkModeButton.Click += OnInkModeClick;
+
+        if (EraseModeButton != null)
+            EraseModeButton.Click += OnEraseModeClick;
+
+        if (ClearButton != null)
+            ClearButton.Click += OnClearClick;
+
+        // Color buttons
+        if (BlackColorButton != null)
+            BlackColorButton.Click += (s, e) => SetColor(Color.FromRgb(0, 0, 0));
+
+        if (RedColorButton != null)
+            RedColorButton.Click += (s, e) => SetColor(Color.FromRgb(232, 17, 35));
+
+        if (BlueColorButton != null)
+            BlueColorButton.Click += (s, e) => SetColor(Color.FromRgb(0, 120, 212));
+
+        if (GreenColorButton != null)
+            GreenColorButton.Click += (s, e) => SetColor(Color.FromRgb(0, 204, 106));
+
+        if (OrangeColorButton != null)
+            OrangeColorButton.Click += (s, e) => SetColor(Color.FromRgb(247, 99, 12));
+
+        if (PurpleColorButton != null)
+            PurpleColorButton.Click += (s, e) => SetColor(Color.FromRgb(136, 108, 228));
+
+        // Width slider
+        if (WidthSlider != null)
+            WidthSlider.ValueChanged += OnWidthSliderChanged;
+
+        // Highlighter checkbox
+        if (HighlighterCheckBox != null)
+            HighlighterCheckBox.Checked += OnHighlighterChanged;
+
+        if (HighlighterCheckBox != null)
+            HighlighterCheckBox.Unchecked += OnHighlighterChanged;
+
+        // Stroke collection events
+        if (MainInkCanvas != null)
+        {
+            MainInkCanvas.StrokeCollected += OnStrokeCollected;
+            MainInkCanvas.StrokesChanged += OnStrokesChanged;
+        }
+
+        // Brush type buttons
+        if (RoundBrushButton != null)
+            RoundBrushButton.Click += (s, e) => SetBrushType(BrushType.Round, "圆笔");
+
+        if (CalligraphyBrushButton != null)
+            CalligraphyBrushButton.Click += (s, e) => SetBrushType(BrushType.Calligraphy, "毛笔");
+
+        if (PenBrushButton != null)
+            PenBrushButton.Click += (s, e) => SetBrushType(BrushType.Pen, "书写笔");
+
+        if (AirbrushButton != null)
+            AirbrushButton.Click += (s, e) => SetBrushType(BrushType.Airbrush, "喷枪");
+
+        if (OilBrushButton != null)
+            OilBrushButton.Click += (s, e) => SetBrushType(BrushType.Oil, "油画笔");
+
+        if (CrayonBrushButton != null)
+            CrayonBrushButton.Click += (s, e) => SetBrushType(BrushType.Crayon, "蜡笔");
+
+        if (MarkerBrushButton != null)
+            MarkerBrushButton.Click += (s, e) => SetBrushType(BrushType.Marker, "记号笔");
+
+        if (PencilBrushButton != null)
+            PencilBrushButton.Click += (s, e) => SetBrushType(BrushType.Pencil, "铅笔");
+
+        if (WatercolorBrushButton != null)
+            WatercolorBrushButton.Click += (s, e) => SetBrushType(BrushType.Watercolor, "水彩笔");
+
+        // Taper mode buttons
+        if (AnimNoneButton != null)
+            AnimNoneButton.Click += OnAnimNoneClick;
+
+        if (AnimGrowInButton != null)
+            AnimGrowInButton.Click += OnAnimGrowInClick;
+
+        if (AnimShrinkOutButton != null)
+            AnimShrinkOutButton.Click += OnAnimShrinkOutClick;
+    }
+
+    private void OnInkModeClick(object? sender, EventArgs e)
+    {
+        if (MainInkCanvas != null)
+        {
+            MainInkCanvas.EditingMode = InkCanvasEditingMode.Ink;
+            UpdateStatus();
+        }
+    }
+
+    private void OnEraseModeClick(object? sender, EventArgs e)
+    {
+        if (MainInkCanvas != null)
+        {
+            MainInkCanvas.EditingMode = InkCanvasEditingMode.EraseByStroke;
+            UpdateStatus();
+        }
+    }
+
+    private void OnClearClick(object? sender, EventArgs e)
+    {
+        if (MainInkCanvas != null)
+        {
+            MainInkCanvas.ClearStrokes();
+            UpdateStrokeCount();
+        }
+    }
+
+    private void SetColor(Color color)
+    {
+        if (MainInkCanvas != null)
+        {
+            MainInkCanvas.DefaultDrawingAttributes.Color = color;
+        }
+    }
+
+    private void SetBrushType(BrushType brushType, string displayName)
+    {
+        if (MainInkCanvas != null)
+        {
+            MainInkCanvas.DefaultDrawingAttributes.BrushType = brushType;
+            UpdateBrushTypeStatus(displayName);
+        }
+    }
+
+    private void UpdateBrushTypeStatus(string brushTypeName)
+    {
+        if (BrushTypeStatusText != null)
+        {
+            BrushTypeStatusText.Text = $"Brush Type: {brushTypeName}";
+        }
+    }
+
+    private void OnWidthSliderChanged(object? sender, RoutedPropertyChangedEventArgs<double> e)
+    {
+        if (MainInkCanvas != null && WidthText != null)
+        {
+            var width = Math.Round(e.NewValue);
+            MainInkCanvas.DefaultDrawingAttributes.Width = width;
+            MainInkCanvas.DefaultDrawingAttributes.Height = width;
+            WidthText.Text = $"Width: {width}";
+        }
+    }
+
+    private void OnHighlighterChanged(object? sender, RoutedEventArgs e)
+    {
+        if (MainInkCanvas != null && HighlighterCheckBox != null)
+        {
+            MainInkCanvas.DefaultDrawingAttributes.IsHighlighter = HighlighterCheckBox.IsChecked == true;
+        }
+    }
+
+    private void OnStrokeCollected(object? sender, InkCanvasStrokeCollectedEventArgs e)
+    {
+        UpdateStrokeCount();
+    }
+
+    private void OnAnimNoneClick(object? sender, EventArgs e)
+    {
+        if (MainInkCanvas != null)
+            MainInkCanvas.DefaultStrokeTaperMode = StrokeTaperMode.None;
+        UpdateAnimationStatus();
+    }
+
+    private void OnAnimGrowInClick(object? sender, EventArgs e)
+    {
+        if (MainInkCanvas != null)
+            MainInkCanvas.DefaultStrokeTaperMode = StrokeTaperMode.TaperedStart;
+        UpdateAnimationStatus();
+    }
+
+    private void OnAnimShrinkOutClick(object? sender, EventArgs e)
+    {
+        if (MainInkCanvas != null)
+            MainInkCanvas.DefaultStrokeTaperMode = StrokeTaperMode.TaperedEnd;
+        UpdateAnimationStatus();
+    }
+
+    private void UpdateAnimationStatus()
+    {
+        if (AnimationStatusText != null && MainInkCanvas != null)
+        {
+            var modeName = MainInkCanvas.DefaultStrokeTaperMode switch
+            {
+                StrokeTaperMode.None => "Normal",
+                StrokeTaperMode.TaperedStart => "Tapered Start",
+                StrokeTaperMode.TaperedEnd => "Tapered End",
+                _ => "Unknown"
+            };
+            AnimationStatusText.Text = $"Taper: {modeName}";
+        }
+    }
+
+    private void OnStrokesChanged(object? sender, EventArgs e)
+    {
+        UpdateStrokeCount();
+    }
+
+    private void UpdateStatus()
+    {
+        if (StatusText != null && MainInkCanvas != null)
+        {
+            var modeName = MainInkCanvas.EditingMode switch
+            {
+                InkCanvasEditingMode.Ink => "Ink",
+                InkCanvasEditingMode.EraseByStroke => "Erase",
+                InkCanvasEditingMode.EraseByPoint => "Erase (Point)",
+                InkCanvasEditingMode.Select => "Select",
+                _ => "None"
+            };
+            StatusText.Text = $"Mode: {modeName}";
+        }
+    }
+
+    private void UpdateStrokeCount()
+    {
+        if (StrokeCountText != null && MainInkCanvas != null)
+        {
+            StrokeCountText.Text = $"Strokes: {MainInkCanvas.Strokes.Count}";
+        }
+    }
+}

--- a/src/managed/Jalium.UI.Controls/Ink/BrushType.cs
+++ b/src/managed/Jalium.UI.Controls/Ink/BrushType.cs
@@ -1,0 +1,52 @@
+namespace Jalium.UI.Controls.Ink;
+
+/// <summary>
+/// Specifies the brush type for stroke rendering.
+/// </summary>
+public enum BrushType
+{
+    /// <summary>
+    /// Round brush - smooth circular stroke.
+    /// </summary>
+    Round,
+
+    /// <summary>
+    /// Calligraphy brush - varied width with artistic effect.
+    /// </summary>
+    Calligraphy,
+
+    /// <summary>
+    /// Writing pen - consistent fine stroke.
+    /// </summary>
+    Pen,
+
+    /// <summary>
+    /// Airbrush - soft spray effect with particles.
+    /// </summary>
+    Airbrush,
+
+    /// <summary>
+    /// Oil brush - textured artistic stroke.
+    /// </summary>
+    Oil,
+
+    /// <summary>
+    /// Crayon - rough textured effect.
+    /// </summary>
+    Crayon,
+
+    /// <summary>
+    /// Marker - semi-transparent wide stroke.
+    /// </summary>
+    Marker,
+
+    /// <summary>
+    /// Pencil - grainy textured stroke.
+    /// </summary>
+    Pencil,
+
+    /// <summary>
+    /// Watercolor - soft blended edges.
+    /// </summary>
+    Watercolor
+}

--- a/src/managed/Jalium.UI.Controls/Ink/DrawingAttributes.cs
+++ b/src/managed/Jalium.UI.Controls/Ink/DrawingAttributes.cs
@@ -1,0 +1,198 @@
+using System.ComponentModel;
+using Jalium.UI.Media;
+
+namespace Jalium.UI.Controls.Ink;
+
+/// <summary>
+/// Specifies the appearance of a <see cref="Stroke"/> when rendered.
+/// </summary>
+public class DrawingAttributes : INotifyPropertyChanged
+{
+    /// <summary>
+    /// The default width value.
+    /// </summary>
+    public const double DefaultWidth = 2.0;
+
+    /// <summary>
+    /// The default height value.
+    /// </summary>
+    public const double DefaultHeight = 2.0;
+
+    private Color _color = Color.FromRgb(0, 0, 0);
+    private double _width = DefaultWidth;
+    private double _height = DefaultHeight;
+    private StylusTip _stylusTip = StylusTip.Ellipse;
+    private bool _isHighlighter;
+    private bool _fitToCurve = true;
+    private bool _ignorePressure;
+    private BrushType _brushType = BrushType.Round;
+
+    /// <summary>
+    /// Occurs when a property value changes.
+    /// </summary>
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    /// <summary>
+    /// Occurs when any attribute changes.
+    /// </summary>
+    public event EventHandler? AttributeChanged;
+
+    /// <summary>
+    /// Gets or sets the color of the stroke.
+    /// </summary>
+    public Color Color
+    {
+        get => _color;
+        set
+        {
+            if (_color != value)
+            {
+                _color = value;
+                OnPropertyChanged(nameof(Color));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the width of the stroke.
+    /// </summary>
+    public double Width
+    {
+        get => _width;
+        set
+        {
+            if (!_width.Equals(value))
+            {
+                _width = Math.Max(0, value);
+                OnPropertyChanged(nameof(Width));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the height of the stroke.
+    /// </summary>
+    public double Height
+    {
+        get => _height;
+        set
+        {
+            if (!_height.Equals(value))
+            {
+                _height = Math.Max(0, value);
+                OnPropertyChanged(nameof(Height));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the shape of the stylus tip.
+    /// </summary>
+    public StylusTip StylusTip
+    {
+        get => _stylusTip;
+        set
+        {
+            if (_stylusTip != value)
+            {
+                _stylusTip = value;
+                OnPropertyChanged(nameof(StylusTip));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this stroke uses highlighter rendering.
+    /// </summary>
+    /// <remarks>
+    /// When true, the stroke is rendered with lower opacity to simulate a highlighter pen.
+    /// </remarks>
+    public bool IsHighlighter
+    {
+        get => _isHighlighter;
+        set
+        {
+            if (_isHighlighter != value)
+            {
+                _isHighlighter = value;
+                OnPropertyChanged(nameof(IsHighlighter));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether Bezier curve fitting is applied to smooth the stroke.
+    /// </summary>
+    public bool FitToCurve
+    {
+        get => _fitToCurve;
+        set
+        {
+            if (_fitToCurve != value)
+            {
+                _fitToCurve = value;
+                OnPropertyChanged(nameof(FitToCurve));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether pressure information is ignored during rendering.
+    /// </summary>
+    public bool IgnorePressure
+    {
+        get => _ignorePressure;
+        set
+        {
+            if (_ignorePressure != value)
+            {
+                _ignorePressure = value;
+                OnPropertyChanged(nameof(IgnorePressure));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the brush type for stroke rendering.
+    /// </summary>
+    public BrushType BrushType
+    {
+        get => _brushType;
+        set
+        {
+            if (_brushType != value)
+            {
+                _brushType = value;
+                OnPropertyChanged(nameof(BrushType));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Creates a copy of this <see cref="DrawingAttributes"/>.
+    /// </summary>
+    /// <returns>A new <see cref="DrawingAttributes"/> with the same values.</returns>
+    public DrawingAttributes Clone()
+    {
+        return new DrawingAttributes
+        {
+            Color = Color,
+            Width = Width,
+            Height = Height,
+            StylusTip = StylusTip,
+            IsHighlighter = IsHighlighter,
+            FitToCurve = FitToCurve,
+            IgnorePressure = IgnorePressure,
+            BrushType = BrushType
+        };
+    }
+
+    /// <summary>
+    /// Raises the <see cref="PropertyChanged"/> event.
+    /// </summary>
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        AttributeChanged?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/managed/Jalium.UI.Controls/Ink/Stroke.cs
+++ b/src/managed/Jalium.UI.Controls/Ink/Stroke.cs
@@ -1,0 +1,804 @@
+using System.ComponentModel;
+using Jalium.UI.Media;
+
+namespace Jalium.UI.Controls.Ink;
+
+/// <summary>
+/// Represents a single ink stroke consisting of stylus points and drawing attributes.
+/// </summary>
+public class Stroke : INotifyPropertyChanged
+{
+    private StylusPointCollection _stylusPoints;
+    private DrawingAttributes _drawingAttributes;
+    private StrokeTaperMode _taperMode = StrokeTaperMode.None;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Stroke"/> class.
+    /// </summary>
+    /// <param name="stylusPoints">The collection of stylus points.</param>
+    public Stroke(StylusPointCollection stylusPoints)
+        : this(stylusPoints, new DrawingAttributes())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Stroke"/> class.
+    /// </summary>
+    /// <param name="stylusPoints">The collection of stylus points.</param>
+    /// <param name="drawingAttributes">The drawing attributes for this stroke.</param>
+    public Stroke(StylusPointCollection stylusPoints, DrawingAttributes drawingAttributes)
+    {
+        _stylusPoints = stylusPoints ?? throw new ArgumentNullException(nameof(stylusPoints));
+        _drawingAttributes = drawingAttributes ?? throw new ArgumentNullException(nameof(drawingAttributes));
+
+        _stylusPoints.Changed += OnStylusPointsChanged;
+        _drawingAttributes.AttributeChanged += OnDrawingAttributesChanged;
+    }
+
+    /// <summary>
+    /// Occurs when a property value changes.
+    /// </summary>
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    /// <summary>
+    /// Occurs when the stroke needs to be redrawn.
+    /// </summary>
+    public event EventHandler? Invalidated;
+
+    /// <summary>
+    /// Occurs when the stylus points collection changes.
+    /// </summary>
+    public event EventHandler? StylusPointsChanged;
+
+    /// <summary>
+    /// Occurs when the drawing attributes change.
+    /// </summary>
+    public event EventHandler? DrawingAttributesChanged;
+
+    /// <summary>
+    /// Gets or sets the collection of stylus points that define this stroke.
+    /// </summary>
+    public StylusPointCollection StylusPoints
+    {
+        get => _stylusPoints;
+        set
+        {
+            if (_stylusPoints != value)
+            {
+                if (_stylusPoints != null)
+                    _stylusPoints.Changed -= OnStylusPointsChanged;
+
+                _stylusPoints = value ?? throw new ArgumentNullException(nameof(value));
+                _stylusPoints.Changed += OnStylusPointsChanged;
+
+                OnPropertyChanged(nameof(StylusPoints));
+                OnInvalidated();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the drawing attributes for this stroke.
+    /// </summary>
+    public DrawingAttributes DrawingAttributes
+    {
+        get => _drawingAttributes;
+        set
+        {
+            if (_drawingAttributes != value)
+            {
+                if (_drawingAttributes != null)
+                    _drawingAttributes.AttributeChanged -= OnDrawingAttributesChanged;
+
+                _drawingAttributes = value ?? throw new ArgumentNullException(nameof(value));
+                _drawingAttributes.AttributeChanged += OnDrawingAttributesChanged;
+
+                OnPropertyChanged(nameof(DrawingAttributes));
+                OnInvalidated();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the taper mode for this stroke.
+    /// </summary>
+    public StrokeTaperMode TaperMode
+    {
+        get => _taperMode;
+        set
+        {
+            if (_taperMode != value)
+            {
+                _taperMode = value;
+                OnPropertyChanged(nameof(TaperMode));
+                OnInvalidated();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Creates a copy of this stroke.
+    /// </summary>
+    /// <returns>A new <see cref="Stroke"/> with cloned points and attributes.</returns>
+    public virtual Stroke Clone()
+    {
+        var clone = new Stroke(_stylusPoints.Clone(), _drawingAttributes.Clone());
+        clone.TaperMode = TaperMode;
+        return clone;
+    }
+
+    /// <summary>
+    /// Gets the bounding rectangle of this stroke.
+    /// </summary>
+    /// <returns>A <see cref="Rect"/> that bounds this stroke.</returns>
+    public Rect GetBounds()
+    {
+        var bounds = _stylusPoints.GetBounds();
+        if (bounds.IsEmpty)
+            return bounds;
+
+        var halfWidth = _drawingAttributes.Width / 2;
+        var halfHeight = _drawingAttributes.Height / 2;
+        var inflate = Math.Max(halfWidth, halfHeight);
+
+        return new Rect(
+            bounds.X - inflate,
+            bounds.Y - inflate,
+            bounds.Width + inflate * 2,
+            bounds.Height + inflate * 2);
+    }
+
+    /// <summary>
+    /// Determines whether this stroke intersects with the specified point.
+    /// </summary>
+    /// <param name="point">The point to test.</param>
+    /// <param name="diameter">The diameter of the hit test area.</param>
+    /// <returns>True if the point hits this stroke; otherwise, false.</returns>
+    public bool HitTest(Point point, double diameter)
+    {
+        if (_stylusPoints.Count == 0)
+            return false;
+
+        var hitRadius = diameter / 2 + Math.Max(_drawingAttributes.Width, _drawingAttributes.Height) / 2;
+
+        if (_stylusPoints.Count == 1)
+        {
+            var sp = _stylusPoints[0];
+            var dx = point.X - sp.X;
+            var dy = point.Y - sp.Y;
+            return dx * dx + dy * dy <= hitRadius * hitRadius;
+        }
+
+        for (int i = 0; i < _stylusPoints.Count - 1; i++)
+        {
+            var p1 = _stylusPoints[i].ToPoint();
+            var p2 = _stylusPoints[i + 1].ToPoint();
+            var distance = DistanceToLineSegment(point, p1, p2);
+            if (distance <= hitRadius)
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether this stroke intersects with the specified rectangle.
+    /// </summary>
+    /// <param name="rect">The rectangle to test.</param>
+    /// <returns>True if the rectangle intersects this stroke; otherwise, false.</returns>
+    public bool HitTest(Rect rect)
+    {
+        var bounds = GetBounds();
+        return rect.IntersectsWith(bounds);
+    }
+
+    /// <summary>
+    /// Draws this stroke using the specified drawing context.
+    /// </summary>
+    /// <param name="dc">The drawing context.</param>
+    public void Draw(DrawingContext dc)
+    {
+        DrawCore(dc);
+    }
+
+    /// <summary>
+    /// Core drawing implementation using ellipse stamping for smooth strokes.
+    /// </summary>
+    /// <param name="dc">The drawing context.</param>
+    protected virtual void DrawCore(DrawingContext dc)
+    {
+        if (_stylusPoints.Count == 0)
+            return;
+
+        // Dispatch to appropriate brush type renderer
+        switch (_drawingAttributes.BrushType)
+        {
+            case BrushType.Round:
+            case BrushType.Pen:
+                DrawRoundBrush(dc);
+                break;
+            case BrushType.Calligraphy:
+                DrawCalligraphyBrush(dc);
+                break;
+            case BrushType.Airbrush:
+                DrawAirbrush(dc);
+                break;
+            case BrushType.Crayon:
+                DrawCrayonBrush(dc);
+                break;
+            case BrushType.Marker:
+                DrawMarkerBrush(dc);
+                break;
+            case BrushType.Pencil:
+                DrawPencilBrush(dc);
+                break;
+            case BrushType.Oil:
+                DrawOilBrush(dc);
+                break;
+            case BrushType.Watercolor:
+                DrawWatercolorBrush(dc);
+                break;
+            default:
+                DrawRoundBrush(dc);
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Draws stroke with round brush (default smooth circular stroke).
+    /// </summary>
+    private void DrawRoundBrush(DrawingContext dc)
+    {
+        // Create brush
+        var baseColor = _drawingAttributes.Color;
+        var brush = new SolidColorBrush(_drawingAttributes.Color);
+        if (_drawingAttributes.IsHighlighter)
+            brush = new SolidColorBrush(Color.FromArgb(128, _drawingAttributes.Color.R, _drawingAttributes.Color.G, _drawingAttributes.Color.B));
+
+        var radiusX = _drawingAttributes.Width / 2;
+        var radiusY = _drawingAttributes.Height / 2;
+
+        // For single point, just draw one ellipse
+        if (_stylusPoints.Count == 1)
+        {
+            var point = _stylusPoints[0].ToPoint();
+            var animatedRadius = ApplyAnimationScale(radiusX, radiusY, 0.0);
+            dc.DrawEllipse(brush, null, point, animatedRadius.X, animatedRadius.Y);
+            return;
+        }
+
+        var totalPoints = _stylusPoints.Count;
+
+        // Draw ellipses along the stroke path with interpolation for smooth appearance
+        for (int i = 0; i < _stylusPoints.Count - 1; i++)
+        {
+            var p1 = _stylusPoints[i].ToPoint();
+            var p2 = _stylusPoints[i + 1].ToPoint();
+
+            // Calculate distance between points
+            var dx = p2.X - p1.X;
+            var dy = p2.Y - p1.Y;
+            var segmentLength = Math.Sqrt(dx * dx + dy * dy);
+
+            // Determine step size based on radius (smaller steps = smoother but slower)
+            // Use 0.25 multiplier to ensure ellipses overlap and create smooth continuous stroke
+            var stepSize = Math.Max(0.5, Math.Min(radiusX, radiusY) * 0.25);
+            var steps = Math.Max(1, (int)(segmentLength / stepSize));
+
+            // Draw interpolated ellipses along the segment
+            for (int j = 0; j <= steps; j++)
+            {
+                var t = (double)j / steps;
+                var x = p1.X + dx * t;
+                var y = p1.Y + dy * t;
+
+                // Calculate progress based on point index (0 = oldest/start, 1 = newest/tip)
+                // This creates real-time animation effect during drawing
+                var pointProgress = (i + t) / (totalPoints - 1);
+
+                // Get pressure factor if available (for variable width)
+                var pressure1 = _stylusPoints[i].PressureFactor;
+                var pressure2 = _stylusPoints[i + 1].PressureFactor;
+                var pressure = pressure1 + (pressure2 - pressure1) * t;
+
+                // Apply pressure to radius if not ignoring pressure
+                var currentRadiusX = radiusX;
+                var currentRadiusY = radiusY;
+                if (!_drawingAttributes.IgnorePressure)
+                {
+                    currentRadiusX *= pressure;
+                    currentRadiusY *= pressure;
+                }
+
+                // Apply animation scaling based on point progress
+                var animatedRadius = ApplyAnimationScale(currentRadiusX, currentRadiusY, pointProgress);
+
+                dc.DrawEllipse(brush, null, new Point(x, y), animatedRadius.X, animatedRadius.Y);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Applies taper scaling to the radius based on the taper mode and progress.
+    /// Progress: 0 = oldest point (start), 1 = newest point (current pen tip).
+    /// </summary>
+    /// <param name="radiusX">The base X radius.</param>
+    /// <param name="radiusY">The base Y radius.</param>
+    /// <param name="progress">The progress along the stroke (0 = start, 1 = tip).</param>
+    /// <returns>The scaled radius.</returns>
+    private Point ApplyAnimationScale(double radiusX, double radiusY, double progress)
+    {
+        double scale = 1.0;
+
+        switch (_taperMode)
+        {
+            case StrokeTaperMode.TaperedStart:
+                // TaperedStart: stroke starts thin and grows to full width
+                // Start (oldest points) = small, Tip (newest points) = large
+                // Using ease-out curve for natural tapering effect
+                scale = EaseOutQuad(progress);
+                // Scale from 0.2 to 1.0
+                scale = 0.2 + scale * 0.8;
+                break;
+
+            case StrokeTaperMode.TaperedEnd:
+                // TaperedEnd: stroke starts at full width and tapers to thin
+                // Start (oldest points) = large, Tip (newest points) = small
+                // Using ease-out curve for natural tapering effect
+                scale = EaseOutQuad(1.0 - progress);
+                // Scale from 0.2 to 1.0
+                scale = 0.2 + scale * 0.8;
+                break;
+
+            case StrokeTaperMode.None:
+            default:
+                scale = 1.0;
+                break;
+        }
+
+        return new Point(radiusX * scale, radiusY * scale);
+    }
+
+    /// <summary>
+    /// Quadratic ease-out function: fast start, slow end.
+    /// </summary>
+    private static double EaseOutQuad(double t)
+    {
+        return 1.0 - (1.0 - t) * (1.0 - t);
+    }
+
+    #region Brush Type Implementations
+
+    /// <summary>
+    /// Draws stroke with calligraphy brush (varied width with artistic effect).
+    /// </summary>
+    private void DrawCalligraphyBrush(DrawingContext dc)
+    {
+        var baseColor = _drawingAttributes.Color;
+        var brush = new SolidColorBrush(baseColor);
+
+        var radiusX = _drawingAttributes.Width / 2;
+        var radiusY = _drawingAttributes.Height / 2;
+
+        if (_stylusPoints.Count == 1)
+        {
+            var point = _stylusPoints[0].ToPoint();
+            dc.DrawEllipse(brush, null, point, radiusX, radiusY * 0.3); // Thin ellipse for calligraphy
+            return;
+        }
+
+        var totalPoints = _stylusPoints.Count;
+
+        for (int i = 0; i < _stylusPoints.Count - 1; i++)
+        {
+            var p1 = _stylusPoints[i].ToPoint();
+            var p2 = _stylusPoints[i + 1].ToPoint();
+
+            var dx = p2.X - p1.X;
+            var dy = p2.Y - p1.Y;
+            var segmentLength = Math.Sqrt(dx * dx + dy * dy);
+
+            // Calculate angle for calligraphy effect
+            var angle = Math.Atan2(dy, dx);
+            var angleVariation = Math.Sin(angle * 3) * 0.5 + 0.5; // Vary width based on direction
+
+            var stepSize = Math.Max(0.5, Math.Min(radiusX, radiusY) * 0.25);
+            var steps = Math.Max(1, (int)(segmentLength / stepSize));
+
+            for (int j = 0; j <= steps; j++)
+            {
+                var t = (double)j / steps;
+                var x = p1.X + dx * t;
+                var y = p1.Y + dy * t;
+
+                var pointProgress = (i + t) / (totalPoints - 1);
+                var pressure1 = _stylusPoints[i].PressureFactor;
+                var pressure2 = _stylusPoints[i + 1].PressureFactor;
+                var pressure = pressure1 + (pressure2 - pressure1) * t;
+
+                var currentRadiusX = radiusX * pressure;
+                var currentRadiusY = radiusY * 0.3 * angleVariation; // Thin, angle-dependent
+
+                var animatedRadius = ApplyAnimationScale(currentRadiusX, currentRadiusY, pointProgress);
+                dc.DrawEllipse(brush, null, new Point(x, y), animatedRadius.X, animatedRadius.Y);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Draws stroke with airbrush (soft spray effect with particles).
+    /// </summary>
+    private void DrawAirbrush(DrawingContext dc)
+    {
+        var baseColor = _drawingAttributes.Color;
+        var radiusX = _drawingAttributes.Width / 2;
+        var radiusY = _drawingAttributes.Height / 2;
+
+        var random = new Random(_stylusPoints.GetHashCode());
+
+        for (int i = 0; i < _stylusPoints.Count - 1; i++)
+        {
+            var p1 = _stylusPoints[i].ToPoint();
+            var p2 = _stylusPoints[i + 1].ToPoint();
+
+            var dx = p2.X - p1.X;
+            var dy = p2.Y - p1.Y;
+            var segmentLength = Math.Sqrt(dx * dx + dy * dy);
+
+            var stepSize = Math.Max(2.0, radiusX * 0.5);
+            var steps = Math.Max(1, (int)(segmentLength / stepSize));
+
+            for (int j = 0; j <= steps; j++)
+            {
+                var t = (double)j / steps;
+                var centerX = p1.X + dx * t;
+                var centerY = p1.Y + dy * t;
+
+                // Draw multiple particles for spray effect
+                int particleCount = 15;
+                for (int k = 0; k < particleCount; k++)
+                {
+                    var angle = random.NextDouble() * Math.PI * 2;
+                    var distance = random.NextDouble() * radiusX * 1.5;
+                    var x = centerX + Math.Cos(angle) * distance;
+                    var y = centerY + Math.Sin(angle) * distance;
+
+                    var alpha = (byte)(20 + random.Next(40)); // Varied transparency
+                    var particleBrush = new SolidColorBrush(Color.FromArgb(alpha, baseColor.R, baseColor.G, baseColor.B));
+                    var particleSize = random.NextDouble() * 1.5 + 0.5;
+
+                    dc.DrawEllipse(particleBrush, null, new Point(x, y), particleSize, particleSize);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Draws stroke with crayon brush (rough textured effect).
+    /// </summary>
+    private void DrawCrayonBrush(DrawingContext dc)
+    {
+        var baseColor = _drawingAttributes.Color;
+        var radiusX = _drawingAttributes.Width / 2;
+        var radiusY = _drawingAttributes.Height / 2;
+
+        var random = new Random(_stylusPoints.GetHashCode());
+
+        for (int i = 0; i < _stylusPoints.Count - 1; i++)
+        {
+            var p1 = _stylusPoints[i].ToPoint();
+            var p2 = _stylusPoints[i + 1].ToPoint();
+
+            var dx = p2.X - p1.X;
+            var dy = p2.Y - p1.Y;
+            var segmentLength = Math.Sqrt(dx * dx + dy * dy);
+
+            var stepSize = Math.Max(0.5, radiusX * 0.2);
+            var steps = Math.Max(1, (int)(segmentLength / stepSize));
+
+            for (int j = 0; j <= steps; j++)
+            {
+                var t = (double)j / steps;
+                var x = p1.X + dx * t;
+                var y = p1.Y + dy * t;
+
+                // Add randomness for crayon texture
+                var offsetX = (random.NextDouble() - 0.5) * radiusX * 0.5;
+                var offsetY = (random.NextDouble() - 0.5) * radiusY * 0.5;
+                var alpha = (byte)(180 + random.Next(75)); // Varied opacity
+
+                var brush = new SolidColorBrush(Color.FromArgb(alpha, baseColor.R, baseColor.G, baseColor.B));
+                var size = radiusX * (0.8 + random.NextDouble() * 0.4);
+
+                dc.DrawEllipse(brush, null, new Point(x + offsetX, y + offsetY), size, size);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Draws stroke with marker brush (semi-transparent wide stroke).
+    /// </summary>
+    private void DrawMarkerBrush(DrawingContext dc)
+    {
+        var baseColor = _drawingAttributes.Color;
+        var alpha = (byte)Math.Min(200, (int)baseColor.A);
+        var brush = new SolidColorBrush(Color.FromArgb(alpha, baseColor.R, baseColor.G, baseColor.B));
+
+        var radiusX = _drawingAttributes.Width / 2;
+        var radiusY = _drawingAttributes.Height / 2;
+
+        if (_stylusPoints.Count == 1)
+        {
+            var point = _stylusPoints[0].ToPoint();
+            dc.DrawEllipse(brush, null, point, radiusX, radiusY);
+            return;
+        }
+
+        var totalPoints = _stylusPoints.Count;
+
+        for (int i = 0; i < _stylusPoints.Count - 1; i++)
+        {
+            var p1 = _stylusPoints[i].ToPoint();
+            var p2 = _stylusPoints[i + 1].ToPoint();
+
+            var dx = p2.X - p1.X;
+            var dy = p2.Y - p1.Y;
+            var segmentLength = Math.Sqrt(dx * dx + dy * dy);
+
+            var stepSize = Math.Max(0.5, Math.Min(radiusX, radiusY) * 0.3);
+            var steps = Math.Max(1, (int)(segmentLength / stepSize));
+
+            for (int j = 0; j <= steps; j++)
+            {
+                var t = (double)j / steps;
+                var x = p1.X + dx * t;
+                var y = p1.Y + dy * t;
+
+                var pointProgress = (i + t) / (totalPoints - 1);
+                var animatedRadius = ApplyAnimationScale(radiusX, radiusY, pointProgress);
+
+                dc.DrawEllipse(brush, null, new Point(x, y), animatedRadius.X, animatedRadius.Y);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Draws stroke with pencil brush (grainy textured stroke).
+    /// </summary>
+    private void DrawPencilBrush(DrawingContext dc)
+    {
+        var baseColor = _drawingAttributes.Color;
+        var radiusX = _drawingAttributes.Width / 2;
+        var radiusY = _drawingAttributes.Height / 2;
+
+        var random = new Random(_stylusPoints.GetHashCode());
+
+        for (int i = 0; i < _stylusPoints.Count - 1; i++)
+        {
+            var p1 = _stylusPoints[i].ToPoint();
+            var p2 = _stylusPoints[i + 1].ToPoint();
+
+            var dx = p2.X - p1.X;
+            var dy = p2.Y - p1.Y;
+            var segmentLength = Math.Sqrt(dx * dx + dy * dy);
+
+            var stepSize = Math.Max(0.3, radiusX * 0.15);
+            var steps = Math.Max(1, (int)(segmentLength / stepSize));
+
+            for (int j = 0; j <= steps; j++)
+            {
+                var t = (double)j / steps;
+                var x = p1.X + dx * t;
+                var y = p1.Y + dy * t;
+
+                // Add slight randomness for pencil grain
+                var offsetX = (random.NextDouble() - 0.5) * radiusX * 0.3;
+                var offsetY = (random.NextDouble() - 0.5) * radiusY * 0.3;
+                var alpha = (byte)(200 + random.Next(55)); // Varied opacity for grain
+
+                var brush = new SolidColorBrush(Color.FromArgb(alpha, baseColor.R, baseColor.G, baseColor.B));
+                var size = radiusX * 0.5 * (0.9 + random.NextDouble() * 0.2);
+
+                dc.DrawEllipse(brush, null, new Point(x + offsetX, y + offsetY), size, size);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Draws stroke with oil brush (textured artistic stroke with thick paint effect).
+    /// </summary>
+    private void DrawOilBrush(DrawingContext dc)
+    {
+        var baseColor = _drawingAttributes.Color;
+        var radiusX = _drawingAttributes.Width / 2;
+        var radiusY = _drawingAttributes.Height / 2;
+
+        var random = new Random(_stylusPoints.GetHashCode());
+
+        for (int i = 0; i < _stylusPoints.Count - 1; i++)
+        {
+            var p1 = _stylusPoints[i].ToPoint();
+            var p2 = _stylusPoints[i + 1].ToPoint();
+
+            var dx = p2.X - p1.X;
+            var dy = p2.Y - p1.Y;
+            var segmentLength = Math.Sqrt(dx * dx + dy * dy);
+
+            var stepSize = Math.Max(0.5, radiusX * 0.2);
+            var steps = Math.Max(1, (int)(segmentLength / stepSize));
+
+            for (int j = 0; j <= steps; j++)
+            {
+                var t = (double)j / steps;
+                var x = p1.X + dx * t;
+                var y = p1.Y + dy * t;
+
+                // Draw multiple overlapping strokes for thick paint texture
+                int layers = 5;
+                for (int layer = 0; layer < layers; layer++)
+                {
+                    var offsetX = (random.NextDouble() - 0.5) * radiusX * 0.6;
+                    var offsetY = (random.NextDouble() - 0.5) * radiusY * 0.6;
+
+                    // Vary color slightly for oil paint mixing effect
+                    var colorVariation = (int)((random.NextDouble() - 0.5) * 20);
+                    var r = (byte)Math.Max(0, Math.Min(255, baseColor.R + colorVariation));
+                    var g = (byte)Math.Max(0, Math.Min(255, baseColor.G + colorVariation));
+                    var b = (byte)Math.Max(0, Math.Min(255, baseColor.B + colorVariation));
+
+                    var alpha = (byte)(150 + random.Next(50)); // Thick, semi-opaque
+                    var brush = new SolidColorBrush(Color.FromArgb(alpha, r, g, b));
+
+                    var size = radiusX * 0.9 * (0.8 + random.NextDouble() * 0.4);
+                    dc.DrawEllipse(brush, null, new Point(x + offsetX, y + offsetY), size, size * 0.8);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Draws stroke with watercolor brush (soft blended edges with color diffusion).
+    /// </summary>
+    private void DrawWatercolorBrush(DrawingContext dc)
+    {
+        var baseColor = _drawingAttributes.Color;
+        var radiusX = _drawingAttributes.Width / 2;
+        var radiusY = _drawingAttributes.Height / 2;
+
+        var random = new Random(_stylusPoints.GetHashCode());
+
+        for (int i = 0; i < _stylusPoints.Count - 1; i++)
+        {
+            var p1 = _stylusPoints[i].ToPoint();
+            var p2 = _stylusPoints[i + 1].ToPoint();
+
+            var dx = p2.X - p1.X;
+            var dy = p2.Y - p1.Y;
+            var segmentLength = Math.Sqrt(dx * dx + dy * dy);
+
+            var stepSize = Math.Max(1.0, radiusX * 0.4);
+            var steps = Math.Max(1, (int)(segmentLength / stepSize));
+
+            for (int j = 0; j <= steps; j++)
+            {
+                var t = (double)j / steps;
+                var x = p1.X + dx * t;
+                var y = p1.Y + dy * t;
+
+                // Draw multiple layers with decreasing opacity for watercolor effect
+                int layers = 8;
+                for (int layer = 0; layer < layers; layer++)
+                {
+                    var layerRadius = radiusX * (1.0 + layer * 0.15); // Expand outward
+                    var angle = random.NextDouble() * Math.PI * 2;
+                    var distance = random.NextDouble() * radiusX * 0.4;
+
+                    var offsetX = Math.Cos(angle) * distance;
+                    var offsetY = Math.Sin(angle) * distance;
+
+                    // Fade out as we go outward (watercolor diffusion)
+                    var alpha = (byte)(15 + (layers - layer) * 8);
+                    var brush = new SolidColorBrush(Color.FromArgb(alpha, baseColor.R, baseColor.G, baseColor.B));
+
+                    var size = layerRadius * (0.7 + random.NextDouble() * 0.3);
+                    dc.DrawEllipse(brush, null, new Point(x + offsetX, y + offsetY), size, size);
+                }
+            }
+        }
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Gets the geometry representation of this stroke.
+    /// </summary>
+    /// <returns>A <see cref="Geometry"/> representing this stroke.</returns>
+    public Geometry GetGeometry()
+    {
+        return GetGeometry(_drawingAttributes);
+    }
+
+    /// <summary>
+    /// Gets the geometry representation of this stroke with the specified drawing attributes.
+    /// </summary>
+    /// <param name="attributes">The drawing attributes to use.</param>
+    /// <returns>A <see cref="Geometry"/> representing this stroke.</returns>
+    public Geometry GetGeometry(DrawingAttributes attributes)
+    {
+        if (_stylusPoints.Count < 2)
+            return new PathGeometry();
+
+        var geometry = new PathGeometry();
+        var figure = new PathFigure
+        {
+            StartPoint = _stylusPoints[0].ToPoint(),
+            IsClosed = false,
+            IsFilled = false
+        };
+
+        for (int i = 1; i < _stylusPoints.Count; i++)
+        {
+            figure.Segments.Add(new LineSegment(_stylusPoints[i].ToPoint()));
+        }
+
+        geometry.Figures.Add(figure);
+        return geometry;
+    }
+
+    /// <summary>
+    /// Calculates the distance from a point to a line segment.
+    /// </summary>
+    private static double DistanceToLineSegment(Point point, Point lineStart, Point lineEnd)
+    {
+        var dx = lineEnd.X - lineStart.X;
+        var dy = lineEnd.Y - lineStart.Y;
+        var lengthSquared = dx * dx + dy * dy;
+
+        if (lengthSquared == 0)
+        {
+            // Line segment is a point
+            var pdx = point.X - lineStart.X;
+            var pdy = point.Y - lineStart.Y;
+            return Math.Sqrt(pdx * pdx + pdy * pdy);
+        }
+
+        // Calculate projection parameter
+        var t = Math.Max(0, Math.Min(1, ((point.X - lineStart.X) * dx + (point.Y - lineStart.Y) * dy) / lengthSquared));
+
+        // Find closest point on segment
+        var closestX = lineStart.X + t * dx;
+        var closestY = lineStart.Y + t * dy;
+
+        var distX = point.X - closestX;
+        var distY = point.Y - closestY;
+        return Math.Sqrt(distX * distX + distY * distY);
+    }
+
+    private void OnStylusPointsChanged(object? sender, EventArgs e)
+    {
+        StylusPointsChanged?.Invoke(this, EventArgs.Empty);
+        OnInvalidated();
+    }
+
+    private void OnDrawingAttributesChanged(object? sender, EventArgs e)
+    {
+        DrawingAttributesChanged?.Invoke(this, EventArgs.Empty);
+        OnInvalidated();
+    }
+
+    /// <summary>
+    /// Raises the <see cref="PropertyChanged"/> event.
+    /// </summary>
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+
+    /// <summary>
+    /// Raises the <see cref="Invalidated"/> event.
+    /// </summary>
+    protected virtual void OnInvalidated()
+    {
+        Invalidated?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/managed/Jalium.UI.Controls/Ink/StrokeCollection.cs
+++ b/src/managed/Jalium.UI.Controls/Ink/StrokeCollection.cs
@@ -1,0 +1,224 @@
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using Jalium.UI.Media;
+
+namespace Jalium.UI.Controls.Ink;
+
+/// <summary>
+/// Represents a collection of <see cref="Stroke"/> objects with change notification.
+/// </summary>
+public class StrokeCollection : ObservableCollection<Stroke>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StrokeCollection"/> class.
+    /// </summary>
+    public StrokeCollection()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StrokeCollection"/> class with the specified strokes.
+    /// </summary>
+    /// <param name="strokes">The strokes to add to the collection.</param>
+    public StrokeCollection(IEnumerable<Stroke> strokes) : base(strokes)
+    {
+        foreach (var stroke in this)
+        {
+            stroke.Invalidated += OnStrokeInvalidated;
+        }
+    }
+
+    /// <summary>
+    /// Occurs when strokes are added, removed, or replaced in the collection.
+    /// </summary>
+    public event EventHandler<StrokeCollectionChangedEventArgs>? StrokesChanged;
+
+    /// <summary>
+    /// Gets the bounding rectangle of all strokes in the collection.
+    /// </summary>
+    /// <returns>A <see cref="Rect"/> that bounds all strokes.</returns>
+    public Rect GetBounds()
+    {
+        if (Count == 0)
+            return Rect.Empty;
+
+        var bounds = Rect.Empty;
+        foreach (var stroke in this)
+        {
+            var strokeBounds = stroke.GetBounds();
+            if (bounds.IsEmpty)
+                bounds = strokeBounds;
+            else
+                bounds = bounds.Union(strokeBounds);
+        }
+
+        return bounds;
+    }
+
+    /// <summary>
+    /// Creates a copy of this collection.
+    /// </summary>
+    /// <returns>A new <see cref="StrokeCollection"/> containing cloned strokes.</returns>
+    public StrokeCollection Clone()
+    {
+        var cloned = new StrokeCollection();
+        foreach (var stroke in this)
+        {
+            cloned.Add(stroke.Clone());
+        }
+        return cloned;
+    }
+
+    /// <summary>
+    /// Adds a range of strokes to the collection.
+    /// </summary>
+    /// <param name="strokes">The strokes to add.</param>
+    public void AddRange(IEnumerable<Stroke> strokes)
+    {
+        foreach (var stroke in strokes)
+        {
+            Add(stroke);
+        }
+    }
+
+    /// <summary>
+    /// Removes a range of strokes from the collection.
+    /// </summary>
+    /// <param name="strokes">The strokes to remove.</param>
+    public void RemoveRange(IEnumerable<Stroke> strokes)
+    {
+        foreach (var stroke in strokes.ToList())
+        {
+            Remove(stroke);
+        }
+    }
+
+    /// <summary>
+    /// Returns all strokes that intersect with the specified point.
+    /// </summary>
+    /// <param name="point">The point to test.</param>
+    /// <param name="diameter">The diameter of the hit test area.</param>
+    /// <returns>A collection of strokes that hit the point.</returns>
+    public StrokeCollection HitTest(Point point, double diameter = 4.0)
+    {
+        var result = new StrokeCollection();
+        foreach (var stroke in this)
+        {
+            if (stroke.HitTest(point, diameter))
+            {
+                result.Add(stroke);
+            }
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Returns all strokes that intersect with the specified rectangle.
+    /// </summary>
+    /// <param name="rect">The rectangle to test.</param>
+    /// <returns>A collection of strokes that intersect the rectangle.</returns>
+    public StrokeCollection HitTest(Rect rect)
+    {
+        var result = new StrokeCollection();
+        foreach (var stroke in this)
+        {
+            if (stroke.HitTest(rect))
+            {
+                result.Add(stroke);
+            }
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Draws all strokes in the collection using the specified drawing context.
+    /// </summary>
+    /// <param name="dc">The drawing context.</param>
+    public void Draw(DrawingContext dc)
+    {
+        foreach (var stroke in this)
+        {
+            stroke.Draw(dc);
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override void InsertItem(int index, Stroke item)
+    {
+        item.Invalidated += OnStrokeInvalidated;
+        base.InsertItem(index, item);
+        OnStrokesChanged(new StrokeCollectionChangedEventArgs(new[] { item }, Array.Empty<Stroke>()));
+    }
+
+    /// <inheritdoc/>
+    protected override void RemoveItem(int index)
+    {
+        var item = this[index];
+        item.Invalidated -= OnStrokeInvalidated;
+        base.RemoveItem(index);
+        OnStrokesChanged(new StrokeCollectionChangedEventArgs(Array.Empty<Stroke>(), new[] { item }));
+    }
+
+    /// <inheritdoc/>
+    protected override void SetItem(int index, Stroke item)
+    {
+        var oldItem = this[index];
+        oldItem.Invalidated -= OnStrokeInvalidated;
+        item.Invalidated += OnStrokeInvalidated;
+        base.SetItem(index, item);
+        OnStrokesChanged(new StrokeCollectionChangedEventArgs(new[] { item }, new[] { oldItem }));
+    }
+
+    /// <inheritdoc/>
+    protected override void ClearItems()
+    {
+        var removed = this.ToArray();
+        foreach (var item in removed)
+        {
+            item.Invalidated -= OnStrokeInvalidated;
+        }
+        base.ClearItems();
+        OnStrokesChanged(new StrokeCollectionChangedEventArgs(Array.Empty<Stroke>(), removed));
+    }
+
+    private void OnStrokeInvalidated(object? sender, EventArgs e)
+    {
+        // Notify that collection needs redraw
+        OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+    }
+
+    /// <summary>
+    /// Raises the <see cref="StrokesChanged"/> event.
+    /// </summary>
+    protected virtual void OnStrokesChanged(StrokeCollectionChangedEventArgs e)
+    {
+        StrokesChanged?.Invoke(this, e);
+    }
+}
+
+/// <summary>
+/// Provides data for the <see cref="StrokeCollection.StrokesChanged"/> event.
+/// </summary>
+public class StrokeCollectionChangedEventArgs : EventArgs
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StrokeCollectionChangedEventArgs"/> class.
+    /// </summary>
+    /// <param name="added">The strokes that were added.</param>
+    /// <param name="removed">The strokes that were removed.</param>
+    public StrokeCollectionChangedEventArgs(IEnumerable<Stroke> added, IEnumerable<Stroke> removed)
+    {
+        Added = added.ToArray();
+        Removed = removed.ToArray();
+    }
+
+    /// <summary>
+    /// Gets the strokes that were added to the collection.
+    /// </summary>
+    public IReadOnlyList<Stroke> Added { get; }
+
+    /// <summary>
+    /// Gets the strokes that were removed from the collection.
+    /// </summary>
+    public IReadOnlyList<Stroke> Removed { get; }
+}

--- a/src/managed/Jalium.UI.Controls/Ink/StrokeTaperMode.cs
+++ b/src/managed/Jalium.UI.Controls/Ink/StrokeTaperMode.cs
@@ -1,0 +1,22 @@
+namespace Jalium.UI.Controls.Ink;
+
+/// <summary>
+/// Specifies the taper mode for stroke rendering.
+/// </summary>
+public enum StrokeTaperMode
+{
+    /// <summary>
+    /// No taper - stroke is rendered at constant width.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// Tapered start - stroke starts thin and grows to full width.
+    /// </summary>
+    TaperedStart,
+
+    /// <summary>
+    /// Tapered end - stroke starts at full width and tapers to thin.
+    /// </summary>
+    TaperedEnd
+}

--- a/src/managed/Jalium.UI.Controls/Ink/StylusPoint.cs
+++ b/src/managed/Jalium.UI.Controls/Ink/StylusPoint.cs
@@ -1,0 +1,129 @@
+namespace Jalium.UI.Controls.Ink;
+
+/// <summary>
+/// Represents a single sampling point from a stylus or mouse input device.
+/// </summary>
+public struct StylusPoint : IEquatable<StylusPoint>
+{
+    /// <summary>
+    /// The default pressure factor value.
+    /// </summary>
+    public const float DefaultPressure = 0.5f;
+
+    private double _x;
+    private double _y;
+    private float _pressureFactor;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StylusPoint"/> struct.
+    /// </summary>
+    /// <param name="x">The x-coordinate of the point.</param>
+    /// <param name="y">The y-coordinate of the point.</param>
+    public StylusPoint(double x, double y)
+    {
+        _x = x;
+        _y = y;
+        _pressureFactor = DefaultPressure;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StylusPoint"/> struct.
+    /// </summary>
+    /// <param name="x">The x-coordinate of the point.</param>
+    /// <param name="y">The y-coordinate of the point.</param>
+    /// <param name="pressureFactor">The pressure factor (0.0 to 1.0).</param>
+    public StylusPoint(double x, double y, float pressureFactor)
+    {
+        _x = x;
+        _y = y;
+        _pressureFactor = Math.Clamp(pressureFactor, 0f, 1f);
+    }
+
+    /// <summary>
+    /// Gets or sets the x-coordinate of this point.
+    /// </summary>
+    public double X
+    {
+        readonly get => _x;
+        set => _x = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the y-coordinate of this point.
+    /// </summary>
+    public double Y
+    {
+        readonly get => _y;
+        set => _y = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the pressure factor of this point.
+    /// </summary>
+    /// <remarks>
+    /// The pressure factor ranges from 0.0 to 1.0, where 0.5 is the default.
+    /// </remarks>
+    public float PressureFactor
+    {
+        readonly get => _pressureFactor;
+        set => _pressureFactor = Math.Clamp(value, 0f, 1f);
+    }
+
+    /// <summary>
+    /// Converts this <see cref="StylusPoint"/> to a <see cref="Point"/>.
+    /// </summary>
+    /// <returns>A <see cref="Point"/> with the same X and Y coordinates.</returns>
+    public readonly Point ToPoint() => new(_x, _y);
+
+    /// <summary>
+    /// Implicitly converts a <see cref="StylusPoint"/> to a <see cref="Point"/>.
+    /// </summary>
+    public static implicit operator Point(StylusPoint sp) => sp.ToPoint();
+
+    /// <summary>
+    /// Creates a <see cref="StylusPoint"/> from a <see cref="Point"/> with default pressure.
+    /// </summary>
+    public static StylusPoint FromPoint(Point point) => new(point.X, point.Y);
+
+    /// <inheritdoc/>
+    public readonly bool Equals(StylusPoint other)
+    {
+        return _x.Equals(other._x) &&
+               _y.Equals(other._y) &&
+               _pressureFactor.Equals(other._pressureFactor);
+    }
+
+    /// <inheritdoc/>
+    public override readonly bool Equals(object? obj)
+    {
+        return obj is StylusPoint other && Equals(other);
+    }
+
+    /// <inheritdoc/>
+    public override readonly int GetHashCode()
+    {
+        return HashCode.Combine(_x, _y, _pressureFactor);
+    }
+
+    /// <summary>
+    /// Determines whether two <see cref="StylusPoint"/> instances are equal.
+    /// </summary>
+    public static bool operator ==(StylusPoint left, StylusPoint right)
+    {
+        return left.Equals(right);
+    }
+
+    /// <summary>
+    /// Determines whether two <see cref="StylusPoint"/> instances are not equal.
+    /// </summary>
+    public static bool operator !=(StylusPoint left, StylusPoint right)
+    {
+        return !left.Equals(right);
+    }
+
+    /// <inheritdoc/>
+    public override readonly string ToString()
+    {
+        return $"{_x},{_y},{_pressureFactor}";
+    }
+}

--- a/src/managed/Jalium.UI.Controls/Ink/StylusPointCollection.cs
+++ b/src/managed/Jalium.UI.Controls/Ink/StylusPointCollection.cs
@@ -1,0 +1,272 @@
+using System.Collections;
+using System.Collections.Specialized;
+using Jalium.UI.Media;
+
+namespace Jalium.UI.Controls.Ink;
+
+/// <summary>
+/// Represents a collection of <see cref="StylusPoint"/> values that can be individually accessed by index.
+/// </summary>
+public class StylusPointCollection : IList<StylusPoint>, IList, INotifyCollectionChanged
+{
+    private readonly List<StylusPoint> _points;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StylusPointCollection"/> class.
+    /// </summary>
+    public StylusPointCollection()
+    {
+        _points = new List<StylusPoint>();
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StylusPointCollection"/> class with the specified capacity.
+    /// </summary>
+    /// <param name="capacity">The number of <see cref="StylusPoint"/> values that the collection can initially store.</param>
+    public StylusPointCollection(int capacity)
+    {
+        _points = new List<StylusPoint>(capacity);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StylusPointCollection"/> class with the specified points.
+    /// </summary>
+    /// <param name="points">The points to add to the collection.</param>
+    public StylusPointCollection(IEnumerable<StylusPoint> points)
+    {
+        _points = new List<StylusPoint>(points);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StylusPointCollection"/> class from a collection of <see cref="Point"/> values.
+    /// </summary>
+    /// <param name="points">The points to add to the collection with default pressure.</param>
+    public StylusPointCollection(IEnumerable<Point> points)
+    {
+        _points = new List<StylusPoint>(points.Select(StylusPoint.FromPoint));
+    }
+
+    /// <summary>
+    /// Occurs when the collection changes.
+    /// </summary>
+    public event NotifyCollectionChangedEventHandler? CollectionChanged;
+
+    /// <summary>
+    /// Occurs when any property of any point in the collection changes.
+    /// </summary>
+    public event EventHandler? Changed;
+
+    /// <summary>
+    /// Gets or sets the point at the specified index.
+    /// </summary>
+    public StylusPoint this[int index]
+    {
+        get => _points[index];
+        set
+        {
+            var oldItem = _points[index];
+            _points[index] = value;
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Replace, value, oldItem, index));
+        }
+    }
+
+    object? IList.this[int index]
+    {
+        get => _points[index];
+        set
+        {
+            if (value is StylusPoint point)
+                this[index] = point;
+        }
+    }
+
+    /// <summary>
+    /// Gets the number of points in the collection.
+    /// </summary>
+    public int Count => _points.Count;
+
+    /// <summary>
+    /// Gets a value indicating whether the collection is read-only.
+    /// </summary>
+    public bool IsReadOnly => false;
+
+    bool IList.IsFixedSize => false;
+    bool ICollection.IsSynchronized => false;
+    object ICollection.SyncRoot => ((ICollection)_points).SyncRoot;
+
+    /// <summary>
+    /// Adds a point to the collection.
+    /// </summary>
+    public void Add(StylusPoint item)
+    {
+        _points.Add(item);
+        OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item, _points.Count - 1));
+    }
+
+    /// <summary>
+    /// Adds a <see cref="Point"/> to the collection with default pressure.
+    /// </summary>
+    public void Add(Point point)
+    {
+        Add(StylusPoint.FromPoint(point));
+    }
+
+    int IList.Add(object? value)
+    {
+        if (value is StylusPoint point)
+        {
+            Add(point);
+            return _points.Count - 1;
+        }
+        return -1;
+    }
+
+    /// <summary>
+    /// Adds a range of points to the collection.
+    /// </summary>
+    public void AddRange(IEnumerable<StylusPoint> points)
+    {
+        var startIndex = _points.Count;
+        var items = points.ToList();
+        _points.AddRange(items);
+        OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, items, startIndex));
+    }
+
+    /// <summary>
+    /// Removes all points from the collection.
+    /// </summary>
+    public void Clear()
+    {
+        _points.Clear();
+        OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+    }
+
+    /// <summary>
+    /// Determines whether the collection contains a specific point.
+    /// </summary>
+    public bool Contains(StylusPoint item) => _points.Contains(item);
+    bool IList.Contains(object? value) => value is StylusPoint point && _points.Contains(point);
+
+    /// <summary>
+    /// Copies the points to an array.
+    /// </summary>
+    public void CopyTo(StylusPoint[] array, int arrayIndex) => _points.CopyTo(array, arrayIndex);
+    void ICollection.CopyTo(Array array, int index) => ((ICollection)_points).CopyTo(array, index);
+
+    /// <summary>
+    /// Returns an enumerator that iterates through the collection.
+    /// </summary>
+    public IEnumerator<StylusPoint> GetEnumerator() => _points.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => _points.GetEnumerator();
+
+    /// <summary>
+    /// Returns the index of the specified point.
+    /// </summary>
+    public int IndexOf(StylusPoint item) => _points.IndexOf(item);
+    int IList.IndexOf(object? value) => value is StylusPoint point ? _points.IndexOf(point) : -1;
+
+    /// <summary>
+    /// Inserts a point at the specified index.
+    /// </summary>
+    public void Insert(int index, StylusPoint item)
+    {
+        _points.Insert(index, item);
+        OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item, index));
+    }
+
+    void IList.Insert(int index, object? value)
+    {
+        if (value is StylusPoint point)
+            Insert(index, point);
+    }
+
+    /// <summary>
+    /// Removes the specified point from the collection.
+    /// </summary>
+    public bool Remove(StylusPoint item)
+    {
+        var index = _points.IndexOf(item);
+        if (index >= 0)
+        {
+            _points.RemoveAt(index);
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item, index));
+            return true;
+        }
+        return false;
+    }
+
+    void IList.Remove(object? value)
+    {
+        if (value is StylusPoint point)
+            Remove(point);
+    }
+
+    /// <summary>
+    /// Removes the point at the specified index.
+    /// </summary>
+    public void RemoveAt(int index)
+    {
+        var item = _points[index];
+        _points.RemoveAt(index);
+        OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item, index));
+    }
+
+    /// <summary>
+    /// Creates a copy of this collection.
+    /// </summary>
+    /// <returns>A new <see cref="StylusPointCollection"/> containing the same points.</returns>
+    public StylusPointCollection Clone()
+    {
+        return new StylusPointCollection(_points);
+    }
+
+    /// <summary>
+    /// Gets the bounding rectangle of all points in the collection.
+    /// </summary>
+    /// <returns>A <see cref="Rect"/> that bounds all points.</returns>
+    public Rect GetBounds()
+    {
+        if (_points.Count == 0)
+            return Rect.Empty;
+
+        var minX = double.MaxValue;
+        var minY = double.MaxValue;
+        var maxX = double.MinValue;
+        var maxY = double.MinValue;
+
+        foreach (var point in _points)
+        {
+            minX = Math.Min(minX, point.X);
+            minY = Math.Min(minY, point.Y);
+            maxX = Math.Max(maxX, point.X);
+            maxY = Math.Max(maxY, point.Y);
+        }
+
+        return new Rect(minX, minY, maxX - minX, maxY - minY);
+    }
+
+    /// <summary>
+    /// Transforms all points in the collection by the specified matrix.
+    /// </summary>
+    /// <param name="matrix">The transformation matrix.</param>
+    public void Transform(Matrix matrix)
+    {
+        for (int i = 0; i < _points.Count; i++)
+        {
+            var point = _points[i];
+            var transformed = matrix.Transform(point.ToPoint());
+            _points[i] = new StylusPoint(transformed.X, transformed.Y, point.PressureFactor);
+        }
+
+        OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+    }
+
+    /// <summary>
+    /// Raises the <see cref="CollectionChanged"/> event.
+    /// </summary>
+    protected virtual void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
+    {
+        CollectionChanged?.Invoke(this, e);
+        Changed?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/managed/Jalium.UI.Controls/Ink/StylusTip.cs
+++ b/src/managed/Jalium.UI.Controls/Ink/StylusTip.cs
@@ -1,0 +1,17 @@
+namespace Jalium.UI.Controls.Ink;
+
+/// <summary>
+/// Specifies the shape of the stylus tip used for ink rendering.
+/// </summary>
+public enum StylusTip
+{
+    /// <summary>
+    /// An elliptical tip shape.
+    /// </summary>
+    Ellipse,
+
+    /// <summary>
+    /// A rectangular tip shape.
+    /// </summary>
+    Rectangle
+}

--- a/src/managed/Jalium.UI.Controls/InkCanvas.cs
+++ b/src/managed/Jalium.UI.Controls/InkCanvas.cs
@@ -1,0 +1,509 @@
+using System.Collections.Specialized;
+using Jalium.UI.Controls.Ink;
+using Jalium.UI.Input;
+using Jalium.UI.Media;
+
+namespace Jalium.UI.Controls;
+
+/// <summary>
+/// Provides an area for ink collection and display.
+/// </summary>
+public class InkCanvas : FrameworkElement
+{
+    #region Private Fields
+
+    private StylusPointCollection? _currentPoints;
+    private Stroke? _currentStroke;
+    private bool _isDrawing;
+
+    /// <summary>
+    /// Minimum distance (in pixels) between consecutive points to avoid jitter.
+    /// </summary>
+    private const double MinPointDistance = 2.0;
+
+    #endregion
+
+    #region Dependency Properties
+
+    /// <summary>
+    /// Identifies the Background dependency property.
+    /// </summary>
+    public static readonly DependencyProperty BackgroundProperty =
+        DependencyProperty.Register(nameof(Background), typeof(Brush), typeof(InkCanvas),
+            new PropertyMetadata(null, OnVisualPropertyChanged));
+
+    /// <summary>
+    /// Identifies the Strokes dependency property.
+    /// </summary>
+    public static readonly DependencyProperty StrokesProperty =
+        DependencyProperty.Register(nameof(Strokes), typeof(StrokeCollection), typeof(InkCanvas),
+            new PropertyMetadata(null, OnStrokesChanged));
+
+    /// <summary>
+    /// Identifies the DefaultDrawingAttributes dependency property.
+    /// </summary>
+    public static readonly DependencyProperty DefaultDrawingAttributesProperty =
+        DependencyProperty.Register(nameof(DefaultDrawingAttributes), typeof(DrawingAttributes), typeof(InkCanvas),
+            new PropertyMetadata(null, OnDefaultDrawingAttributesChanged));
+
+    /// <summary>
+    /// Identifies the EditingMode dependency property.
+    /// </summary>
+    public static readonly DependencyProperty EditingModeProperty =
+        DependencyProperty.Register(nameof(EditingMode), typeof(InkCanvasEditingMode), typeof(InkCanvas),
+            new PropertyMetadata(InkCanvasEditingMode.Ink, OnEditingModeChanged));
+
+    /// <summary>
+    /// Identifies the EraserDiameter dependency property.
+    /// </summary>
+    public static readonly DependencyProperty EraserDiameterProperty =
+        DependencyProperty.Register(nameof(EraserDiameter), typeof(double), typeof(InkCanvas),
+            new PropertyMetadata(8.0));
+
+    /// <summary>
+    /// Identifies the DefaultStrokeTaperMode dependency property.
+    /// </summary>
+    public static readonly DependencyProperty DefaultStrokeTaperModeProperty =
+        DependencyProperty.Register(nameof(DefaultStrokeTaperMode), typeof(StrokeTaperMode), typeof(InkCanvas),
+            new PropertyMetadata(StrokeTaperMode.None));
+
+    #endregion
+
+    #region Constructors
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InkCanvas"/> class.
+    /// </summary>
+    public InkCanvas()
+    {
+        Strokes = new StrokeCollection();
+        DefaultDrawingAttributes = new DrawingAttributes();
+
+        // Reduce anti-aliasing for sharper strokes
+        RenderOptions.SetEdgeMode(this, EdgeMode.Aliased);
+
+        AddHandler(MouseDownEvent, new RoutedEventHandler(OnMouseDownHandler));
+        AddHandler(MouseMoveEvent, new RoutedEventHandler(OnMouseMoveHandler));
+        AddHandler(MouseUpEvent, new RoutedEventHandler(OnMouseUpHandler));
+        AddHandler(MouseLeaveEvent, new RoutedEventHandler(OnMouseLeaveHandler));
+    }
+
+    #endregion
+
+    #region CLR Properties
+
+    /// <summary>
+    /// Gets or sets the background brush for the InkCanvas.
+    /// </summary>
+    public Brush? Background
+    {
+        get => (Brush?)GetValue(BackgroundProperty);
+        set => SetValue(BackgroundProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the collection of strokes displayed on this InkCanvas.
+    /// </summary>
+    public StrokeCollection Strokes
+    {
+        get => (StrokeCollection?)GetValue(StrokesProperty) ?? new StrokeCollection();
+        set => SetValue(StrokesProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the default drawing attributes for new strokes.
+    /// </summary>
+    public DrawingAttributes DefaultDrawingAttributes
+    {
+        get => (DrawingAttributes?)GetValue(DefaultDrawingAttributesProperty) ?? new DrawingAttributes();
+        set => SetValue(DefaultDrawingAttributesProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the editing mode for this InkCanvas.
+    /// </summary>
+    public InkCanvasEditingMode EditingMode
+    {
+        get => (InkCanvasEditingMode)(GetValue(EditingModeProperty) ?? InkCanvasEditingMode.Ink);
+        set => SetValue(EditingModeProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the diameter of the eraser.
+    /// </summary>
+    public double EraserDiameter
+    {
+        get => (double)(GetValue(EraserDiameterProperty) ?? 8.0);
+        set => SetValue(EraserDiameterProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the default taper mode for new strokes.
+    /// </summary>
+    public StrokeTaperMode DefaultStrokeTaperMode
+    {
+        get => (StrokeTaperMode)(GetValue(DefaultStrokeTaperModeProperty) ?? StrokeTaperMode.None);
+        set => SetValue(DefaultStrokeTaperModeProperty, value);
+    }
+
+    #endregion
+
+    #region Events
+
+    /// <summary>
+    /// Occurs when a new stroke has been collected.
+    /// </summary>
+    public event EventHandler<InkCanvasStrokeCollectedEventArgs>? StrokeCollected;
+
+    /// <summary>
+    /// Occurs when a stroke is about to be erased.
+    /// </summary>
+    public event EventHandler<InkCanvasStrokeErasingEventArgs>? StrokeErasing;
+
+    /// <summary>
+    /// Occurs when the strokes collection changes.
+    /// </summary>
+    public event EventHandler? StrokesChanged;
+
+    /// <summary>
+    /// Occurs when the editing mode changes.
+    /// </summary>
+    public event EventHandler<RoutedEventArgs>? EditingModeChanged;
+
+    #endregion
+
+    #region Public Methods
+
+    /// <summary>
+    /// Clears all strokes from this InkCanvas.
+    /// </summary>
+    public void ClearStrokes()
+    {
+        Strokes.Clear();
+    }
+
+    #endregion
+
+    #region Layout
+
+    /// <inheritdoc/>
+    protected override Size MeasureOverride(Size availableSize)
+    {
+        return availableSize;
+    }
+
+    /// <inheritdoc/>
+    protected override Size ArrangeOverride(Size finalSize)
+    {
+        return finalSize;
+    }
+
+    #endregion
+
+    #region Rendering
+
+    /// <inheritdoc/>
+    protected override void OnRender(object drawingContext)
+    {
+        if (drawingContext is not DrawingContext dc)
+            return;
+
+        // Draw background
+        var background = Background;
+        if (background != null)
+        {
+            dc.DrawRectangle(background, null, new Rect(0, 0, ActualWidth, ActualHeight));
+        }
+
+        // Draw all committed strokes
+        Strokes?.Draw(dc);
+
+        // Draw the current stroke being drawn
+        _currentStroke?.Draw(dc);
+    }
+
+    #endregion
+
+    #region Input Handling
+
+    private void OnMouseDownHandler(object sender, RoutedEventArgs e)
+    {
+        if (e is not MouseButtonEventArgs args || args.ChangedButton != MouseButton.Left)
+            return;
+
+        var position = args.GetPosition(this);
+
+        switch (EditingMode)
+        {
+            case InkCanvasEditingMode.Ink:
+                StartDrawing(position);
+                break;
+
+            case InkCanvasEditingMode.EraseByStroke:
+                EraseStrokesAt(position);
+                break;
+
+            case InkCanvasEditingMode.EraseByPoint:
+                // EraseByPoint is more complex, treat like EraseByStroke for now
+                EraseStrokesAt(position);
+                break;
+        }
+
+        e.Handled = true;
+    }
+
+    private void OnMouseMoveHandler(object sender, RoutedEventArgs e)
+    {
+        if (e is not MouseEventArgs args)
+            return;
+
+        var position = args.GetPosition(this);
+
+        if (_isDrawing && EditingMode == InkCanvasEditingMode.Ink)
+        {
+            ContinueDrawing(position);
+            e.Handled = true;
+        }
+        else if (args.LeftButton == MouseButtonState.Pressed)
+        {
+            switch (EditingMode)
+            {
+                case InkCanvasEditingMode.EraseByStroke:
+                case InkCanvasEditingMode.EraseByPoint:
+                    EraseStrokesAt(position);
+                    e.Handled = true;
+                    break;
+            }
+        }
+    }
+
+    private void OnMouseUpHandler(object sender, RoutedEventArgs e)
+    {
+        if (e is not MouseButtonEventArgs args || args.ChangedButton != MouseButton.Left)
+            return;
+
+        if (_isDrawing && EditingMode == InkCanvasEditingMode.Ink)
+        {
+            FinishDrawing();
+            e.Handled = true;
+        }
+    }
+
+    private void OnMouseLeaveHandler(object sender, RoutedEventArgs e)
+    {
+        if (_isDrawing && EditingMode == InkCanvasEditingMode.Ink)
+        {
+            FinishDrawing();
+        }
+    }
+
+    #endregion
+
+    #region Drawing Logic
+
+    private void StartDrawing(Point position)
+    {
+        _currentPoints = new StylusPointCollection();
+        _currentPoints.Add(new StylusPoint(position.X, position.Y));
+        _currentStroke = new Stroke(_currentPoints, DefaultDrawingAttributes.Clone());
+        _currentStroke.TaperMode = DefaultStrokeTaperMode;
+        _isDrawing = true;
+
+        CaptureMouse();
+        InvalidateVisual();
+    }
+
+    private void ContinueDrawing(Point position)
+    {
+        if (_currentPoints == null || _currentPoints.Count == 0)
+            return;
+
+        // Check minimum distance from the last point to avoid jitter
+        var lastPoint = _currentPoints[_currentPoints.Count - 1];
+        var dx = position.X - lastPoint.X;
+        var dy = position.Y - lastPoint.Y;
+        var distanceSquared = dx * dx + dy * dy;
+
+        if (distanceSquared < MinPointDistance * MinPointDistance)
+            return;
+
+        _currentPoints.Add(new StylusPoint(position.X, position.Y));
+        InvalidateVisual();
+    }
+
+    private void FinishDrawing()
+    {
+        if (_currentStroke == null || _currentPoints == null)
+        {
+            _isDrawing = false;
+            ReleaseMouseCapture();
+            return;
+        }
+
+        // Only add stroke if it has at least one point
+        if (_currentPoints.Count > 0)
+        {
+            Strokes.Add(_currentStroke);
+            OnStrokeCollected(new InkCanvasStrokeCollectedEventArgs(_currentStroke));
+        }
+
+        _currentStroke = null;
+        _currentPoints = null;
+        _isDrawing = false;
+
+        ReleaseMouseCapture();
+        InvalidateVisual();
+    }
+
+    #endregion
+
+    #region Erasing Logic
+
+    private void EraseStrokesAt(Point position)
+    {
+        var hitStrokes = Strokes.HitTest(position, EraserDiameter);
+
+        foreach (var stroke in hitStrokes)
+        {
+            var erasingArgs = new InkCanvasStrokeErasingEventArgs(stroke);
+            OnStrokeErasing(erasingArgs);
+
+            if (!erasingArgs.Cancel)
+            {
+                Strokes.Remove(stroke);
+            }
+        }
+
+        if (hitStrokes.Count > 0)
+        {
+            InvalidateVisual();
+        }
+    }
+
+    #endregion
+
+    #region Event Handlers
+
+    private static void OnVisualPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is InkCanvas canvas)
+        {
+            canvas.InvalidateVisual();
+        }
+    }
+
+    private static void OnStrokesChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is not InkCanvas canvas)
+            return;
+
+        if (e.OldValue is StrokeCollection oldCollection)
+        {
+            oldCollection.CollectionChanged -= canvas.OnStrokesCollectionChanged;
+        }
+
+        if (e.NewValue is StrokeCollection newCollection)
+        {
+            newCollection.CollectionChanged += canvas.OnStrokesCollectionChanged;
+        }
+
+        canvas.InvalidateVisual();
+        canvas.StrokesChanged?.Invoke(canvas, EventArgs.Empty);
+    }
+
+    private void OnStrokesCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        InvalidateVisual();
+        StrokesChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private static void OnDefaultDrawingAttributesChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        // No immediate action needed - new attributes will be used for new strokes
+    }
+
+    private static void OnEditingModeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is InkCanvas canvas)
+        {
+            // Cancel any current drawing operation
+            if (canvas._isDrawing)
+            {
+                canvas._currentStroke = null;
+                canvas._currentPoints = null;
+                canvas._isDrawing = false;
+                canvas.ReleaseMouseCapture();
+                canvas.InvalidateVisual();
+            }
+
+            canvas.EditingModeChanged?.Invoke(canvas, new RoutedEventArgs());
+        }
+    }
+
+    #endregion
+
+    #region Event Raisers
+
+    /// <summary>
+    /// Raises the <see cref="StrokeCollected"/> event.
+    /// </summary>
+    protected virtual void OnStrokeCollected(InkCanvasStrokeCollectedEventArgs e)
+    {
+        StrokeCollected?.Invoke(this, e);
+    }
+
+    /// <summary>
+    /// Raises the <see cref="StrokeErasing"/> event.
+    /// </summary>
+    protected virtual void OnStrokeErasing(InkCanvasStrokeErasingEventArgs e)
+    {
+        StrokeErasing?.Invoke(this, e);
+    }
+
+    #endregion
+}
+
+/// <summary>
+/// Provides data for the <see cref="InkCanvas.StrokeCollected"/> event.
+/// </summary>
+public class InkCanvasStrokeCollectedEventArgs : EventArgs
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InkCanvasStrokeCollectedEventArgs"/> class.
+    /// </summary>
+    /// <param name="stroke">The stroke that was collected.</param>
+    public InkCanvasStrokeCollectedEventArgs(Stroke stroke)
+    {
+        Stroke = stroke;
+    }
+
+    /// <summary>
+    /// Gets the stroke that was collected.
+    /// </summary>
+    public Stroke Stroke { get; }
+}
+
+/// <summary>
+/// Provides data for the <see cref="InkCanvas.StrokeErasing"/> event.
+/// </summary>
+public class InkCanvasStrokeErasingEventArgs : EventArgs
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InkCanvasStrokeErasingEventArgs"/> class.
+    /// </summary>
+    /// <param name="stroke">The stroke that is about to be erased.</param>
+    public InkCanvasStrokeErasingEventArgs(Stroke stroke)
+    {
+        Stroke = stroke;
+    }
+
+    /// <summary>
+    /// Gets the stroke that is about to be erased.
+    /// </summary>
+    public Stroke Stroke { get; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to cancel the erase operation.
+    /// </summary>
+    public bool Cancel { get; set; }
+}

--- a/src/managed/Jalium.UI.Controls/InkCanvasEditingMode.cs
+++ b/src/managed/Jalium.UI.Controls/InkCanvasEditingMode.cs
@@ -1,0 +1,32 @@
+namespace Jalium.UI.Controls;
+
+/// <summary>
+/// Specifies the editing modes of an <see cref="InkCanvas"/>.
+/// </summary>
+public enum InkCanvasEditingMode
+{
+    /// <summary>
+    /// No editing interaction is available.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// The user can draw ink strokes.
+    /// </summary>
+    Ink,
+
+    /// <summary>
+    /// The user can select strokes by drawing a lasso around them.
+    /// </summary>
+    Select,
+
+    /// <summary>
+    /// The user can erase portions of strokes by touching them.
+    /// </summary>
+    EraseByPoint,
+
+    /// <summary>
+    /// The user can erase entire strokes by touching them.
+    /// </summary>
+    EraseByStroke
+}

--- a/src/managed/Jalium.UI.Media/EdgeMode.cs
+++ b/src/managed/Jalium.UI.Media/EdgeMode.cs
@@ -1,0 +1,17 @@
+namespace Jalium.UI.Media;
+
+/// <summary>
+/// Specifies how the edges of non-text drawing primitives are rendered.
+/// </summary>
+public enum EdgeMode
+{
+    /// <summary>
+    /// No edge mode is specified. Use the default edge rendering.
+    /// </summary>
+    Unspecified,
+
+    /// <summary>
+    /// Render edges with anti-aliasing for smoother appearance.
+    /// </summary>
+    Aliased
+}

--- a/src/managed/Jalium.UI.Media/RenderOptions.cs
+++ b/src/managed/Jalium.UI.Media/RenderOptions.cs
@@ -1,0 +1,37 @@
+namespace Jalium.UI.Media;
+
+/// <summary>
+/// Provides options for controlling rendering behavior of visual objects.
+/// </summary>
+public static class RenderOptions
+{
+    /// <summary>
+    /// Identifies the EdgeMode attached property.
+    /// </summary>
+    public static readonly DependencyProperty EdgeModeProperty =
+        DependencyProperty.RegisterAttached(
+            "EdgeMode",
+            typeof(EdgeMode),
+            typeof(RenderOptions),
+            new PropertyMetadata(EdgeMode.Unspecified));
+
+    /// <summary>
+    /// Sets the edge mode for the specified dependency object.
+    /// </summary>
+    /// <param name="target">The dependency object to set the edge mode for.</param>
+    /// <param name="edgeMode">The edge mode value.</param>
+    public static void SetEdgeMode(DependencyObject target, EdgeMode edgeMode)
+    {
+        target.SetValue(EdgeModeProperty, edgeMode);
+    }
+
+    /// <summary>
+    /// Gets the edge mode for the specified dependency object.
+    /// </summary>
+    /// <param name="target">The dependency object to get the edge mode from.</param>
+    /// <returns>The edge mode value.</returns>
+    public static EdgeMode GetEdgeMode(DependencyObject target)
+    {
+        return (EdgeMode)target.GetValue(EdgeModeProperty);
+    }
+}


### PR DESCRIPTION
实现完整的 InkCanvas 墨迹绘制控件，支持基本绘制和擦除功能。

## 核心功能
- InkCanvas 控件：支持墨迹绘制和擦除模式
- 数据模型：Stroke、StrokeCollection、StylusPoint、StylusPointCollection
- DrawingAttributes：颜色、宽度、高光、笔尖形状等属性

## 9 种画笔类型
- 圆笔 (Round)：默认平滑圆形笔画
- 毛笔 (Calligraphy)：根据角度变化宽度，实现书法效果
- 书写笔 (Pen)：细腻一致的书写笔触
- 喷枪 (Airbrush)：粒子喷射效果
- 油画笔 (Oil)：厚重质感，颜色混合效果
- 蜡笔 (Crayon)：粗糙纹理效果
- 记号笔 (Marker)：半透明宽笔画
- 铅笔 (Pencil)：颗粒质感效果
- 水彩笔 (Watercolor)：柔和边缘和颜色扩散效果

## 笔画渐变模式
- None：正常宽度
- TaperedStart：从细到粗
- TaperedEnd：从粗到细

## 渲染优化
- 椭圆印章渲染：平滑连续笔画
- EdgeMode 和 RenderOptions：减少抗锯齿实现锐利边缘
- 实时动画：基于点索引的进度计算

## Gallery 演示
- InkCanvasPage：完整的交互演示
- 颜色选择、宽度调整、高光模式
- 画笔类型选择、渐变模式选择
- 绘制和擦除模式切换