### PR TITLE
feat: 修复窗口调整大小抖动和实现光标支持

### DIFF
--- a/samples/Jalium.UI.Gallery/Jalium.UI.Gallery.csproj
+++ b/samples/Jalium.UI.Gallery/Jalium.UI.Gallery.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <OutputType>WinExe</OutputType>
     <TargetFramework>net10.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/Jalium.UI.Gallery/Views/ColorPickerPage.jalxaml
+++ b/samples/Jalium.UI.Gallery/Views/ColorPickerPage.jalxaml
@@ -1,0 +1,182 @@
+<Page xmlns="http://schemas.jalium.ui/2024"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      x:Class="Jalium.UI.Gallery.Views.ColorPickerPage"
+      Title="ColorPicker">
+
+    <StackPanel Orientation="Vertical">
+        <!-- Page Title -->
+        <TextBlock Text="ColorPicker"
+                   FontSize="32"
+                   Foreground="#FFFFFF"
+                   Margin="0,0,0,8"/>
+
+        <!-- Description -->
+        <TextBlock Text="A control that lets users select a color value."
+                   FontSize="14"
+                   Foreground="#888888"
+                   Margin="0,0,0,24"/>
+
+        <!-- Basic ColorPicker Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Basic ColorPicker"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="A full-featured color picker with spectrum and sliders."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <ColorPicker x:Name="BasicColorPicker"/>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Compact ColorPicker Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Compact ColorPicker"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="A more compact version for space-limited scenarios."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <ColorPicker IsCompact="True"/>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- ColorPicker Options Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="ColorPicker Options"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Configure which components are visible."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="With Alpha Channel:" Foreground="#888888" FontSize="12" Margin="0,0,0,8"/>
+                        <ColorPicker IsAlphaEnabled="True" Margin="0,0,0,16"/>
+
+                        <TextBlock Text="Without Alpha Channel:" Foreground="#888888" FontSize="12" Margin="0,0,0,8"/>
+                        <ColorPicker IsAlphaEnabled="False"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Interactive Demo Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Interactive Demo"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Select a color and see it applied to the preview."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Horizontal">
+                        <ColorPicker x:Name="DemoColorPicker" Width="300"/>
+                        <StackPanel Orientation="Vertical" Margin="24,0,0,0" VerticalAlignment="Center">
+                            <TextBlock Text="Preview:" Foreground="#888888" FontSize="12" Margin="0,0,0,8"/>
+                            <Border x:Name="ColorPreview"
+                                    Width="100"
+                                    Height="100"
+                                    Background="#0078D4"
+                                    CornerRadius="8"
+                                    Margin="0,0,0,12"/>
+                            <TextBlock x:Name="ColorHexText"
+                                       Text="#0078D4"
+                                       Foreground="#FFFFFF"
+                                       FontFamily="Consolas"
+                                       HorizontalAlignment="Center"/>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Use Cases Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Common Use Cases"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Examples of ColorPicker in real scenarios."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,16">
+                            <TextBlock Text="Text Color:" Width="120" Foreground="#888888" VerticalAlignment="Center"/>
+                            <Border Background="#FF0000" Width="32" Height="32" CornerRadius="4" Margin="0,0,8,0"/>
+                            <Button Content="Choose..." Width="80" Height="28"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,16">
+                            <TextBlock Text="Background:" Width="120" Foreground="#888888" VerticalAlignment="Center"/>
+                            <Border Background="#00FF00" Width="32" Height="32" CornerRadius="4" Margin="0,0,8,0"/>
+                            <Button Content="Choose..." Width="80" Height="28"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="Border Color:" Width="120" Foreground="#888888" VerticalAlignment="Center"/>
+                            <Border Background="#0000FF" Width="32" Height="32" CornerRadius="4" Margin="0,0,8,0"/>
+                            <Button Content="Choose..." Width="80" Height="28"/>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+    </StackPanel>
+</Page>

--- a/samples/Jalium.UI.Gallery/Views/ColorPickerPage.jalxaml.cs
+++ b/samples/Jalium.UI.Gallery/Views/ColorPickerPage.jalxaml.cs
@@ -1,0 +1,34 @@
+using Jalium.UI.Controls;
+using Jalium.UI.Media;
+
+namespace Jalium.UI.Gallery.Views;
+
+/// <summary>
+/// Code-behind for ColorPickerPage.jalxaml demonstrating color picker functionality.
+/// </summary>
+public partial class ColorPickerPage : Page
+{
+    public ColorPickerPage()
+    {
+        InitializeComponent();
+
+        // Set up event handler for the interactive demo
+        if (DemoColorPicker != null)
+        {
+            DemoColorPicker.ColorChanged += OnDemoColorChanged;
+        }
+    }
+
+    private void OnDemoColorChanged(object? sender, ColorChangedEventArgs e)
+    {
+        if (ColorPreview != null)
+        {
+            ColorPreview.Background = new SolidColorBrush(e.NewColor);
+        }
+
+        if (ColorHexText != null)
+        {
+            ColorHexText.Text = $"#{e.NewColor.R:X2}{e.NewColor.G:X2}{e.NewColor.B:X2}";
+        }
+    }
+}

--- a/samples/Jalium.UI.Gallery/Views/ContextMenuPage.jalxaml
+++ b/samples/Jalium.UI.Gallery/Views/ContextMenuPage.jalxaml
@@ -1,0 +1,152 @@
+<Page xmlns="http://schemas.jalium.ui/2024"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      x:Class="Jalium.UI.Gallery.Views.ContextMenuPage"
+      Title="ContextMenu">
+
+    <StackPanel Orientation="Vertical">
+        <!-- Page Title -->
+        <TextBlock Text="ContextMenu"
+                   FontSize="32"
+                   Foreground="#FFFFFF"
+                   Margin="0,0,0,8"/>
+
+        <!-- Description -->
+        <TextBlock Text="A popup menu that appears when right-clicking on an element."
+                   FontSize="14"
+                   Foreground="#888888"
+                   Margin="0,0,0,24"/>
+
+        <!-- Basic ContextMenu Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Basic ContextMenu"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Right-click on the area below to open the context menu."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="40"
+                        x:Name="ContextMenuArea">
+                    <TextBlock Text="Right-click here"
+                               Foreground="#888888"
+                               HorizontalAlignment="Center"
+                               VerticalAlignment="Center"/>
+                    <Border.ContextMenu>
+                        <ContextMenu>
+                            <MenuItem Header="Cut" InputGestureText="Ctrl+X"/>
+                            <MenuItem Header="Copy" InputGestureText="Ctrl+C"/>
+                            <MenuItem Header="Paste" InputGestureText="Ctrl+V"/>
+                            <Separator/>
+                            <MenuItem Header="Select All" InputGestureText="Ctrl+A"/>
+                        </ContextMenu>
+                    </Border.ContextMenu>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- ContextMenu with Submenus Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="ContextMenu with Submenus"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Context menus can contain nested submenus."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="40">
+                    <TextBlock Text="Right-click here for nested menu"
+                               Foreground="#888888"
+                               HorizontalAlignment="Center"
+                               VerticalAlignment="Center"/>
+                    <Border.ContextMenu>
+                        <ContextMenu>
+                            <MenuItem Header="New">
+                                <MenuItem Header="File"/>
+                                <MenuItem Header="Folder"/>
+                                <MenuItem Header="Project"/>
+                            </MenuItem>
+                            <MenuItem Header="Open"/>
+                            <Separator/>
+                            <MenuItem Header="Sort By">
+                                <MenuItem Header="Name"/>
+                                <MenuItem Header="Date"/>
+                                <MenuItem Header="Size"/>
+                                <MenuItem Header="Type"/>
+                            </MenuItem>
+                            <MenuItem Header="View">
+                                <MenuItem Header="Large Icons"/>
+                                <MenuItem Header="Small Icons"/>
+                                <MenuItem Header="List"/>
+                                <MenuItem Header="Details"/>
+                            </MenuItem>
+                            <Separator/>
+                            <MenuItem Header="Properties"/>
+                        </ContextMenu>
+                    </Border.ContextMenu>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Interactive Demo Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Interactive Demo"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Right-click to select an action. The selected action will be displayed."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="40"
+                        x:Name="InteractiveArea">
+                    <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                        <TextBlock Text="Right-click here"
+                                   Foreground="#888888"
+                                   HorizontalAlignment="Center"/>
+                        <TextBlock x:Name="SelectedActionText"
+                                   Text="No action selected"
+                                   Foreground="#0078D4"
+                                   HorizontalAlignment="Center"
+                                   Margin="0,8,0,0"/>
+                    </StackPanel>
+                    <Border.ContextMenu>
+                        <ContextMenu x:Name="InteractiveContextMenu">
+                            <MenuItem Header="Action 1" x:Name="Action1"/>
+                            <MenuItem Header="Action 2" x:Name="Action2"/>
+                            <MenuItem Header="Action 3" x:Name="Action3"/>
+                        </ContextMenu>
+                    </Border.ContextMenu>
+                </Border>
+            </StackPanel>
+        </Border>
+    </StackPanel>
+</Page>

--- a/samples/Jalium.UI.Gallery/Views/ContextMenuPage.jalxaml.cs
+++ b/samples/Jalium.UI.Gallery/Views/ContextMenuPage.jalxaml.cs
@@ -1,0 +1,16 @@
+using Jalium.UI.Controls;
+
+namespace Jalium.UI.Gallery.Views;
+
+/// <summary>
+/// Code-behind for ContextMenuPage.jalxaml demonstrating context menu functionality.
+/// </summary>
+public partial class ContextMenuPage : Page
+{
+    public ContextMenuPage()
+    {
+        InitializeComponent();
+        // Context menus are demonstrated statically in the XAML.
+        // The interactive demo shows the currently selected action.
+    }
+}

--- a/samples/Jalium.UI.Gallery/Views/DatePickerPage.jalxaml
+++ b/samples/Jalium.UI.Gallery/Views/DatePickerPage.jalxaml
@@ -1,0 +1,183 @@
+<Page xmlns="http://schemas.jalium.ui/2024"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      x:Class="Jalium.UI.Gallery.Views.DatePickerPage"
+      Title="DatePicker">
+
+    <StackPanel Orientation="Vertical">
+        <!-- Page Title -->
+        <TextBlock Text="DatePicker"
+                   FontSize="32"
+                   Foreground="#FFFFFF"
+                   Margin="0,0,0,8"/>
+
+        <!-- Description -->
+        <TextBlock Text="A control that lets users select a date from a calendar dropdown."
+                   FontSize="14"
+                   Foreground="#888888"
+                   Margin="0,0,0,24"/>
+
+        <!-- Basic DatePicker Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Basic DatePicker"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Click to open the calendar and select a date."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Horizontal">
+                        <DatePicker Width="200" Margin="0,0,16,0"/>
+                        <DatePicker Width="200" IsEnabled="False"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- DatePicker with Formats Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Date Formats"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="DatePicker supports different date format displays."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                            <TextBlock Text="Short format:" Width="120" Foreground="#888888" VerticalAlignment="Center"/>
+                            <DatePicker Width="200" SelectedDateFormat="Short"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="Long format:" Width="120" Foreground="#888888" VerticalAlignment="Center"/>
+                            <DatePicker Width="250" SelectedDateFormat="Long"/>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- DatePicker with Constraints Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Date Range Constraints"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="DatePicker can have minimum and maximum date limits."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                            <TextBlock Text="Start Date:" Width="120" Foreground="#888888" VerticalAlignment="Center"/>
+                            <DatePicker x:Name="StartDatePicker" Width="200"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="End Date:" Width="120" Foreground="#888888" VerticalAlignment="Center"/>
+                            <DatePicker x:Name="EndDatePicker" Width="200"/>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Interactive Demo Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Interactive Demo"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Select a date and see the formatted result."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,16">
+                            <TextBlock Text="Select date:" Width="120" Foreground="#888888" VerticalAlignment="Center"/>
+                            <DatePicker x:Name="DemoDatePicker" Width="200"/>
+                        </StackPanel>
+                        <TextBlock x:Name="SelectedDateText"
+                                   Text="No date selected"
+                                   Foreground="#0078D4"
+                                   FontSize="14"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Use Cases Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Common Use Cases"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Examples of DatePicker in real scenarios."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="Birth Date" Foreground="#888888" FontSize="12" Margin="0,0,0,4"/>
+                        <DatePicker Width="200" Margin="0,0,0,16"/>
+
+                        <TextBlock Text="Appointment Date" Foreground="#888888" FontSize="12" Margin="0,0,0,4"/>
+                        <DatePicker Width="200" Margin="0,0,0,16"/>
+
+                        <TextBlock Text="Project Deadline" Foreground="#888888" FontSize="12" Margin="0,0,0,4"/>
+                        <DatePicker Width="200"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+    </StackPanel>
+</Page>

--- a/samples/Jalium.UI.Gallery/Views/DatePickerPage.jalxaml.cs
+++ b/samples/Jalium.UI.Gallery/Views/DatePickerPage.jalxaml.cs
@@ -1,0 +1,35 @@
+using Jalium.UI.Controls;
+
+namespace Jalium.UI.Gallery.Views;
+
+/// <summary>
+/// Code-behind for DatePickerPage.jalxaml demonstrating date picker functionality.
+/// </summary>
+public partial class DatePickerPage : Page
+{
+    public DatePickerPage()
+    {
+        InitializeComponent();
+
+        // Set up event handler for the interactive demo
+        if (DemoDatePicker != null)
+        {
+            DemoDatePicker.SelectedDateChanged += OnDemoDateChanged;
+        }
+    }
+
+    private void OnDemoDateChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (SelectedDateText != null && DemoDatePicker != null)
+        {
+            if (DemoDatePicker.SelectedDate.HasValue)
+            {
+                SelectedDateText.Text = $"Selected: {DemoDatePicker.SelectedDate.Value:D}";
+            }
+            else
+            {
+                SelectedDateText.Text = "No date selected";
+            }
+        }
+    }
+}

--- a/samples/Jalium.UI.Gallery/Views/DialogsPage.jalxaml
+++ b/samples/Jalium.UI.Gallery/Views/DialogsPage.jalxaml
@@ -1,0 +1,229 @@
+<Page xmlns="http://schemas.jalium.ui/2024"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      x:Class="Jalium.UI.Gallery.Views.DialogsPage"
+      Title="Dialogs">
+
+    <StackPanel Orientation="Vertical">
+        <!-- Page Title -->
+        <TextBlock Text="Dialogs"
+                   FontSize="32"
+                   Foreground="#FFFFFF"
+                   Margin="0,0,0,8"/>
+
+        <!-- Description -->
+        <TextBlock Text="Common dialog controls for file operations, fonts, and colors."
+                   FontSize="14"
+                   Foreground="#888888"
+                   Margin="0,0,0,24"/>
+
+        <!-- Open File Dialog Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Open File Dialog"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Allows users to browse and select files to open."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                            <Button x:Name="OpenFileButton" Content="Open File..." Width="100" Height="28" Margin="0,0,8,0"/>
+                            <Button x:Name="OpenMultipleFilesButton" Content="Open Multiple..." Width="110" Height="28"/>
+                        </StackPanel>
+                        <TextBlock x:Name="SelectedFileText"
+                                   Text="No file selected"
+                                   Foreground="#888888"
+                                   TextWrapping="Wrap"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Save File Dialog Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Save File Dialog"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Allows users to specify a file name and location for saving."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <Button x:Name="SaveFileButton" Content="Save As..." Width="100" Height="28" Margin="0,0,0,12"/>
+                        <TextBlock x:Name="SaveFilePathText"
+                                   Text="No save location selected"
+                                   Foreground="#888888"
+                                   TextWrapping="Wrap"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Folder Browser Dialog Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Folder Browser Dialog"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Allows users to browse and select a folder."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <Button x:Name="BrowseFolderButton" Content="Browse Folder..." Width="120" Height="28" Margin="0,0,0,12"/>
+                        <TextBlock x:Name="SelectedFolderText"
+                                   Text="No folder selected"
+                                   Foreground="#888888"
+                                   TextWrapping="Wrap"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Font Dialog Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Font Dialog"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Allows users to select a font family, style, and size."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                            <Button x:Name="ChooseFontButton" Content="Choose Font..." Width="110" Height="28"/>
+                        </StackPanel>
+                        <TextBlock x:Name="FontPreviewText"
+                                   Text="The quick brown fox jumps over the lazy dog"
+                                   Foreground="#FFFFFF"
+                                   FontSize="14"
+                                   TextWrapping="Wrap"/>
+                        <TextBlock x:Name="SelectedFontText"
+                                   Text="Current: Segoe UI, 14pt"
+                                   Foreground="#888888"
+                                   Margin="0,8,0,0"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Message Dialog Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Message Dialogs"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Display messages, confirmations, and alerts to users."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                            <Button x:Name="InfoDialogButton" Content="Info" Width="70" Height="28" Margin="0,0,8,0"/>
+                            <Button x:Name="WarningDialogButton" Content="Warning" Width="80" Height="28" Margin="0,0,8,0"/>
+                            <Button x:Name="ErrorDialogButton" Content="Error" Width="70" Height="28" Margin="0,0,8,0"/>
+                            <Button x:Name="ConfirmDialogButton" Content="Confirm" Width="80" Height="28"/>
+                        </StackPanel>
+                        <TextBlock x:Name="DialogResultText"
+                                   Text="Click a button to show a dialog"
+                                   Foreground="#888888"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Dialog Options Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Dialog Options"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Common configuration options for file dialogs."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="Filter:" Foreground="#888888" FontSize="12" Margin="0,0,0,4"/>
+                        <TextBox Text="Text files (*.txt)|*.txt|All files (*.*)|*.*"
+                                 Width="400"
+                                 Height="28"
+                                 HorizontalAlignment="Left"
+                                 Margin="0,0,0,12"/>
+                        <TextBlock Text="Initial Directory:" Foreground="#888888" FontSize="12" Margin="0,0,0,4"/>
+                        <TextBox Text="C:\Users\Documents"
+                                 Width="400"
+                                 Height="28"
+                                 HorizontalAlignment="Left"
+                                 Margin="0,0,0,12"/>
+                        <CheckBox Content="Check if file exists" Margin="0,0,0,8"/>
+                        <CheckBox Content="Add to recent files" Margin="0,0,0,8" IsChecked="True"/>
+                        <CheckBox Content="Show hidden files"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+    </StackPanel>
+</Page>

--- a/samples/Jalium.UI.Gallery/Views/DialogsPage.jalxaml.cs
+++ b/samples/Jalium.UI.Gallery/Views/DialogsPage.jalxaml.cs
@@ -1,0 +1,167 @@
+using Jalium.UI.Controls;
+
+namespace Jalium.UI.Gallery.Views;
+
+/// <summary>
+/// Code-behind for DialogsPage.jalxaml demonstrating dialog functionality.
+/// </summary>
+public partial class DialogsPage : Page
+{
+    public DialogsPage()
+    {
+        InitializeComponent();
+
+        // Set up file dialog buttons
+        if (OpenFileButton != null)
+        {
+            OpenFileButton.Click += OnOpenFileClick;
+        }
+
+        if (OpenMultipleFilesButton != null)
+        {
+            OpenMultipleFilesButton.Click += OnOpenMultipleFilesClick;
+        }
+
+        if (SaveFileButton != null)
+        {
+            SaveFileButton.Click += OnSaveFileClick;
+        }
+
+        if (BrowseFolderButton != null)
+        {
+            BrowseFolderButton.Click += OnBrowseFolderClick;
+        }
+
+        // Set up font dialog button
+        if (ChooseFontButton != null)
+        {
+            ChooseFontButton.Click += OnChooseFontClick;
+        }
+
+        // Set up message dialog buttons
+        if (InfoDialogButton != null)
+        {
+            InfoDialogButton.Click += (s, e) => ShowMessageDialog("Information", "This is an informational message.", "info");
+        }
+
+        if (WarningDialogButton != null)
+        {
+            WarningDialogButton.Click += (s, e) => ShowMessageDialog("Warning", "This is a warning message.", "warning");
+        }
+
+        if (ErrorDialogButton != null)
+        {
+            ErrorDialogButton.Click += (s, e) => ShowMessageDialog("Error", "This is an error message.", "error");
+        }
+
+        if (ConfirmDialogButton != null)
+        {
+            ConfirmDialogButton.Click += (s, e) => ShowConfirmDialog();
+        }
+    }
+
+    private void OnOpenFileClick(object? sender, EventArgs e)
+    {
+        var dialog = new OpenFileDialog
+        {
+            Title = "Open File",
+            Filter = "Text files (*.txt)|*.txt|All files (*.*)|*.*"
+        };
+
+        if (dialog.ShowDialog() == true)
+        {
+            if (SelectedFileText != null)
+            {
+                SelectedFileText.Text = $"Selected: {dialog.FileName}";
+            }
+        }
+    }
+
+    private void OnOpenMultipleFilesClick(object? sender, EventArgs e)
+    {
+        var dialog = new OpenFileDialog
+        {
+            Title = "Open Files",
+            Filter = "All files (*.*)|*.*",
+            Multiselect = true
+        };
+
+        if (dialog.ShowDialog() == true)
+        {
+            if (SelectedFileText != null)
+            {
+                SelectedFileText.Text = $"Selected {dialog.FileNames?.Length ?? 0} file(s)";
+            }
+        }
+    }
+
+    private void OnSaveFileClick(object? sender, EventArgs e)
+    {
+        var dialog = new SaveFileDialog
+        {
+            Title = "Save File",
+            Filter = "Text files (*.txt)|*.txt|All files (*.*)|*.*"
+        };
+
+        if (dialog.ShowDialog() == true)
+        {
+            if (SaveFilePathText != null)
+            {
+                SaveFilePathText.Text = $"Save to: {dialog.FileName}";
+            }
+        }
+    }
+
+    private void OnBrowseFolderClick(object? sender, EventArgs e)
+    {
+        var dialog = new FolderBrowserDialog
+        {
+            Title = "Select Folder"
+        };
+
+        if (dialog.ShowDialog() == true)
+        {
+            if (SelectedFolderText != null)
+            {
+                SelectedFolderText.Text = $"Selected: {dialog.SelectedPath}";
+            }
+        }
+    }
+
+    private void OnChooseFontClick(object? sender, EventArgs e)
+    {
+        var dialog = new FontDialog();
+
+        if (dialog.ShowDialog())
+        {
+            if (FontPreviewText != null && dialog.FontFamily != null)
+            {
+                FontPreviewText.FontFamily = dialog.FontFamily;
+                FontPreviewText.FontSize = dialog.FontSize;
+            }
+
+            if (SelectedFontText != null && dialog.FontFamily != null)
+            {
+                SelectedFontText.Text = $"Current: {dialog.FontFamily.Source}, {dialog.FontSize}pt";
+            }
+        }
+    }
+
+    private void ShowMessageDialog(string title, string message, string type)
+    {
+        // In a real implementation, this would show a message box
+        if (DialogResultText != null)
+        {
+            DialogResultText.Text = $"{type.ToUpper()}: {message}";
+        }
+    }
+
+    private void ShowConfirmDialog()
+    {
+        // In a real implementation, this would show a confirmation dialog
+        if (DialogResultText != null)
+        {
+            DialogResultText.Text = "Confirmation dialog would appear here";
+        }
+    }
+}

--- a/samples/Jalium.UI.Gallery/Views/ExpanderPage.jalxaml
+++ b/samples/Jalium.UI.Gallery/Views/ExpanderPage.jalxaml
@@ -1,0 +1,200 @@
+<Page xmlns="http://schemas.jalium.ui/2024"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      x:Class="Jalium.UI.Gallery.Views.ExpanderPage"
+      Title="Expander">
+
+    <StackPanel Orientation="Vertical">
+        <!-- Page Title -->
+        <TextBlock Text="Expander"
+                   FontSize="32"
+                   Foreground="#FFFFFF"
+                   Margin="0,0,0,8"/>
+
+        <!-- Description -->
+        <TextBlock Text="A control that can expand and collapse to show or hide content."
+                   FontSize="14"
+                   Foreground="#888888"
+                   Margin="0,0,0,24"/>
+
+        <!-- Basic Expander Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Basic Expander"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Click the header to expand or collapse."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <Expander Header="Click to expand" Margin="0,0,0,8">
+                            <Border Background="#252525" Padding="16" CornerRadius="4">
+                                <TextBlock Text="This content is revealed when the expander is expanded. You can put any content here including text, images, and other controls."
+                                           Foreground="#CCCCCC"
+                                           TextWrapping="Wrap"/>
+                            </Border>
+                        </Expander>
+                        <Expander Header="Initially expanded" IsExpanded="True">
+                            <Border Background="#252525" Padding="16" CornerRadius="4">
+                                <TextBlock Text="This expander starts in the expanded state. Click the header to collapse it."
+                                           Foreground="#CCCCCC"
+                                           TextWrapping="Wrap"/>
+                            </Border>
+                        </Expander>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Expander with Complex Content Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Expander with Complex Content"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Expanders can contain any type of content."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <Expander Header="Settings" Margin="0,0,0,8">
+                            <Border Background="#252525" Padding="16" CornerRadius="4">
+                                <StackPanel Orientation="Vertical">
+                                    <CheckBox Content="Enable notifications" Margin="0,0,0,8"/>
+                                    <CheckBox Content="Auto-save documents" Margin="0,0,0,8"/>
+                                    <CheckBox Content="Show line numbers" Margin="0,0,0,8"/>
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="Theme:" Foreground="#888888" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                                        <ComboBox Width="120" Height="28">
+                                            <ComboBoxItem Content="Light"/>
+                                            <ComboBoxItem Content="Dark" IsSelected="True"/>
+                                            <ComboBoxItem Content="System"/>
+                                        </ComboBox>
+                                    </StackPanel>
+                                </StackPanel>
+                            </Border>
+                        </Expander>
+                        <Expander Header="User Profile">
+                            <Border Background="#252525" Padding="16" CornerRadius="4">
+                                <StackPanel Orientation="Vertical">
+                                    <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                                        <TextBlock Text="Name:" Width="80" Foreground="#888888"/>
+                                        <TextBox Width="200" Height="28" Text="John Doe"/>
+                                    </StackPanel>
+                                    <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                                        <TextBlock Text="Email:" Width="80" Foreground="#888888"/>
+                                        <TextBox Width="200" Height="28" Text="john@example.com"/>
+                                    </StackPanel>
+                                    <Button Content="Save Changes" Width="120" Height="32" HorizontalAlignment="Left"/>
+                                </StackPanel>
+                            </Border>
+                        </Expander>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Nested Expanders Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Nested Expanders"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Expanders can be nested inside each other."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <Expander Header="Category A">
+                        <Border Background="#252525" Padding="8" CornerRadius="4">
+                            <StackPanel Orientation="Vertical">
+                                <Expander Header="Subcategory A1" Margin="0,0,0,4">
+                                    <Border Background="#303030" Padding="12" CornerRadius="4">
+                                        <TextBlock Text="Content for Subcategory A1" Foreground="#AAAAAA"/>
+                                    </Border>
+                                </Expander>
+                                <Expander Header="Subcategory A2" Margin="0,0,0,4">
+                                    <Border Background="#303030" Padding="12" CornerRadius="4">
+                                        <TextBlock Text="Content for Subcategory A2" Foreground="#AAAAAA"/>
+                                    </Border>
+                                </Expander>
+                                <Expander Header="Subcategory A3">
+                                    <Border Background="#303030" Padding="12" CornerRadius="4">
+                                        <TextBlock Text="Content for Subcategory A3" Foreground="#AAAAAA"/>
+                                    </Border>
+                                </Expander>
+                            </StackPanel>
+                        </Border>
+                    </Expander>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Interactive Demo Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Interactive Demo"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Use buttons to control the expander programmatically."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,16">
+                            <Button x:Name="ExpandButton" Content="Expand" Width="80" Height="28" Margin="0,0,8,0"/>
+                            <Button x:Name="CollapseButton" Content="Collapse" Width="80" Height="28" Margin="0,0,8,0"/>
+                            <Button x:Name="ToggleButton" Content="Toggle" Width="80" Height="28"/>
+                        </StackPanel>
+                        <Expander x:Name="ControlledExpander" Header="Controlled Expander">
+                            <Border Background="#252525" Padding="16" CornerRadius="4">
+                                <TextBlock Text="This expander can be controlled using the buttons above."
+                                           Foreground="#CCCCCC"
+                                           TextWrapping="Wrap"/>
+                            </Border>
+                        </Expander>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+    </StackPanel>
+</Page>

--- a/samples/Jalium.UI.Gallery/Views/ExpanderPage.jalxaml.cs
+++ b/samples/Jalium.UI.Gallery/Views/ExpanderPage.jalxaml.cs
@@ -1,0 +1,30 @@
+using Jalium.UI.Controls;
+
+namespace Jalium.UI.Gallery.Views;
+
+/// <summary>
+/// Code-behind for ExpanderPage.jalxaml demonstrating expander functionality.
+/// </summary>
+public partial class ExpanderPage : Page
+{
+    public ExpanderPage()
+    {
+        InitializeComponent();
+
+        // Set up event handlers for the interactive demo
+        if (ExpandButton != null && ControlledExpander != null)
+        {
+            ExpandButton.Click += (s, e) => ControlledExpander.IsExpanded = true;
+        }
+
+        if (CollapseButton != null && ControlledExpander != null)
+        {
+            CollapseButton.Click += (s, e) => ControlledExpander.IsExpanded = false;
+        }
+
+        if (ToggleButton != null && ControlledExpander != null)
+        {
+            ToggleButton.Click += (s, e) => ControlledExpander.IsExpanded = !ControlledExpander.IsExpanded;
+        }
+    }
+}

--- a/samples/Jalium.UI.Gallery/Views/FramePage.jalxaml
+++ b/samples/Jalium.UI.Gallery/Views/FramePage.jalxaml
@@ -1,0 +1,152 @@
+<Page xmlns="http://schemas.jalium.ui/2024"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      x:Class="Jalium.UI.Gallery.Views.FramePage"
+      Title="Frame">
+
+    <StackPanel Orientation="Vertical">
+        <!-- Page Title -->
+        <TextBlock Text="Frame"
+                   FontSize="32"
+                   Foreground="#FFFFFF"
+                   Margin="0,0,0,8"/>
+
+        <!-- Description -->
+        <TextBlock Text="A container that supports navigation between pages."
+                   FontSize="14"
+                   Foreground="#888888"
+                   Margin="0,0,0,24"/>
+
+        <!-- Basic Frame Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Basic Frame"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="A frame can host and navigate between pages."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,16">
+                            <Button x:Name="NavigatePage1Button" Content="Page 1" Width="80" Height="28" Margin="0,0,8,0"/>
+                            <Button x:Name="NavigatePage2Button" Content="Page 2" Width="80" Height="28" Margin="0,0,8,0"/>
+                            <Button x:Name="NavigatePage3Button" Content="Page 3" Width="80" Height="28"/>
+                        </StackPanel>
+                        <Border BorderBrush="#3D3D3D" BorderThickness="1" CornerRadius="4">
+                            <Frame x:Name="DemoFrame" Width="400" Height="200"/>
+                        </Border>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Navigation Controls Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Navigation Controls"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Frame supports back and forward navigation."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,16">
+                            <Button x:Name="BackButton" Content="← Back" Width="80" Height="28" Margin="0,0,8,0"/>
+                            <Button x:Name="ForwardButton" Content="Forward →" Width="80" Height="28" Margin="0,0,8,0"/>
+                            <Button x:Name="RefreshButton" Content="Refresh" Width="80" Height="28"/>
+                        </StackPanel>
+                        <TextBlock x:Name="NavigationHistoryText"
+                                   Text="Navigation history: Empty"
+                                   Foreground="#888888"
+                                   FontSize="12"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Frame Properties Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Frame Properties"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Common frame configuration options."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <CheckBox Content="Show navigation UI" Margin="0,0,0,8"/>
+                        <CheckBox Content="Enable journal (history)" Margin="0,0,0,8" IsChecked="True"/>
+                        <CheckBox Content="Sandboxed navigation" Margin="0,0,0,8"/>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="Cache size:" Width="100" Foreground="#888888" VerticalAlignment="Center"/>
+                            <NumberBox Width="100" Height="28" Value="10" Minimum="0" Maximum="100"/>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Use Cases Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Common Use Cases"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Frame is useful for various navigation scenarios."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="• Wizard-style interfaces" Foreground="#CCCCCC" Margin="0,0,0,8"/>
+                        <TextBlock Text="• Multi-step forms" Foreground="#CCCCCC" Margin="0,0,0,8"/>
+                        <TextBlock Text="• Browser-like navigation" Foreground="#CCCCCC" Margin="0,0,0,8"/>
+                        <TextBlock Text="• Embedded page content" Foreground="#CCCCCC" Margin="0,0,0,8"/>
+                        <TextBlock Text="• Help system navigation" Foreground="#CCCCCC"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+    </StackPanel>
+</Page>

--- a/samples/Jalium.UI.Gallery/Views/FramePage.jalxaml.cs
+++ b/samples/Jalium.UI.Gallery/Views/FramePage.jalxaml.cs
@@ -1,0 +1,84 @@
+using Jalium.UI.Controls;
+
+namespace Jalium.UI.Gallery.Views;
+
+/// <summary>
+/// Code-behind for FramePage.jalxaml demonstrating frame navigation functionality.
+/// </summary>
+public partial class FramePage : Page
+{
+    private int _currentPage = 0;
+
+    public FramePage()
+    {
+        InitializeComponent();
+
+        // Set up navigation buttons
+        if (NavigatePage1Button != null)
+            NavigatePage1Button.Click += (s, e) => NavigateToPage(1);
+        if (NavigatePage2Button != null)
+            NavigatePage2Button.Click += (s, e) => NavigateToPage(2);
+        if (NavigatePage3Button != null)
+            NavigatePage3Button.Click += (s, e) => NavigateToPage(3);
+
+        // Set up back/forward buttons
+        if (BackButton != null)
+            BackButton.Click += (s, e) => GoBack();
+        if (ForwardButton != null)
+            ForwardButton.Click += (s, e) => GoForward();
+
+        // Initialize with first page
+        NavigateToPage(1);
+    }
+
+    private void NavigateToPage(int pageNumber)
+    {
+        _currentPage = pageNumber;
+        UpdateNavigationHistory();
+
+        if (DemoFrame != null)
+        {
+            // Create a simple page content
+            var content = new Border
+            {
+                Background = new Jalium.UI.Media.SolidColorBrush(
+                    pageNumber == 1 ? Jalium.UI.Media.Color.FromArgb(255, 0, 120, 212) :
+                    pageNumber == 2 ? Jalium.UI.Media.Color.FromArgb(255, 0, 204, 106) :
+                    Jalium.UI.Media.Color.FromArgb(255, 247, 99, 12)),
+                Child = new TextBlock
+                {
+                    Text = $"Page {pageNumber}",
+                    FontSize = 24,
+                    Foreground = new Jalium.UI.Media.SolidColorBrush(Jalium.UI.Media.Color.White),
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center
+                }
+            };
+            DemoFrame.Content = content;
+        }
+    }
+
+    private void GoBack()
+    {
+        if (_currentPage > 1)
+        {
+            NavigateToPage(_currentPage - 1);
+        }
+    }
+
+    private void GoForward()
+    {
+        if (_currentPage < 3)
+        {
+            NavigateToPage(_currentPage + 1);
+        }
+    }
+
+    private void UpdateNavigationHistory()
+    {
+        if (NavigationHistoryText != null)
+        {
+            NavigationHistoryText.Text = $"Current page: {_currentPage}";
+        }
+    }
+}

--- a/samples/Jalium.UI.Gallery/Views/ListViewPage.jalxaml
+++ b/samples/Jalium.UI.Gallery/Views/ListViewPage.jalxaml
@@ -1,0 +1,205 @@
+<Page xmlns="http://schemas.jalium.ui/2024"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      x:Class="Jalium.UI.Gallery.Views.ListViewPage"
+      Title="ListView">
+
+    <StackPanel Orientation="Vertical">
+        <!-- Page Title -->
+        <TextBlock Text="ListView"
+                   FontSize="32"
+                   Foreground="#FFFFFF"
+                   Margin="0,0,0,8"/>
+
+        <!-- Description -->
+        <TextBlock Text="A control that displays items in a list with optional columns and details."
+                   FontSize="14"
+                   Foreground="#888888"
+                   Margin="0,0,0,24"/>
+
+        <!-- Basic ListView Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Basic ListView"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="A simple list view displaying items."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <ListView x:Name="BasicListView" Width="300" Height="200">
+                        <ListViewItem Content="Item 1"/>
+                        <ListViewItem Content="Item 2"/>
+                        <ListViewItem Content="Item 3"/>
+                        <ListViewItem Content="Item 4"/>
+                        <ListViewItem Content="Item 5"/>
+                    </ListView>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- ListView with GridView Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="ListView with Columns"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="ListView can display data in columns using GridView."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <ListView x:Name="GridListView" Width="500" Height="200">
+                        <ListView.View>
+                            <GridView>
+                                <GridViewColumn Header="Name" Width="150"/>
+                                <GridViewColumn Header="Type" Width="100"/>
+                                <GridViewColumn Header="Size" Width="80"/>
+                                <GridViewColumn Header="Modified" Width="120"/>
+                            </GridView>
+                        </ListView.View>
+                    </ListView>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Selection Modes Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Selection Modes"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="ListView supports single, multiple, and extended selection."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Horizontal">
+                        <StackPanel Orientation="Vertical" Margin="0,0,24,0">
+                            <TextBlock Text="Single Selection" Foreground="#888888" FontSize="12" Margin="0,0,0,4"/>
+                            <ListView Width="150" Height="120" SelectionMode="Single">
+                                <ListViewItem Content="Apple"/>
+                                <ListViewItem Content="Banana"/>
+                                <ListViewItem Content="Cherry"/>
+                            </ListView>
+                        </StackPanel>
+                        <StackPanel Orientation="Vertical" Margin="0,0,24,0">
+                            <TextBlock Text="Multiple Selection" Foreground="#888888" FontSize="12" Margin="0,0,0,4"/>
+                            <ListView Width="150" Height="120" SelectionMode="Multiple">
+                                <ListViewItem Content="Red"/>
+                                <ListViewItem Content="Green"/>
+                                <ListViewItem Content="Blue"/>
+                            </ListView>
+                        </StackPanel>
+                        <StackPanel Orientation="Vertical">
+                            <TextBlock Text="Extended Selection" Foreground="#888888" FontSize="12" Margin="0,0,0,4"/>
+                            <ListView Width="150" Height="120" SelectionMode="Extended">
+                                <ListViewItem Content="One"/>
+                                <ListViewItem Content="Two"/>
+                                <ListViewItem Content="Three"/>
+                            </ListView>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Interactive Demo Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Interactive Demo"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Add, remove, and select items dynamically."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,16">
+                            <TextBox x:Name="NewItemTextBox" Width="200" Height="28" PlaceholderText="Enter item text" Margin="0,0,8,0"/>
+                            <Button x:Name="AddItemButton" Content="Add" Width="60" Height="28" Margin="0,0,8,0"/>
+                            <Button x:Name="RemoveItemButton" Content="Remove" Width="70" Height="28"/>
+                        </StackPanel>
+                        <ListView x:Name="InteractiveListView" Width="350" Height="150">
+                            <ListViewItem Content="Sample Item 1"/>
+                            <ListViewItem Content="Sample Item 2"/>
+                            <ListViewItem Content="Sample Item 3"/>
+                        </ListView>
+                        <TextBlock x:Name="SelectionText"
+                                   Text="No item selected"
+                                   Foreground="#0078D4"
+                                   Margin="0,8,0,0"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Use Cases Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Common Use Cases"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="ListView is useful for displaying tabular data."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="• File explorers" Foreground="#CCCCCC" Margin="0,0,0,8"/>
+                        <TextBlock Text="• Email lists" Foreground="#CCCCCC" Margin="0,0,0,8"/>
+                        <TextBlock Text="• Contact lists" Foreground="#CCCCCC" Margin="0,0,0,8"/>
+                        <TextBlock Text="• Task managers" Foreground="#CCCCCC" Margin="0,0,0,8"/>
+                        <TextBlock Text="• Log viewers" Foreground="#CCCCCC"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+    </StackPanel>
+</Page>

--- a/samples/Jalium.UI.Gallery/Views/ListViewPage.jalxaml.cs
+++ b/samples/Jalium.UI.Gallery/Views/ListViewPage.jalxaml.cs
@@ -1,0 +1,68 @@
+using Jalium.UI.Controls;
+
+namespace Jalium.UI.Gallery.Views;
+
+/// <summary>
+/// Code-behind for ListViewPage.jalxaml demonstrating list view functionality.
+/// </summary>
+public partial class ListViewPage : Page
+{
+    private int _itemCounter = 4;
+
+    public ListViewPage()
+    {
+        InitializeComponent();
+
+        // Set up event handlers
+        if (AddItemButton != null)
+        {
+            AddItemButton.Click += OnAddItemClick;
+        }
+
+        if (RemoveItemButton != null)
+        {
+            RemoveItemButton.Click += OnRemoveItemClick;
+        }
+
+        if (InteractiveListView != null)
+        {
+            InteractiveListView.SelectionChanged += OnSelectionChanged;
+        }
+    }
+
+    private void OnAddItemClick(object? sender, EventArgs e)
+    {
+        if (InteractiveListView != null && NewItemTextBox != null)
+        {
+            var text = string.IsNullOrWhiteSpace(NewItemTextBox.Text)
+                ? $"Item {_itemCounter++}"
+                : NewItemTextBox.Text;
+
+            InteractiveListView.Items.Add(new ListViewItem { Content = text });
+            NewItemTextBox.Text = string.Empty;
+        }
+    }
+
+    private void OnRemoveItemClick(object? sender, EventArgs e)
+    {
+        if (InteractiveListView != null && InteractiveListView.SelectedItem != null)
+        {
+            InteractiveListView.Items.Remove(InteractiveListView.SelectedItem);
+        }
+    }
+
+    private void OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (SelectionText != null && InteractiveListView != null)
+        {
+            if (InteractiveListView.SelectedItem is ListViewItem item)
+            {
+                SelectionText.Text = $"Selected: {item.Content}";
+            }
+            else
+            {
+                SelectionText.Text = "No item selected";
+            }
+        }
+    }
+}

--- a/samples/Jalium.UI.Gallery/Views/MediaElementPage.jalxaml
+++ b/samples/Jalium.UI.Gallery/Views/MediaElementPage.jalxaml
@@ -1,0 +1,181 @@
+<Page xmlns="http://schemas.jalium.ui/2024"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      x:Class="Jalium.UI.Gallery.Views.MediaElementPage"
+      Title="MediaElement">
+
+    <StackPanel Orientation="Vertical">
+        <!-- Page Title -->
+        <TextBlock Text="MediaElement"
+                   FontSize="32"
+                   Foreground="#FFFFFF"
+                   Margin="0,0,0,8"/>
+
+        <!-- Description -->
+        <TextBlock Text="A control for playing audio and video media."
+                   FontSize="14"
+                   Foreground="#888888"
+                   Margin="0,0,0,24"/>
+
+        <!-- Video Player Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Video Player"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="MediaElement can play video files with playback controls."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <Border Background="#000000" Width="480" Height="270" CornerRadius="4" Margin="0,0,0,16">
+                            <MediaElement x:Name="VideoPlayer" Width="480" Height="270"/>
+                        </Border>
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <Button x:Name="PlayButton" Content="▶ Play" Width="70" Height="28" Margin="0,0,8,0"/>
+                            <Button x:Name="PauseButton" Content="⏸ Pause" Width="70" Height="28" Margin="0,0,8,0"/>
+                            <Button x:Name="StopButton" Content="⏹ Stop" Width="70" Height="28"/>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Audio Player Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Audio Player"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="MediaElement can also play audio files."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <Border Background="#252525" CornerRadius="8" Padding="24" Margin="0,0,0,16">
+                            <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                <Ellipse Width="80" Height="80" Fill="#0078D4" Margin="0,0,0,16"/>
+                                <TextBlock Text="Audio Track" Foreground="#FFFFFF" FontSize="16" HorizontalAlignment="Center"/>
+                                <TextBlock Text="Artist Name" Foreground="#888888" FontSize="12" HorizontalAlignment="Center"/>
+                            </StackPanel>
+                        </Border>
+                        <Slider x:Name="AudioProgressSlider" Minimum="0" Maximum="100" Value="30" Margin="0,0,0,16"/>
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <Button Content="⏮" Width="40" Height="28" Margin="0,0,8,0"/>
+                            <Button Content="▶" Width="50" Height="28" Margin="0,0,8,0"/>
+                            <Button Content="⏭" Width="40" Height="28"/>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Playback Controls Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Playback Controls"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Control volume, speed, and other playback options."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                            <TextBlock Text="Volume:" Width="100" Foreground="#888888" VerticalAlignment="Center"/>
+                            <Slider x:Name="VolumeSlider" Minimum="0" Maximum="100" Value="75" Width="200" Margin="0,0,8,0"/>
+                            <TextBlock x:Name="VolumeText" Text="75%" Foreground="#888888" VerticalAlignment="Center"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                            <TextBlock Text="Speed:" Width="100" Foreground="#888888" VerticalAlignment="Center"/>
+                            <ComboBox Width="120" Height="28">
+                                <ComboBoxItem Content="0.5x"/>
+                                <ComboBoxItem Content="0.75x"/>
+                                <ComboBoxItem Content="1.0x" IsSelected="True"/>
+                                <ComboBoxItem Content="1.25x"/>
+                                <ComboBoxItem Content="1.5x"/>
+                                <ComboBoxItem Content="2.0x"/>
+                            </ComboBox>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal">
+                            <CheckBox Content="Loop" Margin="0,0,16,0"/>
+                            <CheckBox Content="Mute" Margin="0,0,16,0"/>
+                            <CheckBox Content="Auto-play"/>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Supported Formats Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Supported Formats"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="MediaElement supports various audio and video formats."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Horizontal">
+                        <StackPanel Orientation="Vertical" Margin="0,0,48,0">
+                            <TextBlock Text="Video Formats:" Foreground="#888888" FontWeight="SemiBold" Margin="0,0,0,8"/>
+                            <TextBlock Text="• MP4 (H.264)" Foreground="#CCCCCC" Margin="0,0,0,4"/>
+                            <TextBlock Text="• WebM (VP8/VP9)" Foreground="#CCCCCC" Margin="0,0,0,4"/>
+                            <TextBlock Text="• AVI" Foreground="#CCCCCC" Margin="0,0,0,4"/>
+                            <TextBlock Text="• WMV" Foreground="#CCCCCC" Margin="0,0,0,4"/>
+                            <TextBlock Text="• MOV" Foreground="#CCCCCC"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Vertical">
+                            <TextBlock Text="Audio Formats:" Foreground="#888888" FontWeight="SemiBold" Margin="0,0,0,8"/>
+                            <TextBlock Text="• MP3" Foreground="#CCCCCC" Margin="0,0,0,4"/>
+                            <TextBlock Text="• WAV" Foreground="#CCCCCC" Margin="0,0,0,4"/>
+                            <TextBlock Text="• AAC" Foreground="#CCCCCC" Margin="0,0,0,4"/>
+                            <TextBlock Text="• OGG" Foreground="#CCCCCC" Margin="0,0,0,4"/>
+                            <TextBlock Text="• FLAC" Foreground="#CCCCCC"/>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+    </StackPanel>
+</Page>

--- a/samples/Jalium.UI.Gallery/Views/MediaElementPage.jalxaml.cs
+++ b/samples/Jalium.UI.Gallery/Views/MediaElementPage.jalxaml.cs
@@ -1,0 +1,49 @@
+using Jalium.UI.Controls;
+
+namespace Jalium.UI.Gallery.Views;
+
+/// <summary>
+/// Code-behind for MediaElementPage.jalxaml demonstrating media element functionality.
+/// </summary>
+public partial class MediaElementPage : Page
+{
+    public MediaElementPage()
+    {
+        InitializeComponent();
+
+        // Set up event handlers for video controls
+        if (PlayButton != null && VideoPlayer != null)
+        {
+            PlayButton.Click += (s, e) => VideoPlayer.Play();
+        }
+
+        if (PauseButton != null && VideoPlayer != null)
+        {
+            PauseButton.Click += (s, e) => VideoPlayer.Pause();
+        }
+
+        if (StopButton != null && VideoPlayer != null)
+        {
+            StopButton.Click += (s, e) => VideoPlayer.Stop();
+        }
+
+        // Set up volume slider
+        if (VolumeSlider != null)
+        {
+            VolumeSlider.ValueChanged += OnVolumeChanged;
+        }
+    }
+
+    private void OnVolumeChanged(object? sender, RoutedPropertyChangedEventArgs<double> e)
+    {
+        if (VolumeText != null)
+        {
+            VolumeText.Text = $"{(int)e.NewValue}%";
+        }
+
+        if (VideoPlayer != null)
+        {
+            VideoPlayer.Volume = e.NewValue / 100.0;
+        }
+    }
+}

--- a/samples/Jalium.UI.Gallery/Views/MenuPage.jalxaml
+++ b/samples/Jalium.UI.Gallery/Views/MenuPage.jalxaml
@@ -1,0 +1,153 @@
+<Page xmlns="http://schemas.jalium.ui/2024"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      x:Class="Jalium.UI.Gallery.Views.MenuPage"
+      Title="Menu">
+
+    <StackPanel Orientation="Vertical">
+        <!-- Page Title -->
+        <TextBlock Text="Menu"
+                   FontSize="32"
+                   Foreground="#FFFFFF"
+                   Margin="0,0,0,8"/>
+
+        <!-- Description -->
+        <TextBlock Text="Displays a list of menu items for commands and options."
+                   FontSize="14"
+                   Foreground="#888888"
+                   Margin="0,0,0,24"/>
+
+        <!-- Basic Menu Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Basic Menu"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="A standard menu with multiple items."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <Menu Background="Transparent">
+                        <MenuItem Header="File">
+                            <MenuItem Header="New"/>
+                            <MenuItem Header="Open"/>
+                            <MenuItem Header="Save"/>
+                            <Separator/>
+                            <MenuItem Header="Exit"/>
+                        </MenuItem>
+                        <MenuItem Header="Edit">
+                            <MenuItem Header="Undo"/>
+                            <MenuItem Header="Redo"/>
+                            <Separator/>
+                            <MenuItem Header="Cut"/>
+                            <MenuItem Header="Copy"/>
+                            <MenuItem Header="Paste"/>
+                        </MenuItem>
+                        <MenuItem Header="View">
+                            <MenuItem Header="Zoom In"/>
+                            <MenuItem Header="Zoom Out"/>
+                            <MenuItem Header="Reset Zoom"/>
+                        </MenuItem>
+                        <MenuItem Header="Help">
+                            <MenuItem Header="About"/>
+                        </MenuItem>
+                    </Menu>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Menu with Icons Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Menu with Keyboard Shortcuts"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Menu items can display keyboard shortcuts."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <Menu Background="Transparent">
+                        <MenuItem Header="File">
+                            <MenuItem Header="New" InputGestureText="Ctrl+N"/>
+                            <MenuItem Header="Open" InputGestureText="Ctrl+O"/>
+                            <MenuItem Header="Save" InputGestureText="Ctrl+S"/>
+                            <MenuItem Header="Save As" InputGestureText="Ctrl+Shift+S"/>
+                        </MenuItem>
+                        <MenuItem Header="Edit">
+                            <MenuItem Header="Undo" InputGestureText="Ctrl+Z"/>
+                            <MenuItem Header="Redo" InputGestureText="Ctrl+Y"/>
+                            <Separator/>
+                            <MenuItem Header="Cut" InputGestureText="Ctrl+X"/>
+                            <MenuItem Header="Copy" InputGestureText="Ctrl+C"/>
+                            <MenuItem Header="Paste" InputGestureText="Ctrl+V"/>
+                        </MenuItem>
+                    </Menu>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Nested Menu Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Nested Submenus"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Menu items can contain nested submenus."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <Menu Background="Transparent">
+                        <MenuItem Header="Settings">
+                            <MenuItem Header="Appearance">
+                                <MenuItem Header="Theme">
+                                    <MenuItem Header="Light"/>
+                                    <MenuItem Header="Dark"/>
+                                    <MenuItem Header="System"/>
+                                </MenuItem>
+                                <MenuItem Header="Font Size">
+                                    <MenuItem Header="Small"/>
+                                    <MenuItem Header="Medium"/>
+                                    <MenuItem Header="Large"/>
+                                </MenuItem>
+                            </MenuItem>
+                            <MenuItem Header="Language">
+                                <MenuItem Header="English"/>
+                                <MenuItem Header="中文"/>
+                                <MenuItem Header="日本語"/>
+                            </MenuItem>
+                        </MenuItem>
+                    </Menu>
+                </Border>
+            </StackPanel>
+        </Border>
+    </StackPanel>
+</Page>

--- a/samples/Jalium.UI.Gallery/Views/MenuPage.jalxaml.cs
+++ b/samples/Jalium.UI.Gallery/Views/MenuPage.jalxaml.cs
@@ -1,0 +1,14 @@
+using Jalium.UI.Controls;
+
+namespace Jalium.UI.Gallery.Views;
+
+/// <summary>
+/// Code-behind for MenuPage.jalxaml demonstrating menu control functionality.
+/// </summary>
+public partial class MenuPage : Page
+{
+    public MenuPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/samples/Jalium.UI.Gallery/Views/PopupPage.jalxaml
+++ b/samples/Jalium.UI.Gallery/Views/PopupPage.jalxaml
@@ -1,0 +1,172 @@
+<Page xmlns="http://schemas.jalium.ui/2024"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      x:Class="Jalium.UI.Gallery.Views.PopupPage"
+      Title="Popup">
+
+    <StackPanel Orientation="Vertical">
+        <!-- Page Title -->
+        <TextBlock Text="Popup"
+                   FontSize="32"
+                   Foreground="#FFFFFF"
+                   Margin="0,0,0,8"/>
+
+        <!-- Description -->
+        <TextBlock Text="A popup window that displays content over other content."
+                   FontSize="14"
+                   Foreground="#888888"
+                   Margin="0,0,0,24"/>
+
+        <!-- Basic Popup Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Basic Popup"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Click the button to show/hide a popup."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Horizontal">
+                        <Button x:Name="ShowPopupButton"
+                                Content="Show Popup"
+                                Width="100"
+                                Height="32"/>
+                        <Popup x:Name="BasicPopup"
+                               PlacementTarget="{Binding ElementName=ShowPopupButton}"
+                               Placement="Bottom">
+                            <Border Background="#3D3D3D"
+                                    BorderBrush="#5D5D5D"
+                                    BorderThickness="1"
+                                    CornerRadius="4"
+                                    Padding="16">
+                                <StackPanel Orientation="Vertical">
+                                    <TextBlock Text="This is a popup!"
+                                               Foreground="#FFFFFF"
+                                               Margin="0,0,0,8"/>
+                                    <Button x:Name="ClosePopupButton"
+                                            Content="Close"
+                                            Width="80"
+                                            Height="28"/>
+                                </StackPanel>
+                            </Border>
+                        </Popup>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Popup with Form Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Popup with Form"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Popups can contain complex content like forms."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Horizontal">
+                        <Button x:Name="ShowFormPopupButton"
+                                Content="Quick Add"
+                                Width="100"
+                                Height="32"/>
+                        <Popup x:Name="FormPopup"
+                               PlacementTarget="{Binding ElementName=ShowFormPopupButton}"
+                               Placement="Bottom"
+                               StaysOpen="True">
+                            <Border Background="#2D2D2D"
+                                    BorderBrush="#5D5D5D"
+                                    BorderThickness="1"
+                                    CornerRadius="8"
+                                    Padding="20"
+                                    Width="250">
+                                <StackPanel Orientation="Vertical">
+                                    <TextBlock Text="Quick Add Item"
+                                               FontSize="14"
+                                               FontWeight="SemiBold"
+                                               Foreground="#FFFFFF"
+                                               Margin="0,0,0,16"/>
+                                    <TextBlock Text="Name"
+                                               Foreground="#888888"
+                                               FontSize="12"
+                                               Margin="0,0,0,4"/>
+                                    <TextBox PlaceholderText="Enter name"
+                                             Height="32"
+                                             Margin="0,0,0,12"/>
+                                    <TextBlock Text="Description"
+                                               Foreground="#888888"
+                                               FontSize="12"
+                                               Margin="0,0,0,4"/>
+                                    <TextBox PlaceholderText="Enter description"
+                                             Height="32"
+                                             Margin="0,0,0,16"/>
+                                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                        <Button x:Name="CancelFormButton"
+                                                Content="Cancel"
+                                                Width="70"
+                                                Height="28"
+                                                Margin="0,0,8,0"/>
+                                        <Button x:Name="SaveFormButton"
+                                                Content="Save"
+                                                Width="70"
+                                                Height="28"/>
+                                    </StackPanel>
+                                </StackPanel>
+                            </Border>
+                        </Popup>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Popup Placement Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Popup Placement"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Popups can be positioned at different locations relative to the target."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="40">
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                        <Button x:Name="TopPopupButton" Content="Top" Width="60" Height="32" Margin="8"/>
+                        <Button x:Name="RightPopupButton" Content="Right" Width="60" Height="32" Margin="8"/>
+                        <Button x:Name="BottomPopupButton" Content="Bottom" Width="60" Height="32" Margin="8"/>
+                        <Button x:Name="LeftPopupButton" Content="Left" Width="60" Height="32" Margin="8"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+    </StackPanel>
+</Page>

--- a/samples/Jalium.UI.Gallery/Views/PopupPage.jalxaml.cs
+++ b/samples/Jalium.UI.Gallery/Views/PopupPage.jalxaml.cs
@@ -1,0 +1,41 @@
+using Jalium.UI.Controls;
+
+namespace Jalium.UI.Gallery.Views;
+
+/// <summary>
+/// Code-behind for PopupPage.jalxaml demonstrating popup functionality.
+/// </summary>
+public partial class PopupPage : Page
+{
+    public PopupPage()
+    {
+        InitializeComponent();
+
+        // Basic popup toggle
+        if (ShowPopupButton != null && BasicPopup != null)
+        {
+            ShowPopupButton.Click += (s, e) => BasicPopup.IsOpen = !BasicPopup.IsOpen;
+        }
+
+        if (ClosePopupButton != null && BasicPopup != null)
+        {
+            ClosePopupButton.Click += (s, e) => BasicPopup.IsOpen = false;
+        }
+
+        // Form popup toggle
+        if (ShowFormPopupButton != null && FormPopup != null)
+        {
+            ShowFormPopupButton.Click += (s, e) => FormPopup.IsOpen = !FormPopup.IsOpen;
+        }
+
+        if (CancelFormButton != null && FormPopup != null)
+        {
+            CancelFormButton.Click += (s, e) => FormPopup.IsOpen = false;
+        }
+
+        if (SaveFormButton != null && FormPopup != null)
+        {
+            SaveFormButton.Click += (s, e) => FormPopup.IsOpen = false;
+        }
+    }
+}

--- a/samples/Jalium.UI.Gallery/Views/RichTextBoxPage.jalxaml
+++ b/samples/Jalium.UI.Gallery/Views/RichTextBoxPage.jalxaml
@@ -1,0 +1,150 @@
+<Page xmlns="http://schemas.jalium.ui/2024"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      x:Class="Jalium.UI.Gallery.Views.RichTextBoxPage"
+      Title="RichTextBox">
+
+    <StackPanel Orientation="Vertical">
+        <!-- Page Title -->
+        <TextBlock Text="RichTextBox"
+                   FontSize="32"
+                   Foreground="#FFFFFF"
+                   Margin="0,0,0,8"/>
+
+        <!-- Description -->
+        <TextBlock Text="A control for editing rich text documents with formatting."
+                   FontSize="14"
+                   Foreground="#888888"
+                   Margin="0,0,0,24"/>
+
+        <!-- Basic RichTextBox Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Basic RichTextBox"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="A rich text editor for formatted text."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <RichTextBox Width="500" Height="150"/>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- RichTextBox with Toolbar Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="RichTextBox with Formatting Toolbar"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Common text editor with formatting options."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="8">
+                    <StackPanel Orientation="Vertical">
+                        <ToolBar Background="Transparent" Margin="0,0,0,8">
+                            <Button x:Name="BoldButton" Content="B" Width="32" Height="28" FontWeight="Bold"/>
+                            <Button x:Name="ItalicButton" Content="I" Width="32" Height="28" FontStyle="Italic"/>
+                            <Button x:Name="UnderlineButton" Content="U" Width="32" Height="28"/>
+                            <Separator/>
+                            <ComboBox Width="120" Height="28">
+                                <ComboBoxItem Content="Arial"/>
+                                <ComboBoxItem Content="Times New Roman"/>
+                                <ComboBoxItem Content="Consolas"/>
+                                <ComboBoxItem Content="Segoe UI" IsSelected="True"/>
+                            </ComboBox>
+                            <ComboBox Width="60" Height="28">
+                                <ComboBoxItem Content="8"/>
+                                <ComboBoxItem Content="10"/>
+                                <ComboBoxItem Content="12" IsSelected="True"/>
+                                <ComboBoxItem Content="14"/>
+                                <ComboBoxItem Content="16"/>
+                                <ComboBoxItem Content="18"/>
+                                <ComboBoxItem Content="24"/>
+                            </ComboBox>
+                            <Separator/>
+                            <Button Content="Color" Width="50" Height="28"/>
+                        </ToolBar>
+                        <RichTextBox x:Name="FormattedRichTextBox" Width="500" Height="200"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Read-Only RichTextBox Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Read-Only Mode"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="RichTextBox can be used to display read-only formatted content."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <RichTextBox Width="500" Height="150" IsReadOnly="True"/>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Use Cases Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Common Use Cases"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="RichTextBox is useful for various scenarios."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="• Document editing" Foreground="#CCCCCC" Margin="0,0,0,8"/>
+                        <TextBlock Text="• Email composition" Foreground="#CCCCCC" Margin="0,0,0,8"/>
+                        <TextBlock Text="• Note-taking applications" Foreground="#CCCCCC" Margin="0,0,0,8"/>
+                        <TextBlock Text="• Content management systems" Foreground="#CCCCCC" Margin="0,0,0,8"/>
+                        <TextBlock Text="• Report generators" Foreground="#CCCCCC"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+    </StackPanel>
+</Page>

--- a/samples/Jalium.UI.Gallery/Views/RichTextBoxPage.jalxaml.cs
+++ b/samples/Jalium.UI.Gallery/Views/RichTextBoxPage.jalxaml.cs
@@ -1,0 +1,14 @@
+using Jalium.UI.Controls;
+
+namespace Jalium.UI.Gallery.Views;
+
+/// <summary>
+/// Code-behind for RichTextBoxPage.jalxaml demonstrating rich text box functionality.
+/// </summary>
+public partial class RichTextBoxPage : Page
+{
+    public RichTextBoxPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/samples/Jalium.UI.Gallery/Views/ShapesPage.jalxaml
+++ b/samples/Jalium.UI.Gallery/Views/ShapesPage.jalxaml
@@ -1,0 +1,249 @@
+<Page xmlns="http://schemas.jalium.ui/2024"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      x:Class="Jalium.UI.Gallery.Views.ShapesPage"
+      Title="Shapes">
+
+    <StackPanel Orientation="Vertical">
+        <!-- Page Title -->
+        <TextBlock Text="Shapes"
+                   FontSize="32"
+                   Foreground="#FFFFFF"
+                   Margin="0,0,0,8"/>
+
+        <!-- Description -->
+        <TextBlock Text="Basic geometric shapes for drawing graphics."
+                   FontSize="14"
+                   Foreground="#888888"
+                   Margin="0,0,0,24"/>
+
+        <!-- Rectangle Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Rectangle"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="A basic rectangular shape with optional rounded corners."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Horizontal">
+                        <Rectangle Width="100" Height="60" Fill="#0078D4" Margin="0,0,16,0"/>
+                        <Rectangle Width="100" Height="60" Fill="#00CC6A" Stroke="#FFFFFF" StrokeThickness="2" Margin="0,0,16,0"/>
+                        <Rectangle Width="100" Height="60" Fill="#F7630C" RadiusX="10" RadiusY="10" Margin="0,0,16,0"/>
+                        <Rectangle Width="60" Height="60" Fill="Transparent" Stroke="#E81123" StrokeThickness="3"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Ellipse Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Ellipse"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="An elliptical shape that can be a circle when width equals height."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Horizontal">
+                        <Ellipse Width="60" Height="60" Fill="#0078D4" Margin="0,0,16,0"/>
+                        <Ellipse Width="100" Height="60" Fill="#00CC6A" Margin="0,0,16,0"/>
+                        <Ellipse Width="60" Height="60" Fill="Transparent" Stroke="#F7630C" StrokeThickness="3" Margin="0,0,16,0"/>
+                        <Ellipse Width="80" Height="80" Fill="#886CE4" Stroke="#FFFFFF" StrokeThickness="2"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Line Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Line"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="A straight line between two points."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <Canvas Width="400" Height="100">
+                        <Line X1="0" Y1="10" X2="150" Y2="10" Stroke="#0078D4" StrokeThickness="2"/>
+                        <Line X1="0" Y1="30" X2="150" Y2="80" Stroke="#00CC6A" StrokeThickness="3"/>
+                        <Line X1="200" Y1="10" X2="350" Y2="90" Stroke="#F7630C" StrokeThickness="4" StrokeDashArray="5,3"/>
+                        <Line X1="200" Y1="90" X2="350" Y2="10" Stroke="#E81123" StrokeThickness="2" StrokeDashArray="10,5"/>
+                    </Canvas>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Polygon Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Polygon"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="A closed shape consisting of a series of connected lines."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Horizontal">
+                        <!-- Triangle -->
+                        <Polygon Points="30,0 60,60 0,60" Fill="#0078D4" Margin="0,0,24,0"/>
+                        <!-- Pentagon -->
+                        <Polygon Points="30,0 60,22 48,60 12,60 0,22" Fill="#00CC6A" Margin="0,0,24,0"/>
+                        <!-- Star -->
+                        <Polygon Points="30,0 36,20 60,20 42,32 50,55 30,42 10,55 18,32 0,20 24,20"
+                                 Fill="#FFB900" Margin="0,0,24,0"/>
+                        <!-- Hexagon with stroke -->
+                        <Polygon Points="20,0 50,0 65,30 50,60 20,60 5,30"
+                                 Fill="Transparent" Stroke="#E81123" StrokeThickness="2"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Polyline Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Polyline"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="A series of connected line segments (not closed)."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <Canvas Width="400" Height="80">
+                        <Polyline Points="0,40 50,10 100,60 150,20 200,50 250,30 300,70 350,40"
+                                  Stroke="#0078D4" StrokeThickness="3" Fill="Transparent"/>
+                        <Polyline Points="0,70 100,70 150,10 200,70 300,70"
+                                  Stroke="#00CC6A" StrokeThickness="2" Fill="Transparent"
+                                  Canvas.Top="5"/>
+                    </Canvas>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Path Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Path"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Complex shapes using path geometry data."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Horizontal">
+                        <!-- Heart shape -->
+                        <Path Data="M 50,30 C 50,0 0,0 0,30 C 0,60 50,80 50,80 C 50,80 100,60 100,30 C 100,0 50,0 50,30"
+                              Fill="#E81123" Width="50" Height="50" Stretch="Uniform" Margin="0,0,24,0"/>
+                        <!-- Arrow -->
+                        <Path Data="M 0,20 L 30,20 L 30,10 L 50,25 L 30,40 L 30,30 L 0,30 Z"
+                              Fill="#0078D4" Width="50" Height="40" Stretch="Uniform" Margin="0,0,24,0"/>
+                        <!-- Check mark -->
+                        <Path Data="M 10,25 L 20,35 L 40,10"
+                              Stroke="#00CC6A" StrokeThickness="4" Fill="Transparent"
+                              Width="50" Height="45" Stretch="Uniform"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Combined Shapes Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Combined Shapes Example"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Shapes can be combined to create complex graphics."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <Canvas Width="300" Height="150">
+                        <!-- Simple house -->
+                        <Rectangle Canvas.Left="50" Canvas.Top="70" Width="100" Height="70" Fill="#8B4513"/>
+                        <Polygon Points="100,20 50,70 150,70" Fill="#B22222"/>
+                        <Rectangle Canvas.Left="80" Canvas.Top="100" Width="25" Height="40" Fill="#654321"/>
+                        <Ellipse Canvas.Left="135" Canvas.Top="85" Width="25" Height="25" Fill="#87CEEB"/>
+
+                        <!-- Sun -->
+                        <Ellipse Canvas.Left="220" Canvas.Top="20" Width="50" Height="50" Fill="#FFD700"/>
+
+                        <!-- Ground -->
+                        <Rectangle Canvas.Left="0" Canvas.Top="140" Width="300" Height="10" Fill="#228B22"/>
+                    </Canvas>
+                </Border>
+            </StackPanel>
+        </Border>
+    </StackPanel>
+</Page>

--- a/samples/Jalium.UI.Gallery/Views/ShapesPage.jalxaml.cs
+++ b/samples/Jalium.UI.Gallery/Views/ShapesPage.jalxaml.cs
@@ -1,0 +1,14 @@
+using Jalium.UI.Controls;
+
+namespace Jalium.UI.Gallery.Views;
+
+/// <summary>
+/// Code-behind for ShapesPage.jalxaml demonstrating shape controls functionality.
+/// </summary>
+public partial class ShapesPage : Page
+{
+    public ShapesPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/samples/Jalium.UI.Gallery/Views/SplitterPage.jalxaml
+++ b/samples/Jalium.UI.Gallery/Views/SplitterPage.jalxaml
@@ -1,0 +1,198 @@
+<Page xmlns="http://schemas.jalium.ui/2024"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      x:Class="Jalium.UI.Gallery.Views.SplitterPage"
+      Title="Splitter">
+
+    <StackPanel Orientation="Vertical">
+        <!-- Page Title -->
+        <TextBlock Text="Splitter"
+                   FontSize="32"
+                   Foreground="#FFFFFF"
+                   Margin="0,0,0,8"/>
+
+        <!-- Description -->
+        <TextBlock Text="A control for resizing adjacent panels."
+                   FontSize="14"
+                   Foreground="#888888"
+                   Margin="0,0,0,24"/>
+
+        <!-- Horizontal Splitter Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Horizontal Splitter"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Drag the splitter to resize panels horizontally."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="0"
+                        Height="200">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" MinWidth="100"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*" MinWidth="100"/>
+                        </Grid.ColumnDefinitions>
+
+                        <Border Grid.Column="0" Background="#252525" Padding="16">
+                            <TextBlock Text="Left Panel" Foreground="#888888" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+
+                        <GridSplitter Grid.Column="1" Width="6" Background="#3D3D3D" ResizeBehavior="PreviousAndNext"/>
+
+                        <Border Grid.Column="2" Background="#303030" Padding="16">
+                            <TextBlock Text="Right Panel" Foreground="#888888" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                    </Grid>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Vertical Splitter Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Vertical Splitter"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Drag the splitter to resize panels vertically."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="0"
+                        Height="250">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*" MinHeight="50"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*" MinHeight="50"/>
+                        </Grid.RowDefinitions>
+
+                        <Border Grid.Row="0" Background="#252525" Padding="16">
+                            <TextBlock Text="Top Panel" Foreground="#888888" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+
+                        <GridSplitter Grid.Row="1" Height="6" Background="#3D3D3D" HorizontalAlignment="Stretch" ResizeDirection="Rows"/>
+
+                        <Border Grid.Row="2" Background="#303030" Padding="16">
+                            <TextBlock Text="Bottom Panel" Foreground="#888888" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                    </Grid>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Multi-Panel Layout Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Multi-Panel Layout"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Combine multiple splitters for complex layouts."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="0"
+                        Height="300">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="150" MinWidth="100"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+
+                        <!-- Left sidebar -->
+                        <Border Grid.Column="0" Background="#202020" Padding="12">
+                            <StackPanel Orientation="Vertical">
+                                <TextBlock Text="Sidebar" Foreground="#888888" FontWeight="SemiBold" Margin="0,0,0,12"/>
+                                <TextBlock Text="• Item 1" Foreground="#666666" Margin="0,0,0,4"/>
+                                <TextBlock Text="• Item 2" Foreground="#666666" Margin="0,0,0,4"/>
+                                <TextBlock Text="• Item 3" Foreground="#666666" Margin="0,0,0,4"/>
+                                <TextBlock Text="• Item 4" Foreground="#666666"/>
+                            </StackPanel>
+                        </Border>
+
+                        <GridSplitter Grid.Column="1" Width="6" Background="#3D3D3D"/>
+
+                        <!-- Right section with vertical split -->
+                        <Grid Grid.Column="2">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="2*" MinHeight="80"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="*" MinHeight="60"/>
+                            </Grid.RowDefinitions>
+
+                            <Border Grid.Row="0" Background="#252525" Padding="16">
+                                <TextBlock Text="Main Content Area" Foreground="#888888" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+
+                            <GridSplitter Grid.Row="1" Height="6" Background="#3D3D3D" HorizontalAlignment="Stretch" ResizeDirection="Rows"/>
+
+                            <Border Grid.Row="2" Background="#303030" Padding="16">
+                                <TextBlock Text="Output / Console" Foreground="#888888" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                        </Grid>
+                    </Grid>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Use Cases Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Common Use Cases"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Splitters are useful for creating resizable layouts."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="• IDE layouts (code editor + output)" Foreground="#CCCCCC" Margin="0,0,0,8"/>
+                        <TextBlock Text="• File explorers (tree + details)" Foreground="#CCCCCC" Margin="0,0,0,8"/>
+                        <TextBlock Text="• Email clients (folders + list + preview)" Foreground="#CCCCCC" Margin="0,0,0,8"/>
+                        <TextBlock Text="• Dashboard layouts" Foreground="#CCCCCC" Margin="0,0,0,8"/>
+                        <TextBlock Text="• Settings panels" Foreground="#CCCCCC"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+    </StackPanel>
+</Page>

--- a/samples/Jalium.UI.Gallery/Views/SplitterPage.jalxaml.cs
+++ b/samples/Jalium.UI.Gallery/Views/SplitterPage.jalxaml.cs
@@ -1,0 +1,14 @@
+using Jalium.UI.Controls;
+
+namespace Jalium.UI.Gallery.Views;
+
+/// <summary>
+/// Code-behind for SplitterPage.jalxaml demonstrating splitter functionality.
+/// </summary>
+public partial class SplitterPage : Page
+{
+    public SplitterPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/samples/Jalium.UI.Gallery/Views/TimePickerPage.jalxaml
+++ b/samples/Jalium.UI.Gallery/Views/TimePickerPage.jalxaml
@@ -1,0 +1,191 @@
+<Page xmlns="http://schemas.jalium.ui/2024"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      x:Class="Jalium.UI.Gallery.Views.TimePickerPage"
+      Title="TimePicker">
+
+    <StackPanel Orientation="Vertical">
+        <!-- Page Title -->
+        <TextBlock Text="TimePicker"
+                   FontSize="32"
+                   Foreground="#FFFFFF"
+                   Margin="0,0,0,8"/>
+
+        <!-- Description -->
+        <TextBlock Text="A control that lets users select a time value."
+                   FontSize="14"
+                   Foreground="#888888"
+                   Margin="0,0,0,24"/>
+
+        <!-- Basic TimePicker Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Basic TimePicker"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Click to open the time picker and select a time."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Horizontal">
+                        <TimePicker Width="150" Margin="0,0,16,0"/>
+                        <TimePicker Width="150" IsEnabled="False"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- 12-Hour vs 24-Hour Format Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Time Formats"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="TimePicker supports 12-hour and 24-hour formats."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                            <TextBlock Text="12-hour format:" Width="140" Foreground="#888888" VerticalAlignment="Center"/>
+                            <TimePicker Width="150" ClockIdentifier="12HourClock"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="24-hour format:" Width="140" Foreground="#888888" VerticalAlignment="Center"/>
+                            <TimePicker Width="150" ClockIdentifier="24HourClock"/>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Minute Increment Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Minute Increment"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="TimePicker can have different minute increments."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                            <TextBlock Text="1 minute steps:" Width="140" Foreground="#888888" VerticalAlignment="Center"/>
+                            <TimePicker Width="150" MinuteIncrement="1"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                            <TextBlock Text="5 minute steps:" Width="140" Foreground="#888888" VerticalAlignment="Center"/>
+                            <TimePicker Width="150" MinuteIncrement="5"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                            <TextBlock Text="15 minute steps:" Width="140" Foreground="#888888" VerticalAlignment="Center"/>
+                            <TimePicker Width="150" MinuteIncrement="15"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="30 minute steps:" Width="140" Foreground="#888888" VerticalAlignment="Center"/>
+                            <TimePicker Width="150" MinuteIncrement="30"/>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Interactive Demo Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Interactive Demo"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Select a time and see the formatted result."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,16">
+                            <TextBlock Text="Select time:" Width="120" Foreground="#888888" VerticalAlignment="Center"/>
+                            <TimePicker x:Name="DemoTimePicker" Width="150"/>
+                        </StackPanel>
+                        <TextBlock x:Name="SelectedTimeText"
+                                   Text="No time selected"
+                                   Foreground="#0078D4"
+                                   FontSize="14"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Use Cases Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Common Use Cases"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Examples of TimePicker in real scenarios."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="Alarm Time" Foreground="#888888" FontSize="12" Margin="0,0,0,4"/>
+                        <TimePicker Width="150" Margin="0,0,0,16"/>
+
+                        <TextBlock Text="Meeting Start Time" Foreground="#888888" FontSize="12" Margin="0,0,0,4"/>
+                        <TimePicker Width="150" MinuteIncrement="15" Margin="0,0,0,16"/>
+
+                        <TextBlock Text="Reminder Time" Foreground="#888888" FontSize="12" Margin="0,0,0,4"/>
+                        <TimePicker Width="150" MinuteIncrement="5"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+    </StackPanel>
+</Page>

--- a/samples/Jalium.UI.Gallery/Views/TimePickerPage.jalxaml.cs
+++ b/samples/Jalium.UI.Gallery/Views/TimePickerPage.jalxaml.cs
@@ -1,0 +1,35 @@
+using Jalium.UI.Controls;
+
+namespace Jalium.UI.Gallery.Views;
+
+/// <summary>
+/// Code-behind for TimePickerPage.jalxaml demonstrating time picker functionality.
+/// </summary>
+public partial class TimePickerPage : Page
+{
+    public TimePickerPage()
+    {
+        InitializeComponent();
+
+        // Set up event handler for the interactive demo
+        if (DemoTimePicker != null)
+        {
+            DemoTimePicker.SelectedTimeChanged += OnDemoTimeChanged;
+        }
+    }
+
+    private void OnDemoTimeChanged(object? sender, TimePickerSelectedValueChangedEventArgs e)
+    {
+        if (SelectedTimeText != null)
+        {
+            if (e.NewTime.HasValue)
+            {
+                SelectedTimeText.Text = $"Selected: {e.NewTime.Value:hh\\:mm}";
+            }
+            else
+            {
+                SelectedTimeText.Text = "No time selected";
+            }
+        }
+    }
+}

--- a/samples/Jalium.UI.Gallery/Views/ToastNotificationPage.jalxaml
+++ b/samples/Jalium.UI.Gallery/Views/ToastNotificationPage.jalxaml
@@ -1,0 +1,208 @@
+<Page xmlns="http://schemas.jalium.ui/2024"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      x:Class="Jalium.UI.Gallery.Views.ToastNotificationPage"
+      Title="ToastNotification">
+
+    <StackPanel Orientation="Vertical">
+        <!-- Page Title -->
+        <TextBlock Text="ToastNotification"
+                   FontSize="32"
+                   Foreground="#FFFFFF"
+                   Margin="0,0,0,8"/>
+
+        <!-- Description -->
+        <TextBlock Text="Displays transient notifications to users."
+                   FontSize="14"
+                   Foreground="#888888"
+                   Margin="0,0,0,24"/>
+
+        <!-- Basic Toast Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Basic Toast Notifications"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Simple toast notifications with different severity levels."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Horizontal">
+                        <Button x:Name="InfoToastButton" Content="Info" Width="70" Height="28" Margin="0,0,8,0"/>
+                        <Button x:Name="SuccessToastButton" Content="Success" Width="80" Height="28" Margin="0,0,8,0"/>
+                        <Button x:Name="WarningToastButton" Content="Warning" Width="80" Height="28" Margin="0,0,8,0"/>
+                        <Button x:Name="ErrorToastButton" Content="Error" Width="70" Height="28"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Toast Preview Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Toast Preview"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Examples of how toasts appear in different styles."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <!-- Info Toast Preview -->
+                        <Border Background="#0078D4" CornerRadius="4" Padding="12" Margin="0,0,0,8">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="ℹ️" FontSize="16" Margin="0,0,12,0"/>
+                                <StackPanel Orientation="Vertical">
+                                    <TextBlock Text="Information" Foreground="#FFFFFF" FontWeight="SemiBold"/>
+                                    <TextBlock Text="This is an informational message." Foreground="#E0E0E0" FontSize="12"/>
+                                </StackPanel>
+                            </StackPanel>
+                        </Border>
+
+                        <!-- Success Toast Preview -->
+                        <Border Background="#107C10" CornerRadius="4" Padding="12" Margin="0,0,0,8">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="✓" FontSize="16" Margin="0,0,12,0" Foreground="#FFFFFF"/>
+                                <StackPanel Orientation="Vertical">
+                                    <TextBlock Text="Success" Foreground="#FFFFFF" FontWeight="SemiBold"/>
+                                    <TextBlock Text="Operation completed successfully." Foreground="#E0E0E0" FontSize="12"/>
+                                </StackPanel>
+                            </StackPanel>
+                        </Border>
+
+                        <!-- Warning Toast Preview -->
+                        <Border Background="#FF8C00" CornerRadius="4" Padding="12" Margin="0,0,0,8">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="⚠️" FontSize="16" Margin="0,0,12,0"/>
+                                <StackPanel Orientation="Vertical">
+                                    <TextBlock Text="Warning" Foreground="#FFFFFF" FontWeight="SemiBold"/>
+                                    <TextBlock Text="Please review before proceeding." Foreground="#E0E0E0" FontSize="12"/>
+                                </StackPanel>
+                            </StackPanel>
+                        </Border>
+
+                        <!-- Error Toast Preview -->
+                        <Border Background="#E81123" CornerRadius="4" Padding="12">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="✕" FontSize="16" Margin="0,0,12,0" Foreground="#FFFFFF"/>
+                                <StackPanel Orientation="Vertical">
+                                    <TextBlock Text="Error" Foreground="#FFFFFF" FontWeight="SemiBold"/>
+                                    <TextBlock Text="An error occurred during the operation." Foreground="#E0E0E0" FontSize="12"/>
+                                </StackPanel>
+                            </StackPanel>
+                        </Border>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Toast with Actions Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Toast with Actions"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Toasts can include action buttons."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <!-- Toast with Actions Preview -->
+                        <Border Background="#2D2D2D" BorderBrush="#3D3D3D" BorderThickness="1" CornerRadius="4" Padding="12">
+                            <StackPanel Orientation="Vertical">
+                                <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                                    <TextBlock Text="📥" FontSize="16" Margin="0,0,12,0"/>
+                                    <StackPanel Orientation="Vertical">
+                                        <TextBlock Text="Download Complete" Foreground="#FFFFFF" FontWeight="SemiBold"/>
+                                        <TextBlock Text="Your file has been downloaded." Foreground="#888888" FontSize="12"/>
+                                    </StackPanel>
+                                </StackPanel>
+                                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                    <Button Content="Open" Width="60" Height="24" FontSize="11" Margin="0,0,8,0"/>
+                                    <Button Content="Dismiss" Width="70" Height="24" FontSize="11"/>
+                                </StackPanel>
+                            </StackPanel>
+                        </Border>
+
+                        <Button x:Name="ShowActionToastButton" Content="Show Toast with Actions" Width="180" Height="28" Margin="0,16,0,0"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Toast Configuration Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Toast Configuration"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Customize toast appearance and behavior."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                            <TextBlock Text="Position:" Width="100" Foreground="#888888" VerticalAlignment="Center"/>
+                            <ComboBox Width="150" Height="28">
+                                <ComboBoxItem Content="Top Right" IsSelected="True"/>
+                                <ComboBoxItem Content="Top Left"/>
+                                <ComboBoxItem Content="Bottom Right"/>
+                                <ComboBoxItem Content="Bottom Left"/>
+                                <ComboBoxItem Content="Top Center"/>
+                                <ComboBoxItem Content="Bottom Center"/>
+                            </ComboBox>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                            <TextBlock Text="Duration:" Width="100" Foreground="#888888" VerticalAlignment="Center"/>
+                            <Slider x:Name="DurationSlider" Minimum="1" Maximum="10" Value="5" Width="150" Margin="0,0,8,0"/>
+                            <TextBlock x:Name="DurationText" Text="5s" Foreground="#888888" VerticalAlignment="Center"/>
+                        </StackPanel>
+                        <CheckBox Content="Show close button" IsChecked="True" Margin="0,0,0,8"/>
+                        <CheckBox Content="Pause on hover" IsChecked="True" Margin="0,0,0,8"/>
+                        <CheckBox Content="Play sound" Margin="0,0,0,8"/>
+                        <Button x:Name="ShowCustomToastButton" Content="Show Custom Toast" Width="150" Height="28" Margin="0,8,0,0"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+    </StackPanel>
+</Page>

--- a/samples/Jalium.UI.Gallery/Views/ToastNotificationPage.jalxaml.cs
+++ b/samples/Jalium.UI.Gallery/Views/ToastNotificationPage.jalxaml.cs
@@ -1,0 +1,123 @@
+using Jalium.UI.Controls;
+
+namespace Jalium.UI.Gallery.Views;
+
+/// <summary>
+/// Code-behind for ToastNotificationPage.jalxaml demonstrating toast notification functionality.
+/// </summary>
+public partial class ToastNotificationPage : Page
+{
+    public ToastNotificationPage()
+    {
+        InitializeComponent();
+
+        // Set up toast buttons
+        if (InfoToastButton != null)
+        {
+            InfoToastButton.Click += (s, e) => ShowToast("Information", "This is an informational message.", "info");
+        }
+
+        if (SuccessToastButton != null)
+        {
+            SuccessToastButton.Click += (s, e) => ShowToast("Success", "Operation completed successfully.", "success");
+        }
+
+        if (WarningToastButton != null)
+        {
+            WarningToastButton.Click += (s, e) => ShowToast("Warning", "Please review before proceeding.", "warning");
+        }
+
+        if (ErrorToastButton != null)
+        {
+            ErrorToastButton.Click += (s, e) => ShowToast("Error", "An error occurred during the operation.", "error");
+        }
+
+        if (ShowActionToastButton != null)
+        {
+            ShowActionToastButton.Click += OnShowActionToastClick;
+        }
+
+        if (ShowCustomToastButton != null)
+        {
+            ShowCustomToastButton.Click += OnShowCustomToastClick;
+        }
+
+        // Set up duration slider
+        if (DurationSlider != null)
+        {
+            DurationSlider.ValueChanged += OnDurationChanged;
+        }
+    }
+
+    private void ShowToast(string title, string message, string type)
+    {
+        // Create a toast notification using the Windows toast API
+        var xmlContent = $@"
+            <toast>
+                <visual>
+                    <binding template=""ToastText02"">
+                        <text id=""1"">{title}</text>
+                        <text id=""2"">{message}</text>
+                    </binding>
+                </visual>
+            </toast>";
+
+        var notification = new ToastNotification(xmlContent);
+        notification.Tag = type;
+
+        var notifier = ToastNotificationManager.CreateToastNotifier();
+        notifier.Show(notification);
+    }
+
+    private void OnShowActionToastClick(object? sender, EventArgs e)
+    {
+        var xmlContent = @"
+            <toast>
+                <visual>
+                    <binding template=""ToastText02"">
+                        <text id=""1"">Download Complete</text>
+                        <text id=""2"">Your file has been downloaded.</text>
+                    </binding>
+                </visual>
+                <actions>
+                    <action content=""Open"" arguments=""open""/>
+                    <action content=""Dismiss"" arguments=""dismiss""/>
+                </actions>
+            </toast>";
+
+        var notification = new ToastNotification(xmlContent);
+        notification.Tag = "download";
+
+        var notifier = ToastNotificationManager.CreateToastNotifier();
+        notifier.Show(notification);
+    }
+
+    private void OnShowCustomToastClick(object? sender, EventArgs e)
+    {
+        var duration = DurationSlider?.Value ?? 5;
+
+        var xmlContent = $@"
+            <toast duration=""long"">
+                <visual>
+                    <binding template=""ToastText02"">
+                        <text id=""1"">Custom Toast</text>
+                        <text id=""2"">This toast demonstrates custom settings.</text>
+                    </binding>
+                </visual>
+            </toast>";
+
+        var notification = new ToastNotification(xmlContent);
+        notification.ExpirationTime = DateTimeOffset.Now.AddSeconds(duration);
+
+        var notifier = ToastNotificationManager.CreateToastNotifier();
+        notifier.Show(notification);
+    }
+
+    private void OnDurationChanged(object? sender, RoutedPropertyChangedEventArgs<double> e)
+    {
+        if (DurationText != null)
+        {
+            DurationText.Text = $"{e.NewValue:F0}s";
+        }
+    }
+}

--- a/samples/Jalium.UI.Gallery/Views/ToolBarPage.jalxaml
+++ b/samples/Jalium.UI.Gallery/Views/ToolBarPage.jalxaml
@@ -1,0 +1,170 @@
+<Page xmlns="http://schemas.jalium.ui/2024"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      x:Class="Jalium.UI.Gallery.Views.ToolBarPage"
+      Title="ToolBar">
+
+    <StackPanel Orientation="Vertical">
+        <!-- Page Title -->
+        <TextBlock Text="ToolBar"
+                   FontSize="32"
+                   Foreground="#FFFFFF"
+                   Margin="0,0,0,8"/>
+
+        <!-- Description -->
+        <TextBlock Text="A container for a group of commands or controls."
+                   FontSize="14"
+                   Foreground="#888888"
+                   Margin="0,0,0,24"/>
+
+        <!-- Basic ToolBar Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Basic ToolBar"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="A toolbar with buttons."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="8">
+                    <ToolBar Background="Transparent">
+                        <Button Content="New" Width="60" Height="28"/>
+                        <Button Content="Open" Width="60" Height="28"/>
+                        <Button Content="Save" Width="60" Height="28"/>
+                        <Separator/>
+                        <Button Content="Cut" Width="50" Height="28"/>
+                        <Button Content="Copy" Width="50" Height="28"/>
+                        <Button Content="Paste" Width="50" Height="28"/>
+                    </ToolBar>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- ToolBar with Mixed Controls Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="ToolBar with Mixed Controls"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Toolbars can contain various types of controls."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="8">
+                    <ToolBar Background="Transparent">
+                        <Button Content="File" Width="50" Height="28"/>
+                        <Separator/>
+                        <TextBlock Text="Zoom:" VerticalAlignment="Center" Foreground="#888888" Margin="4,0"/>
+                        <ComboBox Width="80" Height="28">
+                            <ComboBoxItem Content="50%"/>
+                            <ComboBoxItem Content="75%"/>
+                            <ComboBoxItem Content="100%" IsSelected="True"/>
+                            <ComboBoxItem Content="150%"/>
+                            <ComboBoxItem Content="200%"/>
+                        </ComboBox>
+                        <Separator/>
+                        <CheckBox Content="Bold" Margin="4,0"/>
+                        <CheckBox Content="Italic" Margin="4,0"/>
+                        <Separator/>
+                        <TextBox Width="150" Height="28" PlaceholderText="Search..."/>
+                    </ToolBar>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Multiple ToolBars Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="ToolBar Tray"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Multiple toolbars can be organized in a tray."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="8">
+                    <StackPanel Orientation="Vertical">
+                        <ToolBar Background="Transparent" Margin="0,0,0,4">
+                            <Button Content="New" Width="50" Height="26"/>
+                            <Button Content="Open" Width="50" Height="26"/>
+                            <Button Content="Save" Width="50" Height="26"/>
+                            <Button Content="Print" Width="50" Height="26"/>
+                        </ToolBar>
+                        <ToolBar Background="Transparent">
+                            <Button Content="Undo" Width="50" Height="26"/>
+                            <Button Content="Redo" Width="50" Height="26"/>
+                            <Separator/>
+                            <Button Content="Find" Width="50" Height="26"/>
+                            <Button Content="Replace" Width="60" Height="26"/>
+                        </ToolBar>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Interactive Demo Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Interactive Demo"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Click toolbar buttons to see the action."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="8">
+                    <StackPanel Orientation="Vertical">
+                        <ToolBar Background="Transparent" Margin="0,0,0,16">
+                            <Button x:Name="NewButton" Content="New" Width="50" Height="28"/>
+                            <Button x:Name="OpenButton" Content="Open" Width="50" Height="28"/>
+                            <Button x:Name="SaveButton" Content="Save" Width="50" Height="28"/>
+                            <Separator/>
+                            <Button x:Name="UndoButton" Content="Undo" Width="50" Height="28"/>
+                            <Button x:Name="RedoButton" Content="Redo" Width="50" Height="28"/>
+                        </ToolBar>
+                        <TextBlock x:Name="ActionText"
+                                   Text="No action performed"
+                                   Foreground="#0078D4"
+                                   HorizontalAlignment="Center"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+    </StackPanel>
+</Page>

--- a/samples/Jalium.UI.Gallery/Views/ToolBarPage.jalxaml.cs
+++ b/samples/Jalium.UI.Gallery/Views/ToolBarPage.jalxaml.cs
@@ -1,0 +1,29 @@
+using Jalium.UI.Controls;
+
+namespace Jalium.UI.Gallery.Views;
+
+/// <summary>
+/// Code-behind for ToolBarPage.jalxaml demonstrating toolbar functionality.
+/// </summary>
+public partial class ToolBarPage : Page
+{
+    public ToolBarPage()
+    {
+        InitializeComponent();
+
+        // Set up event handlers
+        if (NewButton != null) NewButton.Click += (s, e) => UpdateAction("New clicked");
+        if (OpenButton != null) OpenButton.Click += (s, e) => UpdateAction("Open clicked");
+        if (SaveButton != null) SaveButton.Click += (s, e) => UpdateAction("Save clicked");
+        if (UndoButton != null) UndoButton.Click += (s, e) => UpdateAction("Undo clicked");
+        if (RedoButton != null) RedoButton.Click += (s, e) => UpdateAction("Redo clicked");
+    }
+
+    private void UpdateAction(string action)
+    {
+        if (ActionText != null)
+        {
+            ActionText.Text = action;
+        }
+    }
+}

--- a/samples/Jalium.UI.Gallery/Views/ToolTipPage.jalxaml
+++ b/samples/Jalium.UI.Gallery/Views/ToolTipPage.jalxaml
@@ -1,0 +1,197 @@
+<Page xmlns="http://schemas.jalium.ui/2024"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      x:Class="Jalium.UI.Gallery.Views.ToolTipPage"
+      Title="ToolTip">
+
+    <StackPanel Orientation="Vertical">
+        <!-- Page Title -->
+        <TextBlock Text="ToolTip"
+                   FontSize="32"
+                   Foreground="#FFFFFF"
+                   Margin="0,0,0,8"/>
+
+        <!-- Description -->
+        <TextBlock Text="A popup that displays information when hovering over an element."
+                   FontSize="14"
+                   Foreground="#888888"
+                   Margin="0,0,0,24"/>
+
+        <!-- Basic ToolTip Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Basic ToolTip"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Hover over the buttons to see tooltips."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Horizontal">
+                        <Button Content="Save"
+                                Width="80"
+                                Height="32"
+                                Margin="0,0,12,0"
+                                ToolTip="Save the current document"/>
+                        <Button Content="Open"
+                                Width="80"
+                                Height="32"
+                                Margin="0,0,12,0"
+                                ToolTip="Open an existing document"/>
+                        <Button Content="Delete"
+                                Width="80"
+                                Height="32"
+                                ToolTip="Delete the selected item"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- ToolTip on Various Controls Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="ToolTips on Various Controls"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="ToolTips can be added to any control."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                            <TextBox Width="200"
+                                     Height="32"
+                                     PlaceholderText="Enter username"
+                                     ToolTip="Enter your username (3-20 characters)"
+                                     Margin="0,0,12,0"/>
+                            <TextBlock Text="Username field"
+                                       Foreground="#888888"
+                                       VerticalAlignment="Center"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                            <Slider Width="200"
+                                    Minimum="0"
+                                    Maximum="100"
+                                    ToolTip="Adjust the volume level"
+                                    Margin="0,0,12,0"/>
+                            <TextBlock Text="Volume slider"
+                                       Foreground="#888888"
+                                       VerticalAlignment="Center"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal">
+                            <CheckBox Content="Enable notifications"
+                                      ToolTip="Turn on/off notification alerts"
+                                      Margin="0,0,12,0"/>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Rich Content ToolTip Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Rich Content ToolTip"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="ToolTips can contain rich content with multiple elements."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <Button Content="Hover for rich tooltip" Width="180" Height="32">
+                        <Button.ToolTip>
+                            <ToolTip>
+                                <StackPanel Orientation="Vertical">
+                                    <TextBlock Text="Rich ToolTip" FontWeight="Bold" Margin="0,0,0,4"/>
+                                    <TextBlock Text="This tooltip contains multiple lines of text" TextWrapping="Wrap"/>
+                                    <TextBlock Text="with formatting and structure." TextWrapping="Wrap"/>
+                                    <Separator Margin="0,8"/>
+                                    <TextBlock Text="Shortcut: Ctrl+R" Foreground="#888888" FontSize="11"/>
+                                </StackPanel>
+                            </ToolTip>
+                        </Button.ToolTip>
+                    </Button>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- ToolTip Placement Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="ToolTip Placement"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="ToolTips can be positioned at different locations."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="40">
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                        <Button Content="Top"
+                                Width="60"
+                                Height="32"
+                                Margin="8"
+                                ToolTip="Tooltip on top"
+                                ToolTipService.Placement="Top"/>
+                        <Button Content="Right"
+                                Width="60"
+                                Height="32"
+                                Margin="8"
+                                ToolTip="Tooltip on right"
+                                ToolTipService.Placement="Right"/>
+                        <Button Content="Bottom"
+                                Width="60"
+                                Height="32"
+                                Margin="8"
+                                ToolTip="Tooltip on bottom"
+                                ToolTipService.Placement="Bottom"/>
+                        <Button Content="Left"
+                                Width="60"
+                                Height="32"
+                                Margin="8"
+                                ToolTip="Tooltip on left"
+                                ToolTipService.Placement="Left"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+    </StackPanel>
+</Page>

--- a/samples/Jalium.UI.Gallery/Views/ToolTipPage.jalxaml.cs
+++ b/samples/Jalium.UI.Gallery/Views/ToolTipPage.jalxaml.cs
@@ -1,0 +1,14 @@
+using Jalium.UI.Controls;
+
+namespace Jalium.UI.Gallery.Views;
+
+/// <summary>
+/// Code-behind for ToolTipPage.jalxaml demonstrating tooltip functionality.
+/// </summary>
+public partial class ToolTipPage : Page
+{
+    public ToolTipPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/samples/Jalium.UI.Gallery/Views/ViewboxPage.jalxaml
+++ b/samples/Jalium.UI.Gallery/Views/ViewboxPage.jalxaml
@@ -1,0 +1,245 @@
+<Page xmlns="http://schemas.jalium.ui/2024"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      x:Class="Jalium.UI.Gallery.Views.ViewboxPage"
+      Title="Viewbox">
+
+    <StackPanel Orientation="Vertical">
+        <!-- Page Title -->
+        <TextBlock Text="Viewbox"
+                   FontSize="32"
+                   Foreground="#FFFFFF"
+                   Margin="0,0,0,8"/>
+
+        <!-- Description -->
+        <TextBlock Text="A decorator that scales its child to fit the available space."
+                   FontSize="14"
+                   Foreground="#888888"
+                   Margin="0,0,0,24"/>
+
+        <!-- Uniform Stretch Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Uniform Stretch"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Content is scaled uniformly to fit while preserving aspect ratio."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Horizontal">
+                        <Border BorderBrush="#3D3D3D" BorderThickness="1" Width="100" Height="100" Margin="0,0,16,0">
+                            <Viewbox Stretch="Uniform">
+                                <Button Content="Scale Me" Width="200" Height="50"/>
+                            </Viewbox>
+                        </Border>
+                        <Border BorderBrush="#3D3D3D" BorderThickness="1" Width="150" Height="100" Margin="0,0,16,0">
+                            <Viewbox Stretch="Uniform">
+                                <Button Content="Scale Me" Width="200" Height="50"/>
+                            </Viewbox>
+                        </Border>
+                        <Border BorderBrush="#3D3D3D" BorderThickness="1" Width="200" Height="100">
+                            <Viewbox Stretch="Uniform">
+                                <Button Content="Scale Me" Width="200" Height="50"/>
+                            </Viewbox>
+                        </Border>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Stretch Modes Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Stretch Modes"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Different stretch modes control how content fills the viewbox."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,16">
+                            <StackPanel Orientation="Vertical" Margin="0,0,24,0">
+                                <TextBlock Text="None" Foreground="#888888" FontSize="12" Margin="0,0,0,4" HorizontalAlignment="Center"/>
+                                <Border BorderBrush="#3D3D3D" BorderThickness="1" Width="100" Height="80">
+                                    <Viewbox Stretch="None">
+                                        <Ellipse Width="60" Height="40" Fill="#0078D4"/>
+                                    </Viewbox>
+                                </Border>
+                            </StackPanel>
+                            <StackPanel Orientation="Vertical" Margin="0,0,24,0">
+                                <TextBlock Text="Fill" Foreground="#888888" FontSize="12" Margin="0,0,0,4" HorizontalAlignment="Center"/>
+                                <Border BorderBrush="#3D3D3D" BorderThickness="1" Width="100" Height="80">
+                                    <Viewbox Stretch="Fill">
+                                        <Ellipse Width="60" Height="40" Fill="#00CC6A"/>
+                                    </Viewbox>
+                                </Border>
+                            </StackPanel>
+                            <StackPanel Orientation="Vertical" Margin="0,0,24,0">
+                                <TextBlock Text="Uniform" Foreground="#888888" FontSize="12" Margin="0,0,0,4" HorizontalAlignment="Center"/>
+                                <Border BorderBrush="#3D3D3D" BorderThickness="1" Width="100" Height="80">
+                                    <Viewbox Stretch="Uniform">
+                                        <Ellipse Width="60" Height="40" Fill="#F7630C"/>
+                                    </Viewbox>
+                                </Border>
+                            </StackPanel>
+                            <StackPanel Orientation="Vertical">
+                                <TextBlock Text="UniformToFill" Foreground="#888888" FontSize="12" Margin="0,0,0,4" HorizontalAlignment="Center"/>
+                                <Border BorderBrush="#3D3D3D" BorderThickness="1" Width="100" Height="80" ClipToBounds="True">
+                                    <Viewbox Stretch="UniformToFill">
+                                        <Ellipse Width="60" Height="40" Fill="#E81123"/>
+                                    </Viewbox>
+                                </Border>
+                            </StackPanel>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Stretch Direction Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Stretch Direction"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Control whether content scales up, down, or both."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Horizontal">
+                        <StackPanel Orientation="Vertical" Margin="0,0,24,0">
+                            <TextBlock Text="UpOnly" Foreground="#888888" FontSize="12" Margin="0,0,0,4" HorizontalAlignment="Center"/>
+                            <Border BorderBrush="#3D3D3D" BorderThickness="1" Width="120" Height="80">
+                                <Viewbox Stretch="Uniform" StretchDirection="UpOnly">
+                                    <TextBlock Text="Small" FontSize="8" Foreground="#0078D4"/>
+                                </Viewbox>
+                            </Border>
+                        </StackPanel>
+                        <StackPanel Orientation="Vertical" Margin="0,0,24,0">
+                            <TextBlock Text="DownOnly" Foreground="#888888" FontSize="12" Margin="0,0,0,4" HorizontalAlignment="Center"/>
+                            <Border BorderBrush="#3D3D3D" BorderThickness="1" Width="60" Height="40">
+                                <Viewbox Stretch="Uniform" StretchDirection="DownOnly">
+                                    <TextBlock Text="Large" FontSize="24" Foreground="#00CC6A"/>
+                                </Viewbox>
+                            </Border>
+                        </StackPanel>
+                        <StackPanel Orientation="Vertical">
+                            <TextBlock Text="Both" Foreground="#888888" FontSize="12" Margin="0,0,0,4" HorizontalAlignment="Center"/>
+                            <Border BorderBrush="#3D3D3D" BorderThickness="1" Width="100" Height="60">
+                                <Viewbox Stretch="Uniform" StretchDirection="Both">
+                                    <TextBlock Text="Both" FontSize="16" Foreground="#F7630C"/>
+                                </Viewbox>
+                            </Border>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Interactive Demo Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Interactive Demo"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Resize the container to see viewbox scaling in action."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,16">
+                            <TextBlock Text="Width:" Foreground="#888888" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                            <Slider x:Name="WidthSlider" Minimum="50" Maximum="400" Value="200" Width="200"/>
+                            <TextBlock x:Name="WidthText" Text="200" Foreground="#888888" VerticalAlignment="Center" Margin="8,0,0,0"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,16">
+                            <TextBlock Text="Height:" Foreground="#888888" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                            <Slider x:Name="HeightSlider" Minimum="50" Maximum="300" Value="150" Width="200"/>
+                            <TextBlock x:Name="HeightText" Text="150" Foreground="#888888" VerticalAlignment="Center" Margin="8,0,0,0"/>
+                        </StackPanel>
+                        <Border x:Name="DemoContainer" BorderBrush="#3D3D3D" BorderThickness="1" Width="200" Height="150" HorizontalAlignment="Left">
+                            <Viewbox Stretch="Uniform">
+                                <StackPanel Orientation="Vertical" Width="200">
+                                    <TextBlock Text="Viewbox Demo" FontSize="18" Foreground="#FFFFFF" HorizontalAlignment="Center"/>
+                                    <Button Content="Scaled Button" Width="120" Height="30" HorizontalAlignment="Center" Margin="0,10,0,0"/>
+                                </StackPanel>
+                            </Viewbox>
+                        </Border>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Use Cases Card -->
+        <Border Background="#2D2D2D"
+                BorderBrush="#3D3D3D"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="20"
+                Margin="0,0,0,16">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="Common Use Cases"
+                           FontSize="16"
+                           Foreground="#FFFFFF"
+                           Margin="0,0,0,4"/>
+                <TextBlock Text="Viewbox is useful for various scenarios."
+                           FontSize="12"
+                           Foreground="#666666"
+                           Margin="0,0,0,16"/>
+
+                <Border Background="#1E1E1E"
+                        CornerRadius="4"
+                        Padding="16">
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="• Scaling icons to different sizes" Foreground="#CCCCCC" Margin="0,0,0,8"/>
+                        <TextBlock Text="• Creating responsive layouts" Foreground="#CCCCCC" Margin="0,0,0,8"/>
+                        <TextBlock Text="• Fitting vector graphics" Foreground="#CCCCCC" Margin="0,0,0,8"/>
+                        <TextBlock Text="• Thumbnail previews" Foreground="#CCCCCC" Margin="0,0,0,8"/>
+                        <TextBlock Text="• Zoom functionality" Foreground="#CCCCCC"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+    </StackPanel>
+</Page>

--- a/samples/Jalium.UI.Gallery/Views/ViewboxPage.jalxaml.cs
+++ b/samples/Jalium.UI.Gallery/Views/ViewboxPage.jalxaml.cs
@@ -1,0 +1,43 @@
+using Jalium.UI.Controls;
+
+namespace Jalium.UI.Gallery.Views;
+
+/// <summary>
+/// Code-behind for ViewboxPage.jalxaml demonstrating viewbox functionality.
+/// </summary>
+public partial class ViewboxPage : Page
+{
+    public ViewboxPage()
+    {
+        InitializeComponent();
+
+        // Set up slider event handlers
+        if (WidthSlider != null)
+        {
+            WidthSlider.ValueChanged += OnWidthSliderChanged;
+        }
+
+        if (HeightSlider != null)
+        {
+            HeightSlider.ValueChanged += OnHeightSliderChanged;
+        }
+    }
+
+    private void OnWidthSliderChanged(object? sender, RoutedPropertyChangedEventArgs<double> e)
+    {
+        if (DemoContainer != null && WidthText != null)
+        {
+            DemoContainer.Width = e.NewValue;
+            WidthText.Text = ((int)e.NewValue).ToString();
+        }
+    }
+
+    private void OnHeightSliderChanged(object? sender, RoutedPropertyChangedEventArgs<double> e)
+    {
+        if (DemoContainer != null && HeightText != null)
+        {
+            DemoContainer.Height = e.NewValue;
+            HeightText.Text = ((int)e.NewValue).ToString();
+        }
+    }
+}

--- a/src/managed/Jalium.UI.Controls/AutoCompleteBox.cs
+++ b/src/managed/Jalium.UI.Controls/AutoCompleteBox.cs
@@ -796,6 +796,13 @@ public class AutoCompleteBox : TextBoxBase, IImeSupport
     /// <inheritdoc />
     protected override Size MeasureOverride(Size availableSize)
     {
+        // If using template, delegate to base class which handles template root
+        if (Template != null)
+        {
+            return base.MeasureOverride(availableSize);
+        }
+
+        // Direct rendering mode
         var width = double.IsPositiveInfinity(availableSize.Width) ? 200 : availableSize.Width;
         var height = DefaultHeight;
 
@@ -809,6 +816,13 @@ public class AutoCompleteBox : TextBoxBase, IImeSupport
         return new Size(width, height);
     }
 
+    /// <inheritdoc />
+    internal override Size MeasureTextContent(Size availableSize)
+    {
+        var lineHeight = Math.Round(GetLineHeight());
+        return new Size(availableSize.Width, Math.Min(lineHeight, availableSize.Height));
+    }
+
     #endregion
 
     #region Rendering
@@ -816,41 +830,37 @@ public class AutoCompleteBox : TextBoxBase, IImeSupport
     /// <inheritdoc />
     protected override void OnRender(object drawingContext)
     {
-        if (drawingContext is not DrawingContext dc)
+        // If using content host, text rendering is handled by TextBoxContentHost
+        // But AutoCompleteBox still needs to draw dropdown
+        if (HasContentHost)
+        {
+            if (drawingContext is DrawingContext dc && IsDropDownOpen && FilteredItems.Count > 0)
+            {
+                DrawDropDown(dc);
+            }
+            return;
+        }
+
+        // Direct rendering mode
+        if (drawingContext is not DrawingContext directDc)
             return;
 
         var inputRect = new Rect(0, 0, RenderSize.Width, DefaultHeight);
         var cornerRadius = CornerRadius;
-        var hasCornerRadius = cornerRadius.TopLeft > 0;
         var lineHeight = Math.Round(GetLineHeight());
         var padding = Padding;
 
-        // Draw background
+        // Draw background and border
         if (Background != null)
         {
-            if (hasCornerRadius)
-            {
-                dc.DrawRoundedRectangle(Background, null, inputRect, cornerRadius.TopLeft, cornerRadius.TopLeft);
-            }
-            else
-            {
-                dc.DrawRectangle(Background, null, inputRect);
-            }
+            directDc.DrawRoundedRectangle(Background, null, inputRect, cornerRadius);
         }
 
-        // Draw border
         var borderBrush = IsFocused ? new SolidColorBrush(Color.FromRgb(0, 120, 212)) : BorderBrush;
         if (borderBrush != null && BorderThickness.TotalWidth > 0)
         {
             var pen = new Pen(borderBrush, BorderThickness.Left);
-            if (hasCornerRadius)
-            {
-                dc.DrawRoundedRectangle(null, pen, inputRect, cornerRadius.TopLeft, cornerRadius.TopLeft);
-            }
-            else
-            {
-                dc.DrawRectangle(null, pen, inputRect);
-            }
+            directDc.DrawRoundedRectangle(null, pen, inputRect, cornerRadius);
         }
 
         // Content area
@@ -860,6 +870,33 @@ public class AutoCompleteBox : TextBoxBase, IImeSupport
             Math.Max(0, inputRect.Width - padding.Left - padding.Right),
             Math.Max(0, inputRect.Height - padding.Top - padding.Bottom));
 
+        // Render text content
+        RenderTextContentCore(directDc, contentRect, lineHeight);
+
+        // Draw drop-down
+        if (IsDropDownOpen && FilteredItems.Count > 0)
+        {
+            DrawDropDown(directDc);
+        }
+    }
+
+    /// <inheritdoc />
+    internal override void RenderTextContent(object drawingContext)
+    {
+        if (drawingContext is not DrawingContext dc)
+            return;
+
+        var lineHeight = Math.Round(GetLineHeight());
+        var contentRect = new Rect(0, 0, _textContentSize.Width, _textContentSize.Height);
+
+        RenderTextContentCore(dc, contentRect, lineHeight);
+    }
+
+    /// <summary>
+    /// Core text rendering logic used by both direct rendering and content host modes.
+    /// </summary>
+    private void RenderTextContentCore(DrawingContext dc, Rect contentRect, double lineHeight)
+    {
         // Clip to content area
         dc.PushClip(new RectangleGeometry(contentRect));
 
@@ -877,8 +914,8 @@ public class AutoCompleteBox : TextBoxBase, IImeSupport
                 Foreground = new SolidColorBrush(Color.FromRgb(128, 128, 128))
             };
             TextMeasurement.MeasureText(watermarkText);
-            var textY = (DefaultHeight - watermarkText.Height) / 2;
-            dc.DrawText(watermarkText, new Point(contentRect.X - Math.Round(_horizontalOffset), textY));
+            var textY = (contentRect.Height - watermarkText.Height) / 2;
+            dc.DrawText(watermarkText, new Point(contentRect.X - Math.Round(_horizontalOffset), contentRect.Y + textY));
         }
         else if (!string.IsNullOrEmpty(_text))
         {
@@ -887,8 +924,8 @@ public class AutoCompleteBox : TextBoxBase, IImeSupport
                 Foreground = Foreground ?? new SolidColorBrush(Color.White)
             };
             TextMeasurement.MeasureText(formattedText);
-            var textY = (DefaultHeight - formattedText.Height) / 2;
-            dc.DrawText(formattedText, new Point(contentRect.X - Math.Round(_horizontalOffset), textY));
+            var textY = (contentRect.Height - formattedText.Height) / 2;
+            dc.DrawText(formattedText, new Point(contentRect.X - Math.Round(_horizontalOffset), contentRect.Y + textY));
         }
 
         // Draw IME composition
@@ -904,12 +941,6 @@ public class AutoCompleteBox : TextBoxBase, IImeSupport
         }
 
         dc.Pop(); // Pop clip
-
-        // Draw drop-down
-        if (IsDropDownOpen && FilteredItems.Count > 0)
-        {
-            DrawDropDown(dc);
-        }
     }
 
     private void DrawSelection(DrawingContext dc, Rect contentRect, double lineHeight)
@@ -923,7 +954,7 @@ public class AutoCompleteBox : TextBoxBase, IImeSupport
 
         var startX = Math.Round(contentRect.X + MeasureTextWidth(textBefore) - roundedHorizontalOffset);
         var width = Math.Max(Math.Round(MeasureTextWidth(selectedText)), 1);
-        var textY = (DefaultHeight - lineHeight) / 2;
+        var textY = contentRect.Y + (contentRect.Height - lineHeight) / 2;
 
         var selRect = new Rect(startX, textY, width, lineHeight);
         dc.DrawRectangle(SelectionBrush, null, selRect);
@@ -937,7 +968,7 @@ public class AutoCompleteBox : TextBoxBase, IImeSupport
         var roundedHorizontalOffset = Math.Round(_horizontalOffset);
         var textBeforeCaret = _text.Substring(0, Math.Min(_caretIndex, _text.Length));
         var x = Math.Round(contentRect.X + MeasureTextWidth(textBeforeCaret) - roundedHorizontalOffset);
-        var textY = (DefaultHeight - lineHeight) / 2;
+        var textY = contentRect.Y + (contentRect.Height - lineHeight) / 2;
 
         var compositionWidth = MeasureTextWidth(_imeCompositionString);
         var compositionBgBrush = new SolidColorBrush(Color.FromRgb(60, 60, 80));
@@ -967,7 +998,7 @@ public class AutoCompleteBox : TextBoxBase, IImeSupport
 
         var roundedHorizontalOffset = Math.Round(_horizontalOffset);
         var x = Math.Round(contentRect.X + MeasureTextWidth(textBeforeCaret) - roundedHorizontalOffset);
-        var textY = (DefaultHeight - lineHeight) / 2;
+        var textY = contentRect.Y + (contentRect.Height - lineHeight) / 2;
 
         Brush caretBrushWithOpacity;
         if (CaretBrush is SolidColorBrush solidBrush)

--- a/src/managed/Jalium.UI.Controls/Border.cs
+++ b/src/managed/Jalium.UI.Controls/Border.cs
@@ -185,57 +185,55 @@ public class Border : FrameworkElement
         var rect = new Rect(RenderSize);
         var border = BorderThickness;
         var cornerRadius = CornerRadius;
+        var borderWidth = Math.Max(border.Left, Math.Max(border.Top, Math.Max(border.Right, border.Bottom)));
+        var halfBorder = borderWidth / 2;
 
         // Draw backdrop effect (if any)
         var backdropEffect = BackdropEffect;
         if (backdropEffect != null && backdropEffect.HasEffect)
         {
-            var effectRect = new Rect(0, 0, rect.Width, rect.Height);
-            dc.DrawBackdropEffect(effectRect, backdropEffect, cornerRadius);
+            dc.DrawBackdropEffect(rect, backdropEffect, cornerRadius);
         }
 
-        // Draw background
+        // Draw background - fill the entire area inside the border
         if (Background != null)
         {
+            // Background fills the area inside the border stroke
             var backgroundRect = new Rect(
-                border.Left / 2,
-                border.Top / 2,
-                Math.Max(0, rect.Width - (border.Left + border.Right) / 2),
-                Math.Max(0, rect.Height - (border.Top + border.Bottom) / 2));
+                halfBorder,
+                halfBorder,
+                Math.Max(0, rect.Width - borderWidth),
+                Math.Max(0, rect.Height - borderWidth));
 
-            if (cornerRadius.TopLeft > 0 || cornerRadius.TopRight > 0 ||
-                cornerRadius.BottomLeft > 0 || cornerRadius.BottomRight > 0)
-            {
-                dc.DrawRoundedRectangle(Background, null, backgroundRect,
-                    cornerRadius.TopLeft, cornerRadius.TopLeft);
-            }
-            else
-            {
-                dc.DrawRectangle(Background, null, backgroundRect);
-            }
+            // Adjust corner radius for inner background
+            var innerRadius = new CornerRadius(
+                Math.Max(0, cornerRadius.TopLeft - halfBorder),
+                Math.Max(0, cornerRadius.TopRight - halfBorder),
+                Math.Max(0, cornerRadius.BottomRight - halfBorder),
+                Math.Max(0, cornerRadius.BottomLeft - halfBorder));
+
+            dc.DrawRoundedRectangle(Background, null, backgroundRect, innerRadius);
         }
 
-        // Draw border
-        if (BorderBrush != null && (border.Left > 0 || border.Top > 0 || border.Right > 0 || border.Bottom > 0))
+        // Draw border - stroke is centered on the edge
+        if (BorderBrush != null && borderWidth > 0)
         {
-            var pen = new Pen(BorderBrush, Math.Max(border.Left, Math.Max(border.Top, Math.Max(border.Right, border.Bottom))));
+            var pen = new Pen(BorderBrush, borderWidth);
 
             var borderRect = new Rect(
-                border.Left / 2,
-                border.Top / 2,
-                Math.Max(0, rect.Width - border.Left / 2 - border.Right / 2),
-                Math.Max(0, rect.Height - border.Top / 2 - border.Bottom / 2));
+                halfBorder,
+                halfBorder,
+                Math.Max(0, rect.Width - borderWidth),
+                Math.Max(0, rect.Height - borderWidth));
 
-            if (cornerRadius.TopLeft > 0 || cornerRadius.TopRight > 0 ||
-                cornerRadius.BottomLeft > 0 || cornerRadius.BottomRight > 0)
-            {
-                dc.DrawRoundedRectangle(null, pen, borderRect,
-                    cornerRadius.TopLeft, cornerRadius.TopLeft);
-            }
-            else
-            {
-                dc.DrawRectangle(null, pen, borderRect);
-            }
+            // Adjust corner radius for border stroke position
+            var strokeRadius = new CornerRadius(
+                Math.Max(0, cornerRadius.TopLeft - halfBorder),
+                Math.Max(0, cornerRadius.TopRight - halfBorder),
+                Math.Max(0, cornerRadius.BottomRight - halfBorder),
+                Math.Max(0, cornerRadius.BottomLeft - halfBorder));
+
+            dc.DrawRoundedRectangle(null, pen, borderRect, strokeRadius);
         }
     }
 

--- a/src/managed/Jalium.UI.Controls/Calendar.cs
+++ b/src/managed/Jalium.UI.Controls/Calendar.cs
@@ -408,33 +408,18 @@ public class Calendar : Control
         var rect = new Rect(RenderSize);
         var padding = Padding;
         var cornerRadius = CornerRadius;
-        var hasCornerRadius = cornerRadius.TopLeft > 0;
 
         // Draw background
         if (Background != null)
         {
-            if (hasCornerRadius)
-            {
-                dc.DrawRoundedRectangle(Background, null, rect, cornerRadius.TopLeft, cornerRadius.TopLeft);
-            }
-            else
-            {
-                dc.DrawRectangle(Background, null, rect);
-            }
+            dc.DrawRoundedRectangle(Background, null, rect, cornerRadius);
         }
 
         // Draw border
         if (BorderBrush != null && BorderThickness.TotalWidth > 0)
         {
             var pen = new Pen(BorderBrush, BorderThickness.Left);
-            if (hasCornerRadius)
-            {
-                dc.DrawRoundedRectangle(null, pen, rect, cornerRadius.TopLeft, cornerRadius.TopLeft);
-            }
-            else
-            {
-                dc.DrawRectangle(null, pen, rect);
-            }
+            dc.DrawRoundedRectangle(null, pen, rect, cornerRadius);
         }
 
         var startX = padding.Left + BorderThickness.Left;

--- a/src/managed/Jalium.UI.Controls/ContextMenu.cs
+++ b/src/managed/Jalium.UI.Controls/ContextMenu.cs
@@ -261,45 +261,23 @@ public class ContextMenu : ItemsControl
 
         var rect = new Rect(RenderSize);
         var cornerRadius = CornerRadius;
-        var hasCornerRadius = cornerRadius.TopLeft > 0;
 
         // Draw shadow (simplified)
         var shadowRect = new Rect(rect.X + 2, rect.Y + 2, rect.Width, rect.Height);
         var shadowBrush = new SolidColorBrush(Color.FromArgb(64, 0, 0, 0));
-        if (hasCornerRadius)
-        {
-            dc.DrawRoundedRectangle(shadowBrush, null, shadowRect, cornerRadius.TopLeft, cornerRadius.TopLeft);
-        }
-        else
-        {
-            dc.DrawRectangle(shadowBrush, null, shadowRect);
-        }
+        dc.DrawRoundedRectangle(shadowBrush, null, shadowRect, cornerRadius);
 
         // Draw background
         if (Background != null)
         {
-            if (hasCornerRadius)
-            {
-                dc.DrawRoundedRectangle(Background, null, rect, cornerRadius.TopLeft, cornerRadius.TopLeft);
-            }
-            else
-            {
-                dc.DrawRectangle(Background, null, rect);
-            }
+            dc.DrawRoundedRectangle(Background, null, rect, cornerRadius);
         }
 
         // Draw border
         if (BorderBrush != null && BorderThickness.TotalWidth > 0)
         {
             var pen = new Pen(BorderBrush, BorderThickness.Left);
-            if (hasCornerRadius)
-            {
-                dc.DrawRoundedRectangle(null, pen, rect, cornerRadius.TopLeft, cornerRadius.TopLeft);
-            }
-            else
-            {
-                dc.DrawRectangle(null, pen, rect);
-            }
+            dc.DrawRoundedRectangle(null, pen, rect, cornerRadius);
         }
     }
 

--- a/src/managed/Jalium.UI.Controls/Control.cs
+++ b/src/managed/Jalium.UI.Controls/Control.cs
@@ -113,6 +113,7 @@ public class Control : FrameworkElement
 
     private FrameworkElement? _templateRoot;
     private bool _templateApplied;
+    private IList<Trigger>? _appliedTemplateTriggers;
 
     #endregion
 
@@ -281,6 +282,20 @@ public class Control : FrameworkElement
                 // This allows RelativeSource FindAncestor bindings to resolve
                 ReactivateBindingsRecursive(_templateRoot);
 
+                // Apply template triggers
+                // Triggers are attached to the templated control (this) but target elements in the template by name
+                if (template.Triggers.Count > 0)
+                {
+                    _appliedTemplateTriggers = template.Triggers;
+                    foreach (var trigger in _appliedTemplateTriggers)
+                    {
+                        // Set the parent template triggers so the trigger can find sibling triggers
+                        // when it needs to re-apply values after deactivation
+                        trigger.ParentTemplateTriggers = _appliedTemplateTriggers;
+                        trigger.Attach(this);
+                    }
+                }
+
                 // Call OnApplyTemplate for derived classes to get template parts
                 OnApplyTemplate();
 
@@ -343,6 +358,17 @@ public class Control : FrameworkElement
 
     private void ClearTemplateContent()
     {
+        // Detach template triggers
+        if (_appliedTemplateTriggers != null)
+        {
+            foreach (var trigger in _appliedTemplateTriggers)
+            {
+                trigger.Detach(this);
+                trigger.ParentTemplateTriggers = null;
+            }
+            _appliedTemplateTriggers = null;
+        }
+
         if (_templateRoot != null)
         {
             RemoveVisualChild(_templateRoot);

--- a/src/managed/Jalium.UI.Controls/DatePicker.cs
+++ b/src/managed/Jalium.UI.Controls/DatePicker.cs
@@ -327,14 +327,7 @@ public class DatePicker : Control
         // Draw background
         if (Background != null)
         {
-            if (hasCornerRadius)
-            {
-                dc.DrawRoundedRectangle(Background, null, inputRect, cornerRadius.TopLeft, cornerRadius.TopLeft);
-            }
-            else
-            {
-                dc.DrawRectangle(Background, null, inputRect);
-            }
+            dc.DrawRoundedRectangle(Background, null, inputRect, cornerRadius);
         }
 
         // Draw border
@@ -342,14 +335,7 @@ public class DatePicker : Control
         if (borderBrush != null && BorderThickness.TotalWidth > 0)
         {
             var pen = new Pen(borderBrush, BorderThickness.Left);
-            if (hasCornerRadius)
-            {
-                dc.DrawRoundedRectangle(null, pen, inputRect, cornerRadius.TopLeft, cornerRadius.TopLeft);
-            }
-            else
-            {
-                dc.DrawRectangle(null, pen, inputRect);
-            }
+            dc.DrawRoundedRectangle(null, pen, inputRect, cornerRadius);
         }
 
         // Draw date text or placeholder

--- a/src/managed/Jalium.UI.Controls/Expander.cs
+++ b/src/managed/Jalium.UI.Controls/Expander.cs
@@ -351,34 +351,18 @@ public class Expander : ContentControl
 
         var rect = new Rect(RenderSize);
         var cornerRadius = CornerRadius;
-        var hasCornerRadius = cornerRadius.TopLeft > 0 || cornerRadius.TopRight > 0 ||
-                              cornerRadius.BottomLeft > 0 || cornerRadius.BottomRight > 0;
 
         // Draw background
         if (Background != null)
         {
-            if (hasCornerRadius)
-            {
-                dc.DrawRoundedRectangle(Background, null, rect, cornerRadius.TopLeft, cornerRadius.TopLeft);
-            }
-            else
-            {
-                dc.DrawRectangle(Background, null, rect);
-            }
+            dc.DrawRoundedRectangle(Background, null, rect, cornerRadius);
         }
 
         // Draw border
         if (BorderBrush != null && BorderThickness.TotalWidth > 0)
         {
             var pen = new Pen(BorderBrush, BorderThickness.Left);
-            if (hasCornerRadius)
-            {
-                dc.DrawRoundedRectangle(null, pen, rect, cornerRadius.TopLeft, cornerRadius.TopLeft);
-            }
-            else
-            {
-                dc.DrawRectangle(null, pen, rect);
-            }
+            dc.DrawRoundedRectangle(null, pen, rect, cornerRadius);
         }
 
         // Draw header

--- a/src/managed/Jalium.UI.Controls/GroupBox.cs
+++ b/src/managed/Jalium.UI.Controls/GroupBox.cs
@@ -185,7 +185,6 @@ public class GroupBox : ContentControl
         var headerSize = MeasureHeader(RenderSize);
         var headerTextHeight = headerSize.Height;
         var cornerRadius = CornerRadius;
-        var hasCornerRadius = cornerRadius.TopLeft > 0;
 
         // Calculate the border rect (starts at half header height)
         var borderRect = new Rect(0, headerTextHeight / 2, rect.Width, rect.Height - headerTextHeight / 2);
@@ -193,14 +192,7 @@ public class GroupBox : ContentControl
         // Draw background
         if (Background != null)
         {
-            if (hasCornerRadius)
-            {
-                dc.DrawRoundedRectangle(Background, null, borderRect, cornerRadius.TopLeft, cornerRadius.TopLeft);
-            }
-            else
-            {
-                dc.DrawRectangle(Background, null, borderRect);
-            }
+            dc.DrawRoundedRectangle(Background, null, borderRect, cornerRadius);
         }
 
         // Draw border (with gap for header)
@@ -232,14 +224,7 @@ public class GroupBox : ContentControl
             else
             {
                 // Draw full border
-                if (hasCornerRadius)
-                {
-                    dc.DrawRoundedRectangle(null, pen, borderRect, cornerRadius.TopLeft, cornerRadius.TopLeft);
-                }
-                else
-                {
-                    dc.DrawRectangle(null, pen, borderRect);
-                }
+                dc.DrawRoundedRectangle(null, pen, borderRect, cornerRadius);
             }
         }
 

--- a/src/managed/Jalium.UI.Controls/HyperlinkButton.cs
+++ b/src/managed/Jalium.UI.Controls/HyperlinkButton.cs
@@ -3,6 +3,8 @@ using Jalium.UI.Input;
 using Jalium.UI.Interop;
 using Jalium.UI.Media;
 
+using static Jalium.UI.Cursors;
+
 namespace Jalium.UI.Controls;
 
 /// <summary>
@@ -74,7 +76,7 @@ public class HyperlinkButton : ButtonBase
         Background = null;
         Padding = new Thickness(0);
         BorderThickness = new Thickness(0);
-        // Note: Cursor support will be added when the base class supports it
+        Cursor = Hand; // Hand cursor for clickable hyperlinks
     }
 
     #endregion
@@ -140,6 +142,13 @@ public class HyperlinkButton : ButtonBase
     /// <inheritdoc />
     protected override Size MeasureOverride(Size availableSize)
     {
+        // If using template, delegate to base class which handles template root
+        if (Template != null)
+        {
+            return base.MeasureOverride(availableSize);
+        }
+
+        // Direct rendering fallback when no template
         var padding = Padding;
 
         if (Content is string text)
@@ -164,6 +173,19 @@ public class HyperlinkButton : ButtonBase
         return new Size(padding.TotalWidth, padding.TotalHeight);
     }
 
+    /// <inheritdoc />
+    protected override Size ArrangeOverride(Size finalSize)
+    {
+        // If using template, delegate to base class
+        if (Template != null)
+        {
+            return base.ArrangeOverride(finalSize);
+        }
+
+        // Direct rendering fallback
+        return base.ArrangeOverride(finalSize);
+    }
+
     #endregion
 
     #region Rendering
@@ -172,7 +194,7 @@ public class HyperlinkButton : ButtonBase
     protected override void OnRender(object drawingContext)
     {
         // If using template, let the template handle rendering
-        if (_underlineBorder != null)
+        if (Template != null)
         {
             return;
         }

--- a/src/managed/Jalium.UI.Controls/InfoBar.cs
+++ b/src/managed/Jalium.UI.Controls/InfoBar.cs
@@ -295,34 +295,19 @@ public class InfoBar : ContentControl
         var rect = new Rect(RenderSize);
         var padding = Padding;
         var cornerRadius = CornerRadius;
-        var hasCornerRadius = cornerRadius.TopLeft > 0;
 
         // Get severity colors
         var (bgColor, fgColor, iconColor) = GetSeverityColors();
 
         // Draw background
         var bgBrush = Background ?? new SolidColorBrush(bgColor);
-        if (hasCornerRadius)
-        {
-            dc.DrawRoundedRectangle(bgBrush, null, rect, cornerRadius.TopLeft, cornerRadius.TopLeft);
-        }
-        else
-        {
-            dc.DrawRectangle(bgBrush, null, rect);
-        }
+        dc.DrawRoundedRectangle(bgBrush, null, rect, cornerRadius);
 
-        // Draw left accent bar
+        // Draw left accent bar (only left corners have radius)
         var accentRect = new Rect(0, 0, 4, rect.Height);
         var accentBrush = new SolidColorBrush(iconColor);
-        if (hasCornerRadius)
-        {
-            // Clip to corner radius on left side
-            dc.DrawRoundedRectangle(accentBrush, null, accentRect, cornerRadius.TopLeft, 0);
-        }
-        else
-        {
-            dc.DrawRectangle(accentBrush, null, accentRect);
-        }
+        var accentCornerRadius = new CornerRadius(cornerRadius.TopLeft, 0, 0, cornerRadius.BottomLeft);
+        dc.DrawRoundedRectangle(accentBrush, null, accentRect, accentCornerRadius);
 
         var currentX = padding.Left + 4; // After accent bar
 

--- a/src/managed/Jalium.UI.Controls/NumberBox.cs
+++ b/src/managed/Jalium.UI.Controls/NumberBox.cs
@@ -38,6 +38,12 @@ public class NumberBox : TextBoxBase, IImeSupport
     private bool _isUpButtonPressed;
     private bool _isDownButtonPressed;
 
+    // Template parts
+    private RepeatButton? _upSpinButton;
+    private RepeatButton? _downSpinButton;
+    private Border? _partContentHost;
+    private Grid? _layoutRoot;
+
     // Edit state
     private bool _isEditing;
     private bool _isUpdatingValue;
@@ -298,13 +304,6 @@ public class NumberBox : TextBoxBase, IImeSupport
     public NumberBox()
     {
         // Dark theme appearance
-        Background = new SolidColorBrush(Color.FromRgb(45, 45, 45));
-        BorderBrush = new SolidColorBrush(Color.FromRgb(100, 100, 100));
-        Foreground = new SolidColorBrush(Color.White);
-        BorderThickness = new Thickness(1);
-        Padding = new Thickness(8, 4, 8, 4);
-        CornerRadius = new CornerRadius(4);
-        FontSize = 14;
         Height = DefaultHeight;
 
         // Set IBeam cursor for text input
@@ -318,6 +317,201 @@ public class NumberBox : TextBoxBase, IImeSupport
         // Subscribe to focus events
         AddHandler(GotKeyboardFocusEvent, new RoutedEventHandler(OnGotFocusHandler));
         AddHandler(LostKeyboardFocusEvent, new RoutedEventHandler(OnLostFocusHandler));
+
+        // Subscribe to preview mouse events for direct spin button handling
+        // This ensures spin buttons work even if event routing has issues
+        AddHandler(PreviewMouseDownEvent, new RoutedEventHandler(OnPreviewMouseDownHandler));
+        AddHandler(PreviewMouseUpEvent, new RoutedEventHandler(OnPreviewMouseUpHandler));
+    }
+
+    private RepeatButton? _pressedSpinButton;
+
+    private void OnPreviewMouseDownHandler(object sender, RoutedEventArgs e)
+    {
+        if (!IsEnabled || SpinButtonPlacementMode == NumberBoxSpinButtonPlacementMode.Hidden)
+            return;
+
+        if (e is MouseButtonEventArgs mouseArgs && mouseArgs.ChangedButton == MouseButton.Left)
+        {
+            var position = mouseArgs.GetPosition(this);
+
+            // Check if click is in the spin button area
+            var spinAction = GetSpinActionAtPosition(position);
+            if (spinAction != SpinAction.None)
+            {
+                _currentSpinAction = spinAction;
+
+                // Set pressed state on the button if available (for visual feedback)
+                var hitButton = spinAction == SpinAction.Up ? _upSpinButton : _downSpinButton;
+                if (hitButton != null)
+                {
+                    _pressedSpinButton = hitButton;
+                    hitButton.SetIsPressed(true);
+                }
+
+                CaptureMouse();
+
+                // Fire the initial action immediately
+                if (spinAction == SpinAction.Up)
+                {
+                    StepUp();
+                }
+                else
+                {
+                    StepDown();
+                }
+
+                // Update text display even if in editing mode
+                _text = FormatValue(Value);
+                _caretIndex = _text.Length;
+                _selectionLength = 0;
+
+                // Force visual update
+                InvalidateVisual();
+                e.Handled = true;
+            }
+        }
+    }
+
+    private void OnPreviewMouseUpHandler(object sender, RoutedEventArgs e)
+    {
+        if (_currentSpinAction == SpinAction.None)
+            return;
+
+        if (e is MouseButtonEventArgs mouseArgs && mouseArgs.ChangedButton == MouseButton.Left)
+        {
+            // Reset button state
+            if (_pressedSpinButton != null)
+            {
+                _pressedSpinButton.SetIsPressed(false);
+                _pressedSpinButton = null;
+            }
+
+            ReleaseMouseCapture();
+            _currentSpinAction = SpinAction.None;
+            InvalidateVisual();
+            e.Handled = true;
+        }
+    }
+
+    private enum SpinAction { None, Up, Down }
+    private SpinAction _currentSpinAction = SpinAction.None;
+
+    private SpinAction GetSpinActionAtPosition(Point position)
+    {
+        // The spin buttons are in a 32px wide column on the right side
+        var spinButtonAreaLeft = RenderSize.Width - SpinButtonWidth;
+
+        // Check if click is in the spin button column
+        if (position.X < spinButtonAreaLeft || position.X > RenderSize.Width)
+            return SpinAction.None;
+
+        if (position.Y < 0 || position.Y > RenderSize.Height)
+            return SpinAction.None;
+
+        // Determine which button based on Y position (top half = up, bottom half = down)
+        var midY = RenderSize.Height / 2;
+
+        return position.Y < midY ? SpinAction.Up : SpinAction.Down;
+    }
+
+    /// <inheritdoc />
+    protected override void OnLostMouseCapture()
+    {
+        base.OnLostMouseCapture();
+
+        // Reset spin button state if we lose capture unexpectedly
+        if (_pressedSpinButton != null)
+        {
+            _pressedSpinButton.SetIsPressed(false);
+            _pressedSpinButton = null;
+        }
+        _currentSpinAction = SpinAction.None;
+    }
+
+    /// <inheritdoc />
+    protected override void OnApplyTemplate()
+    {
+        // Detach previous handlers
+        if (_upSpinButton != null)
+        {
+            _upSpinButton.Click -= OnUpButtonClick;
+        }
+        if (_downSpinButton != null)
+        {
+            _downSpinButton.Click -= OnDownButtonClick;
+        }
+
+        base.OnApplyTemplate();
+
+        // Get template parts
+        _layoutRoot = GetTemplateChild("PART_LayoutRoot") as Grid;
+        _partContentHost = GetTemplateChild("PART_ContentHost") as Border;
+        _upSpinButton = GetTemplateChild("PART_UpSpinButton") as RepeatButton;
+        _downSpinButton = GetTemplateChild("PART_DownSpinButton") as RepeatButton;
+
+        // Update corner radii based on NumberBox.CornerRadius
+        UpdateTemplateCornerRadii();
+
+        // Attach handlers
+        if (_upSpinButton != null)
+        {
+            _upSpinButton.Click += OnUpButtonClick;
+        }
+        if (_downSpinButton != null)
+        {
+            _downSpinButton.Click += OnDownButtonClick;
+        }
+    }
+
+    /// <summary>
+    /// Updates the corner radii of template parts based on the control's CornerRadius.
+    /// </summary>
+    private void UpdateTemplateCornerRadii()
+    {
+        var radius = CornerRadius;
+
+        // PART_ContentHost: left corners only (TopLeft, 0, 0, BottomLeft)
+        if (_partContentHost != null)
+        {
+            _partContentHost.CornerRadius = new CornerRadius(radius.TopLeft, 0, 0, radius.BottomLeft);
+        }
+
+        // PART_UpSpinButton: top-right corner only (0, TopRight, 0, 0)
+        if (_upSpinButton != null)
+        {
+            _upSpinButton.CornerRadius = new CornerRadius(0, radius.TopRight, 0, 0);
+            _upSpinButton.BorderThickness = new Thickness(BorderThickness.Left, 0, 0, 0);
+        }
+
+        // PART_DownSpinButton: bottom-right corner only (0, 0, BottomRight, 0)
+        if (_downSpinButton != null)
+        {
+            _downSpinButton.CornerRadius = new CornerRadius(0, 0, radius.BottomRight, 0);
+            _downSpinButton.BorderThickness = new Thickness(0, 0, BorderThickness.Right, 0);
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void OnPropertyChanged(DependencyPropertyChangedEventArgs e)
+    {
+        base.OnPropertyChanged(e);
+
+        // Update template parts when CornerRadius changes
+        if (e.Property == CornerRadiusProperty)
+        {
+            UpdateTemplateCornerRadii();
+        }
+    }
+
+    private void OnUpButtonClick(object sender, RoutedEventArgs e)
+    {
+        StepUp();
+    }
+
+    private void OnDownButtonClick(object sender, RoutedEventArgs e)
+    {
+        StepDown();
     }
 
     private void OnGotFocusHandler(object sender, RoutedEventArgs e)
@@ -805,6 +999,13 @@ public class NumberBox : TextBoxBase, IImeSupport
     /// <inheritdoc />
     protected override Size MeasureOverride(Size availableSize)
     {
+        // If using template, delegate to base class which handles template root
+        if (Template != null)
+        {
+            return base.MeasureOverride(availableSize);
+        }
+
+        // Direct rendering mode
         var padding = Padding;
         var border = BorderThickness;
         var headerHeight = 0.0;
@@ -820,6 +1021,13 @@ public class NumberBox : TextBoxBase, IImeSupport
         var height = DefaultHeight + headerHeight;
 
         return new Size(width, height);
+    }
+
+    /// <inheritdoc />
+    internal override Size MeasureTextContent(Size availableSize)
+    {
+        var lineHeight = Math.Round(GetLineHeight());
+        return new Size(availableSize.Width, Math.Min(lineHeight, availableSize.Height));
     }
 
     #endregion
@@ -840,7 +1048,7 @@ public class NumberBox : TextBoxBase, IImeSupport
         var headerHeight = 0.0;
         var lineHeight = Math.Round(GetLineHeight());
 
-        // Draw header
+        // Draw header (always draw, regardless of template mode)
         if (Header is string headerText && Foreground != null)
         {
             var headerFormatted = new FormattedText(headerText, FontFamily ?? "Segoe UI", FontSize > 0 ? FontSize : 14)
@@ -855,35 +1063,23 @@ public class NumberBox : TextBoxBase, IImeSupport
         // Input area rect
         var inputRect = new Rect(0, headerHeight, bounds.Width, bounds.Height - headerHeight);
 
-        // Draw background
-        if (Background != null)
+        // Draw background and border only in direct rendering mode (template provides these)
+        if (!HasContentHost)
         {
-            if (hasCornerRadius)
+            if (Background != null)
             {
-                dc.DrawRoundedRectangle(Background, null, inputRect, cornerRadius.TopLeft, cornerRadius.TopLeft);
+                dc.DrawRoundedRectangle(Background, null, inputRect, cornerRadius);
             }
-            else
+
+            var borderBrush = IsKeyboardFocused ? new SolidColorBrush(Color.FromRgb(0, 120, 212)) : BorderBrush;
+            if (borderBrush != null && border.TotalWidth > 0)
             {
-                dc.DrawRectangle(Background, null, inputRect);
+                var pen = new Pen(borderBrush, border.Left);
+                dc.DrawRoundedRectangle(null, pen, inputRect, cornerRadius);
             }
         }
 
-        // Draw border
-        var borderBrush = IsKeyboardFocused ? new SolidColorBrush(Color.FromRgb(0, 120, 212)) : BorderBrush;
-        if (borderBrush != null && border.TotalWidth > 0)
-        {
-            var pen = new Pen(borderBrush, border.Left);
-            if (hasCornerRadius)
-            {
-                dc.DrawRoundedRectangle(null, pen, inputRect, cornerRadius.TopLeft, cornerRadius.TopLeft);
-            }
-            else
-            {
-                dc.DrawRectangle(null, pen, inputRect);
-            }
-        }
-
-        // Calculate regions
+        // Calculate regions for spin buttons
         var spinButtonWidth = SpinButtonPlacementMode == NumberBoxSpinButtonPlacementMode.Hidden ? 0 : SpinButtonWidth;
         _textRect = new Rect(
             padding.Left,
@@ -891,7 +1087,8 @@ public class NumberBox : TextBoxBase, IImeSupport
             inputRect.Width - spinButtonWidth - padding.Left - padding.Right,
             inputRect.Height - padding.Top - padding.Bottom);
 
-        if (SpinButtonPlacementMode == NumberBoxSpinButtonPlacementMode.Inline)
+        // Draw spin buttons only in direct rendering mode (template provides buttons via PART_*)
+        if (SpinButtonPlacementMode == NumberBoxSpinButtonPlacementMode.Inline && !HasContentHost)
         {
             _upButtonRect = new Rect(inputRect.Right - SpinButtonWidth, inputRect.Top, SpinButtonWidth, inputRect.Height / 2);
             _downButtonRect = new Rect(inputRect.Right - SpinButtonWidth, inputRect.Top + inputRect.Height / 2, SpinButtonWidth, inputRect.Height / 2);
@@ -900,13 +1097,37 @@ public class NumberBox : TextBoxBase, IImeSupport
             DrawSpinButton(dc, _downButtonRect, false);
         }
 
+        // Render text content only in direct rendering mode (content host handles this)
+        if (!HasContentHost)
+        {
+            RenderTextContentCore(dc, _textRect, lineHeight);
+        }
+    }
+
+    /// <inheritdoc />
+    internal override void RenderTextContent(object drawingContext)
+    {
+        if (drawingContext is not DrawingContext dc)
+            return;
+
+        var lineHeight = Math.Round(GetLineHeight());
+        var contentRect = new Rect(0, 0, _textContentSize.Width, _textContentSize.Height);
+
+        RenderTextContentCore(dc, contentRect, lineHeight);
+    }
+
+    /// <summary>
+    /// Core text rendering logic used by both direct rendering and content host modes.
+    /// </summary>
+    private void RenderTextContentCore(DrawingContext dc, Rect contentRect, double lineHeight)
+    {
         // Clip to text area
-        dc.PushClip(new RectangleGeometry(_textRect));
+        dc.PushClip(new RectangleGeometry(contentRect));
 
         // Draw selection background
         if (_selectionLength > 0 && IsKeyboardFocused)
         {
-            DrawSelection(dc, _textRect, lineHeight);
+            DrawSelection(dc, contentRect, lineHeight);
         }
 
         // Draw text or placeholder
@@ -918,8 +1139,8 @@ public class NumberBox : TextBoxBase, IImeSupport
                 Foreground = new SolidColorBrush(Color.FromRgb(128, 128, 128))
             };
             TextMeasurement.MeasureText(placeholderFormatted);
-            var textY = _textRect.Top + (_textRect.Height - placeholderFormatted.Height) / 2;
-            dc.DrawText(placeholderFormatted, new Point(_textRect.Left - Math.Round(_horizontalOffset), textY));
+            var textY = contentRect.Top + (contentRect.Height - placeholderFormatted.Height) / 2;
+            dc.DrawText(placeholderFormatted, new Point(contentRect.Left - Math.Round(_horizontalOffset), textY));
         }
         else if (!string.IsNullOrEmpty(displayText))
         {
@@ -928,20 +1149,20 @@ public class NumberBox : TextBoxBase, IImeSupport
                 Foreground = Foreground ?? new SolidColorBrush(Color.White)
             };
             TextMeasurement.MeasureText(valueFormatted);
-            var textY = _textRect.Top + (_textRect.Height - valueFormatted.Height) / 2;
-            dc.DrawText(valueFormatted, new Point(_textRect.Left - Math.Round(_horizontalOffset), textY));
+            var textY = contentRect.Top + (contentRect.Height - valueFormatted.Height) / 2;
+            dc.DrawText(valueFormatted, new Point(contentRect.Left - Math.Round(_horizontalOffset), textY));
         }
 
         // Draw IME composition
         if (_isImeComposing && !string.IsNullOrEmpty(_imeCompositionString))
         {
-            DrawImeComposition(dc, _textRect, lineHeight);
+            DrawImeComposition(dc, contentRect, lineHeight);
         }
 
         // Draw caret
         if (IsFocused && !IsReadOnly)
         {
-            DrawCaret(dc, _textRect, lineHeight);
+            DrawCaret(dc, contentRect, lineHeight);
         }
 
         dc.Pop(); // Pop clip

--- a/src/managed/Jalium.UI.Controls/PasswordBox.cs
+++ b/src/managed/Jalium.UI.Controls/PasswordBox.cs
@@ -570,6 +570,7 @@ public class PasswordBox : Control, IImeSupport
     /// <inheritdoc />
     protected override Size MeasureOverride(Size availableSize)
     {
+        // PasswordBox always uses direct rendering (doesn't extend TextBoxBase for security)
         var padding = Padding;
         var border = BorderThickness;
         var lineHeight = Math.Round(GetLineHeight());
@@ -598,33 +599,17 @@ public class PasswordBox : Control, IImeSupport
         var bounds = new Rect(0, 0, RenderSize.Width, RenderSize.Height);
         var lineHeight = Math.Round(GetLineHeight());
 
-        // Draw background
+        // Draw background and border
+        var cornerRadius = CornerRadius;
         if (Background != null)
         {
-            var cornerRadius = CornerRadius;
-            if (cornerRadius.TopLeft > 0)
-            {
-                dc.DrawRoundedRectangle(Background, null, bounds, cornerRadius.TopLeft, cornerRadius.TopLeft);
-            }
-            else
-            {
-                dc.DrawRectangle(Background, null, bounds);
-            }
+            dc.DrawRoundedRectangle(Background, null, bounds, cornerRadius);
         }
 
-        // Draw border
         if (BorderBrush != null && border.Left > 0)
         {
             var borderPen = new Pen(BorderBrush, border.Left);
-            var cornerRadius = CornerRadius;
-            if (cornerRadius.TopLeft > 0)
-            {
-                dc.DrawRoundedRectangle(null, borderPen, bounds, cornerRadius.TopLeft, cornerRadius.TopLeft);
-            }
-            else
-            {
-                dc.DrawRectangle(null, borderPen, bounds);
-            }
+            dc.DrawRoundedRectangle(null, borderPen, bounds, cornerRadius);
         }
 
         // Content area

--- a/src/managed/Jalium.UI.Controls/Primitives/TextBoxContentHost.cs
+++ b/src/managed/Jalium.UI.Controls/Primitives/TextBoxContentHost.cs
@@ -1,0 +1,52 @@
+using Jalium.UI.Media;
+
+namespace Jalium.UI.Controls.Primitives;
+
+/// <summary>
+/// Internal element that renders text content for TextBoxBase controls.
+/// This element is inserted into the PART_ContentHost of the control's template.
+/// Similar to WPF's TextBoxView.
+/// </summary>
+internal class TextBoxContentHost : FrameworkElement
+{
+    private readonly TextBoxBase _owner;
+
+    /// <summary>
+    /// Initializes a new instance of the TextBoxContentHost class.
+    /// </summary>
+    /// <param name="owner">The owning TextBoxBase control.</param>
+    public TextBoxContentHost(TextBoxBase owner)
+    {
+        _owner = owner ?? throw new ArgumentNullException(nameof(owner));
+
+        // This element should be hit-testable so clicks are routed through it
+        IsHitTestVisible = true;
+    }
+
+    /// <summary>
+    /// Gets the owning TextBoxBase control.
+    /// </summary>
+    public TextBoxBase Owner => _owner;
+
+    /// <inheritdoc />
+    protected override Size MeasureOverride(Size availableSize)
+    {
+        // Delegate measurement to the owner
+        return _owner.MeasureTextContent(availableSize);
+    }
+
+    /// <inheritdoc />
+    protected override Size ArrangeOverride(Size finalSize)
+    {
+        // Notify owner of content area size
+        _owner.ArrangeTextContent(finalSize);
+        return finalSize;
+    }
+
+    /// <inheritdoc />
+    protected override void OnRender(object drawingContext)
+    {
+        // Delegate rendering to the owner
+        _owner.RenderTextContent(drawingContext);
+    }
+}

--- a/src/managed/Jalium.UI.Controls/RepeatButton.cs
+++ b/src/managed/Jalium.UI.Controls/RepeatButton.cs
@@ -1,7 +1,4 @@
 using System.Timers;
-using Jalium.UI.Input;
-using Jalium.UI.Interop;
-using Jalium.UI.Media;
 
 namespace Jalium.UI.Controls;
 
@@ -150,108 +147,6 @@ public class RepeatButton : ButtonBase
         if (d is RepeatButton button && button._timer != null && !button._isInDelay)
         {
             button._timer.Interval = (int)(e.NewValue ?? SystemParameters.KeyboardSpeed);
-        }
-    }
-
-    #endregion
-
-    #region Layout
-
-    /// <inheritdoc />
-    protected override Size MeasureOverride(Size availableSize)
-    {
-        var padding = Padding;
-        var border = BorderThickness;
-        var contentAvailable = new Size(
-            Math.Max(0, availableSize.Width - padding.TotalWidth - border.TotalWidth),
-            Math.Max(0, availableSize.Height - padding.TotalHeight - border.TotalHeight));
-
-        var contentSize = MeasureContent(contentAvailable);
-
-        return new Size(
-            contentSize.Width + padding.TotalWidth + border.TotalWidth,
-            contentSize.Height + padding.TotalHeight + border.TotalHeight);
-    }
-
-    private Size MeasureContent(Size availableSize)
-    {
-        if (Content is string text)
-        {
-            var fontFamily = FontFamily ?? "Segoe UI";
-            var fontSize = FontSize > 0 ? FontSize : 14;
-            var formattedText = new FormattedText(text, fontFamily, fontSize);
-            TextMeasurement.MeasureText(formattedText);
-            return new Size(formattedText.Width, formattedText.Height);
-        }
-
-        if (Content is UIElement element)
-        {
-            element.Measure(availableSize);
-            return element.DesiredSize;
-        }
-
-        return new Size(0, 0);
-    }
-
-    #endregion
-
-    #region Rendering
-
-    /// <inheritdoc />
-    protected override void OnRender(object drawingContext)
-    {
-        if (drawingContext is not DrawingContext dc)
-            return;
-
-        var rect = new Rect(RenderSize);
-        var cornerRadius = CornerRadius;
-        var hasCornerRadius = cornerRadius.TopLeft > 0 || cornerRadius.TopRight > 0 ||
-                              cornerRadius.BottomLeft > 0 || cornerRadius.BottomRight > 0;
-
-        var bgBrush = Background;
-        var borderBrush = BorderBrush;
-        var fgBrush = Foreground;
-
-        // Draw background
-        if (bgBrush != null)
-        {
-            if (hasCornerRadius)
-            {
-                dc.DrawRoundedRectangle(bgBrush, null, rect, cornerRadius.TopLeft, cornerRadius.TopLeft);
-            }
-            else
-            {
-                dc.DrawRectangle(bgBrush, null, rect);
-            }
-        }
-
-        // Draw border
-        if (borderBrush != null && BorderThickness.TotalWidth > 0)
-        {
-            var pen = new Pen(borderBrush, BorderThickness.Left);
-            if (hasCornerRadius)
-            {
-                dc.DrawRoundedRectangle(null, pen, rect, cornerRadius.TopLeft, cornerRadius.TopLeft);
-            }
-            else
-            {
-                dc.DrawRectangle(null, pen, rect);
-            }
-        }
-
-        // Draw content
-        if (Content is string text && fgBrush != null)
-        {
-            var formattedText = new FormattedText(text, FontFamily, FontSize)
-            {
-                Foreground = fgBrush
-            };
-
-            TextMeasurement.MeasureText(formattedText);
-            var textX = (rect.Width - formattedText.Width) / 2;
-            var textY = (rect.Height - formattedText.Height) / 2;
-
-            dc.DrawText(formattedText, new Point(textX, textY));
         }
     }
 

--- a/src/managed/Jalium.UI.Controls/Shapes/Path.cs
+++ b/src/managed/Jalium.UI.Controls/Shapes/Path.cs
@@ -61,18 +61,38 @@ public class Path : Shape
             return naturalSize;
         }
 
-        // For other stretch modes, prefer explicit Width/Height if set
-        var width = double.IsNaN(Width) ? availableSize.Width : Width;
-        var height = double.IsNaN(Height) ? availableSize.Height : Height;
+        // Check which dimensions are explicitly set
+        var hasExplicitWidth = !double.IsNaN(Width);
+        var hasExplicitHeight = !double.IsNaN(Height);
 
-        // If available size is infinite, fall back to natural geometry size
-        if (double.IsPositiveInfinity(width))
+        // Calculate aspect ratio from natural geometry size
+        var aspectRatio = naturalSize.Height > 0 ? naturalSize.Width / naturalSize.Height : 1.0;
+
+        double width, height;
+
+        if (hasExplicitWidth && hasExplicitHeight)
         {
-            width = naturalSize.Width;
+            // Both dimensions set - use them directly
+            width = Width;
+            height = Height;
         }
-        if (double.IsPositiveInfinity(height))
+        else if (hasExplicitWidth && !hasExplicitHeight)
         {
-            height = naturalSize.Height;
+            // Only Width set - calculate Height based on aspect ratio
+            width = Width;
+            height = aspectRatio > 0 ? width / aspectRatio : width;
+        }
+        else if (!hasExplicitWidth && hasExplicitHeight)
+        {
+            // Only Height set - calculate Width based on aspect ratio
+            height = Height;
+            width = height * aspectRatio;
+        }
+        else
+        {
+            // Neither dimension set - use available size or natural size
+            width = double.IsPositiveInfinity(availableSize.Width) ? naturalSize.Width : availableSize.Width;
+            height = double.IsPositiveInfinity(availableSize.Height) ? naturalSize.Height : availableSize.Height;
         }
 
         return new Size(width, height);

--- a/src/managed/Jalium.UI.Controls/Splitter.cs
+++ b/src/managed/Jalium.UI.Controls/Splitter.cs
@@ -1,6 +1,8 @@
 using Jalium.UI.Input;
 using Jalium.UI.Media;
 
+using static Jalium.UI.Cursors;
+
 namespace Jalium.UI.Controls;
 
 /// <summary>
@@ -134,6 +136,7 @@ public class GridSplitter : Control
         Background = new SolidColorBrush(Color.FromRgb(60, 60, 60));
         HorizontalAlignment = HorizontalAlignment.Stretch;
         VerticalAlignment = VerticalAlignment.Stretch;
+        Cursor = SizeWE; // Default to horizontal resize cursor
 
         AddHandler(MouseDownEvent, new RoutedEventHandler(OnMouseDownHandler));
         AddHandler(MouseUpEvent, new RoutedEventHandler(OnMouseUpHandler));
@@ -416,6 +419,16 @@ public class GridSplitter : Control
         }
     }
 
+    /// <inheritdoc />
+    protected override Size ArrangeOverride(Size finalSize)
+    {
+        var result = base.ArrangeOverride(finalSize);
+        // Update cursor after layout when we know the actual dimensions
+        // (needed for Auto resize direction which depends on dimensions)
+        UpdateCursor();
+        return result;
+    }
+
     #endregion
 
     #region Rendering
@@ -484,9 +497,21 @@ public class GridSplitter : Control
     {
         if (d is GridSplitter splitter)
         {
+            splitter.UpdateCursor();
             splitter.InvalidateMeasure();
             splitter.InvalidateVisual();
         }
+    }
+
+    /// <summary>
+    /// Updates the cursor based on the effective resize direction.
+    /// </summary>
+    private void UpdateCursor()
+    {
+        var direction = GetEffectiveResizeDirection();
+        Cursor = direction == GridResizeDirection.Columns
+            ? SizeWE    // Horizontal resize (left-right)
+            : SizeNS;   // Vertical resize (up-down)
     }
 
     #endregion

--- a/src/managed/Jalium.UI.Controls/TextBox.cs
+++ b/src/managed/Jalium.UI.Controls/TextBox.cs
@@ -695,6 +695,14 @@ public class TextBox : TextBoxBase, IImeSupport
     /// <inheritdoc />
     protected override Size MeasureOverride(Size availableSize)
     {
+        // If using template, delegate to base class which handles template root
+        // The TextBoxContentHost will call MeasureTextContent for the text area
+        if (Template != null)
+        {
+            return base.MeasureOverride(availableSize);
+        }
+
+        // Direct rendering mode - calculate size based on content
         var padding = Padding;
         var border = BorderThickness;
         // Round line height for consistent layout
@@ -726,6 +734,26 @@ public class TextBox : TextBoxBase, IImeSupport
             Math.Min(desiredHeight, availableSize.Height));
     }
 
+    /// <inheritdoc />
+    internal override Size MeasureTextContent(Size availableSize)
+    {
+        EnsureLinesValid();
+
+        var lineHeight = Math.Round(GetLineHeight());
+
+        double textHeight;
+        if (AcceptsReturn)
+        {
+            textHeight = Math.Max(1, _lines.Count) * lineHeight;
+        }
+        else
+        {
+            textHeight = lineHeight;
+        }
+
+        return new Size(availableSize.Width, Math.Min(textHeight, availableSize.Height));
+    }
+
     #endregion
 
     #region Rendering
@@ -735,53 +763,71 @@ public class TextBox : TextBoxBase, IImeSupport
     {
         base.OnRender(drawingContext);
 
+        // If using content host, text rendering is handled by TextBoxContentHost
+        if (HasContentHost)
+            return;
+
+        // Direct rendering mode
         if (drawingContext is not DrawingContext dc)
             return;
 
         var border = BorderThickness;
         var padding = Padding;
         var bounds = new Rect(0, 0, RenderSize.Width, RenderSize.Height);
-        // Round line height to prevent sub-pixel jittering from floating-point accumulation
         var lineHeight = Math.Round(GetLineHeight());
 
         EnsureLinesValid();
 
-        // Draw background
+        // Draw background and border (no template = direct rendering)
+        var cornerRadius = CornerRadius;
         if (Background != null)
         {
-            var cornerRadius = CornerRadius;
-            if (cornerRadius.TopLeft > 0)
-            {
-                dc.DrawRoundedRectangle(Background, null, bounds, cornerRadius.TopLeft, cornerRadius.TopLeft);
-            }
-            else
-            {
-                dc.DrawRectangle(Background, null, bounds);
-            }
+            dc.DrawRoundedRectangle(Background, null, bounds, cornerRadius);
         }
 
-        // Draw border
         if (BorderBrush != null && border.Left > 0)
         {
             var borderPen = new Pen(BorderBrush, border.Left);
-            var cornerRadius = CornerRadius;
-            if (cornerRadius.TopLeft > 0)
-            {
-                dc.DrawRoundedRectangle(null, borderPen, bounds, cornerRadius.TopLeft, cornerRadius.TopLeft);
-            }
-            else
-            {
-                dc.DrawRectangle(null, borderPen, bounds);
-            }
+            dc.DrawRoundedRectangle(null, borderPen, bounds, cornerRadius);
         }
 
-        // Content area - round to pixel boundaries to prevent sub-pixel jittering
+        // Content area
         var contentRect = new Rect(
             Math.Round(border.Left + padding.Left),
             Math.Round(border.Top + padding.Top),
             Math.Max(0, Math.Round(bounds.Width - border.Left - border.Right - padding.Left - padding.Right)),
             Math.Max(0, Math.Round(bounds.Height - border.Top - border.Bottom - padding.Top - padding.Bottom)));
 
+        // Render text content
+        RenderTextContentCore(dc, contentRect, lineHeight);
+
+        // Draw focus indicator
+        if (IsKeyboardFocused)
+        {
+            var focusPen = new Pen(new SolidColorBrush(Color.FromRgb(0, 120, 212)), 1);
+            dc.DrawRoundedRectangle(null, focusPen, bounds, cornerRadius);
+        }
+    }
+
+    /// <inheritdoc />
+    internal override void RenderTextContent(object drawingContext)
+    {
+        if (drawingContext is not DrawingContext dc)
+            return;
+
+        EnsureLinesValid();
+
+        var lineHeight = Math.Round(GetLineHeight());
+        var contentRect = new Rect(0, 0, _textContentSize.Width, _textContentSize.Height);
+
+        RenderTextContentCore(dc, contentRect, lineHeight);
+    }
+
+    /// <summary>
+    /// Core text rendering logic used by both direct rendering and content host modes.
+    /// </summary>
+    private void RenderTextContentCore(DrawingContext dc, Rect contentRect, double lineHeight)
+    {
         // Clip to content area
         dc.PushClip(new RectangleGeometry(contentRect));
 
@@ -793,16 +839,14 @@ public class TextBox : TextBoxBase, IImeSupport
             DrawSelection(dc, contentRect, lineHeight);
         }
 
-        // Round scroll offsets for consistent rendering
-        var roundedHorizontalOffset = Math.Round(_horizontalOffset);
-        var roundedVerticalOffset = Math.Round(_verticalOffset);
-
         // Draw text or placeholder
         if (string.IsNullOrEmpty(text))
         {
             if (!string.IsNullOrEmpty(Placeholder))
             {
                 var placeholderBrush = new SolidColorBrush(Color.FromRgb(128, 128, 128));
+                var roundedHorizontalOffset = Math.Round(_horizontalOffset);
+                var roundedVerticalOffset = Math.Round(_verticalOffset);
                 var formattedPlaceholder = new FormattedText(Placeholder, FontFamily ?? "Segoe UI", FontSize)
                 {
                     Foreground = placeholderBrush,
@@ -829,28 +873,13 @@ public class TextBox : TextBoxBase, IImeSupport
             DrawImeComposition(dc, contentRect, lineHeight);
         }
 
-        // Draw caret - always call DrawCaret when focused to keep animation running
-        // DrawCaret will internally check opacity and skip drawing when hidden
+        // Draw caret
         if (IsFocused && !IsReadOnly)
         {
             DrawCaret(dc, contentRect, lineHeight);
         }
 
         dc.Pop(); // Pop clip
-
-        // Draw focus indicator
-        if (IsKeyboardFocused)
-        {
-            var focusPen = new Pen(new SolidColorBrush(Color.FromRgb(0, 120, 212)), 1);
-            if (CornerRadius.TopLeft > 0)
-            {
-                dc.DrawRoundedRectangle(null, focusPen, bounds, CornerRadius.TopLeft, CornerRadius.TopLeft);
-            }
-            else
-            {
-                dc.DrawRectangle(null, focusPen, bounds);
-            }
-        }
     }
 
     private void DrawText(DrawingContext dc, Rect contentRect, double lineHeight)

--- a/src/managed/Jalium.UI.Controls/TextBoxBase.cs
+++ b/src/managed/Jalium.UI.Controls/TextBoxBase.cs
@@ -1,6 +1,9 @@
 using System.Timers;
+using Jalium.UI.Controls.Primitives;
 using Jalium.UI.Input;
 using Jalium.UI.Media;
+
+using static Jalium.UI.Cursors;
 
 namespace Jalium.UI.Controls;
 
@@ -9,6 +12,30 @@ namespace Jalium.UI.Controls;
 /// </summary>
 public abstract class TextBoxBase : Control
 {
+    #region Content Host Fields
+
+    /// <summary>
+    /// The content host element from the template (PART_ContentHost).
+    /// </summary>
+    private FrameworkElement? _contentHost;
+
+    /// <summary>
+    /// The text rendering element inserted into the content host.
+    /// </summary>
+    private TextBoxContentHost? _textBoxContentHost;
+
+    /// <summary>
+    /// The bounds of the content area for text rendering (set by ArrangeTextContent).
+    /// </summary>
+    protected Size _textContentSize;
+
+    /// <summary>
+    /// Whether content host mode is active (template with PART_ContentHost).
+    /// </summary>
+    protected bool HasContentHost => _textBoxContentHost != null;
+
+    #endregion
+
     #region Fields
 
     /// <summary>
@@ -375,6 +402,7 @@ public abstract class TextBoxBase : Control
     protected TextBoxBase()
     {
         Focusable = true;
+        Cursor = IBeam; // Text input cursor for text editing controls
 
         _lastCaretBlink = DateTime.Now;
         _lastClickTime = DateTime.MinValue;
@@ -387,6 +415,123 @@ public abstract class TextBoxBase : Control
         AddHandler(TextInputEvent, new RoutedEventHandler(OnTextInputHandler));
         AddHandler(MouseWheelEvent, new RoutedEventHandler(OnMouseWheelHandler));
     }
+
+    #endregion
+
+    #region Template Handling
+
+    /// <inheritdoc />
+    protected override void OnApplyTemplate()
+    {
+        base.OnApplyTemplate();
+
+        // Clean up previous content host
+        if (_contentHost != null && _textBoxContentHost != null)
+        {
+            RemoveContentHostChild(_contentHost, _textBoxContentHost);
+            _textBoxContentHost = null;
+            _contentHost = null;
+        }
+
+        // Find PART_ContentHost in the template
+        var contentHost = GetTemplateChild("PART_ContentHost") as FrameworkElement;
+        if (contentHost != null)
+        {
+            _contentHost = contentHost;
+
+            // Create the text rendering element
+            _textBoxContentHost = new TextBoxContentHost(this);
+
+            // Insert into the content host
+            AddContentHostChild(_contentHost, _textBoxContentHost);
+        }
+    }
+
+    /// <summary>
+    /// Adds the text rendering element to the content host.
+    /// </summary>
+    private void AddContentHostChild(FrameworkElement host, TextBoxContentHost child)
+    {
+        // Support different container types
+        if (host is Border border)
+        {
+            border.Child = child;
+        }
+        else if (host is ContentControl contentControl)
+        {
+            contentControl.Content = child;
+        }
+        else if (host is ScrollViewer scrollViewer)
+        {
+            scrollViewer.Content = child;
+        }
+        else if (host is Panel panel)
+        {
+            panel.Children.Add(child);
+        }
+    }
+
+    /// <summary>
+    /// Removes the text rendering element from the content host.
+    /// </summary>
+    private void RemoveContentHostChild(FrameworkElement host, TextBoxContentHost child)
+    {
+        if (host is Border border)
+        {
+            if (border.Child == child)
+                border.Child = null;
+        }
+        else if (host is ContentControl contentControl)
+        {
+            if (contentControl.Content == child)
+                contentControl.Content = null;
+        }
+        else if (host is ScrollViewer scrollViewer)
+        {
+            if (scrollViewer.Content == child)
+                scrollViewer.Content = null;
+        }
+        else if (host is Panel panel)
+        {
+            panel.Children.Remove(child);
+        }
+    }
+
+    /// <summary>
+    /// Measures the text content. Called by TextBoxContentHost.
+    /// </summary>
+    internal virtual Size MeasureTextContent(Size availableSize)
+    {
+        // Default implementation - subclasses should override
+        var lineHeight = Math.Round(GetLineHeight());
+        var lineCount = GetLineCount();
+
+        double textHeight;
+        if (lineCount > 1)
+        {
+            textHeight = lineCount * lineHeight;
+        }
+        else
+        {
+            textHeight = lineHeight;
+        }
+
+        return new Size(availableSize.Width, Math.Min(textHeight, availableSize.Height));
+    }
+
+    /// <summary>
+    /// Arranges the text content. Called by TextBoxContentHost.
+    /// </summary>
+    internal virtual void ArrangeTextContent(Size finalSize)
+    {
+        _textContentSize = finalSize;
+    }
+
+    /// <summary>
+    /// Renders the text content. Called by TextBoxContentHost.
+    /// Override in subclasses to implement actual text rendering.
+    /// </summary>
+    internal abstract void RenderTextContent(object drawingContext);
 
     #endregion
 
@@ -1090,6 +1235,10 @@ public abstract class TextBoxBase : Control
     {
         if (!IsEnabled) return;
 
+        // Don't handle clicks that originated from buttons in the template
+        if (e.OriginalSource is DependencyObject source && IsInsideButton(source))
+            return;
+
         if (e is MouseButtonEventArgs mouseArgs && mouseArgs.ChangedButton == MouseButton.Left)
         {
             Focus();
@@ -1163,6 +1312,10 @@ public abstract class TextBoxBase : Control
     {
         if (!IsEnabled) return;
 
+        // Don't handle clicks that originated from buttons in the template
+        if (e.OriginalSource is DependencyObject source && IsInsideButton(source))
+            return;
+
         if (e is MouseButtonEventArgs mouseArgs && mouseArgs.ChangedButton == MouseButton.Left)
         {
             if (_isSelecting)
@@ -1173,6 +1326,22 @@ public abstract class TextBoxBase : Control
 
             e.Handled = true;
         }
+    }
+
+    /// <summary>
+    /// Checks if the given element is inside a ButtonBase control.
+    /// Used to allow clicks on buttons in templates to pass through.
+    /// </summary>
+    private static bool IsInsideButton(DependencyObject element)
+    {
+        var current = element;
+        while (current != null)
+        {
+            if (current is ButtonBase)
+                return true;
+            current = (current as UIElement)?.VisualParent;
+        }
+        return false;
     }
 
     private void OnMouseMoveHandler(object sender, RoutedEventArgs e)

--- a/src/managed/Jalium.UI.Controls/Themes/Controls/Button.jalxaml
+++ b/src/managed/Jalium.UI.Controls/Themes/Controls/Button.jalxaml
@@ -106,25 +106,26 @@
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="Template">
             <ControlTemplate TargetType="HyperlinkButton">
-                <Border Background="{TemplateBinding Background}"
+                <Border Name="RootBorder"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
                         Padding="{TemplateBinding Padding}">
-                    <StackPanel Orientation="Vertical">
-                        <ContentPresenter Name="ContentElement"
-                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+                    <Grid>
+                        <ContentPresenter
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+                        <!-- Underline border at the bottom -->
                         <Border Name="UnderlineBorder"
+                                VerticalAlignment="Bottom"
                                 Height="1"
-                                Background="{TemplateBinding Foreground}"
-                                Margin="0,-1,0,0" />
-                    </StackPanel>
+                                Background="{TemplateBinding Foreground}" />
+                    </Grid>
                 </Border>
             </ControlTemplate>
         </Setter>
 
         <Style.Triggers>
-            <PropertyTrigger Property="IsUnderlined" Value="False">
-                <Setter TargetName="UnderlineBorder" Property="Visibility" Value="Collapsed" />
-            </PropertyTrigger>
             <PropertyTrigger Property="IsMouseOver" Value="True">
                 <Setter Property="Foreground" Value="{StaticResource HyperlinkForegroundHover}" />
             </PropertyTrigger>
@@ -133,6 +134,9 @@
             </PropertyTrigger>
             <PropertyTrigger Property="IsEnabled" Value="False">
                 <Setter Property="Foreground" Value="{StaticResource TextDisabled}" />
+            </PropertyTrigger>
+            <PropertyTrigger Property="IsUnderlined" Value="False">
+                <Setter TargetName="UnderlineBorder" Property="Visibility" Value="Collapsed" />
             </PropertyTrigger>
         </Style.Triggers>
     </Style>

--- a/src/managed/Jalium.UI.Controls/Themes/Controls/TextControls.jalxaml
+++ b/src/managed/Jalium.UI.Controls/Themes/Controls/TextControls.jalxaml
@@ -5,6 +5,8 @@
     <!-- ============================================== -->
     <!-- TextBox Style -->
     <!-- ============================================== -->
+    <!-- Template provides the chrome (background, border). PART_ContentHost is a Border
+         where the control inserts its TextBoxContentHost for text rendering. -->
     <Style TargetType="TextBox">
         <Setter Property="Background" Value="{StaticResource SurfaceBackground}" />
         <Setter Property="Foreground" Value="{StaticResource TextPrimary}" />
@@ -15,13 +17,14 @@
         <Setter Property="CornerRadius" Value="8" />
         <Setter Property="Template">
             <ControlTemplate TargetType="TextBox">
-                <Border Name="BackgroundBorder"
+                <Border Name="OuterBorder"
                         Background="{TemplateBinding Background}"
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
-                        CornerRadius="8">
-                    <ScrollViewer Name="PART_ContentHost"
-                                  Margin="{TemplateBinding Padding}" />
+                        CornerRadius="{TemplateBinding CornerRadius}">
+                    <!-- PART_ContentHost: The control will insert TextBoxContentHost here -->
+                    <Border Name="PART_ContentHost"
+                            Padding="{TemplateBinding Padding}" />
                 </Border>
             </ControlTemplate>
         </Setter>
@@ -51,6 +54,7 @@
     <!-- ============================================== -->
     <!-- PasswordBox Style -->
     <!-- ============================================== -->
+    <!-- PasswordBox uses direct rendering (doesn't extend TextBoxBase for security reasons) -->
     <Style TargetType="PasswordBox">
         <Setter Property="Background" Value="{StaticResource SurfaceBackground}" />
         <Setter Property="Foreground" Value="{StaticResource TextPrimary}" />
@@ -60,18 +64,6 @@
         <Setter Property="FontSize" Value="14" />
         <Setter Property="CornerRadius" Value="8" />
         <Setter Property="PasswordChar" Value="●" />
-        <Setter Property="Template">
-            <ControlTemplate TargetType="PasswordBox">
-                <Border Name="BackgroundBorder"
-                        Background="{TemplateBinding Background}"
-                        BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="{TemplateBinding BorderThickness}"
-                        CornerRadius="8">
-                    <ScrollViewer Name="PART_ContentHost"
-                                  Margin="{TemplateBinding Padding}" />
-                </Border>
-            </ControlTemplate>
-        </Setter>
 
         <Style.Triggers>
             <PropertyTrigger Property="IsMouseOver" Value="True">
@@ -100,37 +92,55 @@
         <Setter Property="CornerRadius" Value="8" />
         <Setter Property="Template">
             <ControlTemplate TargetType="NumberBox">
-                <Border Name="BackgroundBorder"
+                <Border Name="OuterBorder"
                         Background="{TemplateBinding Background}"
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
-                        CornerRadius="8">
-                    <Grid>
+                        CornerRadius="{TemplateBinding CornerRadius}">
+                    <Grid Name="PART_LayoutRoot">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="32" />
                         </Grid.ColumnDefinitions>
-                        <ScrollViewer Name="PART_ContentHost"
-                                      Grid.Column="0"
-                                      Margin="{TemplateBinding Padding}" />
-                        <StackPanel Name="PART_SpinButtons"
-                                    Grid.Column="1"
-                                    Orientation="Vertical"
-                                    VerticalAlignment="Center"
-                                    Margin="0,0,4,0">
-                            <RepeatButton Name="PART_UpButton"
-                                          Content="▲"
-                                          FontSize="8"
-                                          MinWidth="20"
-                                          MinHeight="12"
-                                          Padding="4,2,4,2" />
-                            <RepeatButton Name="PART_DownButton"
-                                          Content="▼"
-                                          FontSize="8"
-                                          MinWidth="20"
-                                          MinHeight="12"
-                                          Padding="4,2,4,2" />
-                        </StackPanel>
+                        <!-- Text content area -->
+                        <Border Name="PART_ContentHost"
+                                Grid.Column="0"
+                                Padding="{TemplateBinding Padding}" />
+                        <!-- Spin buttons stacked vertically -->
+                        <Grid Grid.Column="1">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="*" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
+                            <RepeatButton Name="PART_UpSpinButton"
+                                          Grid.Row="0"
+                                          Background="#3C3C3C"
+                                          BorderThickness="0"
+                                          Padding="0"
+                                          VerticalAlignment="Stretch"
+                                          HorizontalAlignment="Stretch">
+                                <Path Data="M 0,5 L 5,0 L 10,5"
+                                      Stroke="White"
+                                      StrokeThickness="1.5"
+                                      Stretch="None"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center" />
+                            </RepeatButton>
+                            <RepeatButton Name="PART_DownSpinButton"
+                                          Grid.Row="1"
+                                          Background="#3C3C3C"
+                                          BorderThickness="0"
+                                          Padding="0"
+                                          VerticalAlignment="Stretch"
+                                          HorizontalAlignment="Stretch">
+                                <Path Data="M 0,0 L 5,5 L 10,0"
+                                      Stroke="White"
+                                      StrokeThickness="1.5"
+                                      Stretch="None"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center" />
+                            </RepeatButton>
+                        </Grid>
                     </Grid>
                 </Border>
             </ControlTemplate>
@@ -146,9 +156,6 @@
             <PropertyTrigger Property="IsEnabled" Value="False">
                 <Setter Property="Background" Value="{StaticResource ControlBackgroundDisabled}" />
                 <Setter Property="Foreground" Value="{StaticResource TextDisabled}" />
-            </PropertyTrigger>
-            <PropertyTrigger Property="SpinButtonPlacementMode" Value="Hidden">
-                <Setter TargetName="PART_SpinButtons" Property="Visibility" Value="Collapsed" />
             </PropertyTrigger>
         </Style.Triggers>
     </Style>
@@ -167,32 +174,14 @@
         <Setter Property="MaxDropDownHeight" Value="200" />
         <Setter Property="Template">
             <ControlTemplate TargetType="AutoCompleteBox">
-                <Grid>
-                    <Border Name="BackgroundBorder"
-                            Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            CornerRadius="8">
-                        <ScrollViewer Name="PART_ContentHost"
-                                      Margin="{TemplateBinding Padding}" />
-                    </Border>
-                    <Popup Name="PART_Popup"
-                           PlacementTarget="{TemplateBinding}"
-                           Placement="Bottom"
-                           IsOpen="{TemplateBinding IsDropDownOpen}"
-                           StaysOpen="False"
-                           MaxHeight="{TemplateBinding MaxDropDownHeight}">
-                        <Border Background="{StaticResource SurfaceBackground}"
-                                BorderBrush="{StaticResource ControlBorder}"
-                                BorderThickness="1"
-                                CornerRadius="8">
-                            <ListBox Name="PART_SelectionAdapter"
-                                     ItemsSource="{TemplateBinding FilteredItems}"
-                                     Background="Transparent"
-                                     BorderThickness="0" />
-                        </Border>
-                    </Popup>
-                </Grid>
+                <Border Name="OuterBorder"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        CornerRadius="{TemplateBinding CornerRadius}">
+                    <Border Name="PART_ContentHost"
+                            Padding="{TemplateBinding Padding}" />
+                </Border>
             </ControlTemplate>
         </Setter>
 

--- a/src/managed/Jalium.UI.Controls/Themes/Controls/TitleBar.jalxaml
+++ b/src/managed/Jalium.UI.Controls/Themes/Controls/TitleBar.jalxaml
@@ -26,12 +26,14 @@
             <ControlTemplate TargetType="TitleBarButton">
                 <Border Name="PART_RootBorder"
                         Background="{TemplateBinding Background}">
-                    <Grid HorizontalAlignment="Center" VerticalAlignment="Center">
+                    <Grid Width="10" Height="10" HorizontalAlignment="Center" VerticalAlignment="Center">
                         <!-- Minimize Glyph (horizontal line) -->
                         <Path Name="MinimizeGlyph"
-                              Data="M 0,5 L 10,5"
+                              Data="M 0,0 L 10,0"
                               Stroke="{TemplateBinding Foreground}"
                               StrokeThickness="1"
+                              Stretch="None"
+                              VerticalAlignment="Center"
                               Visibility="Collapsed" />
 
                         <!-- Maximize Glyph (square) -->
@@ -39,20 +41,21 @@
                               Data="M 0,0 L 10,0 L 10,10 L 0,10 Z"
                               Stroke="{TemplateBinding Foreground}"
                               StrokeThickness="1"
-                              Fill="Transparent"
+                              Stretch="None"
                               Visibility="Collapsed" />
 
                         <!-- Restore Glyph (two overlapping squares) -->
-                        <Grid Name="RestoreGlyph" Visibility="Collapsed">
+                        <Grid Name="RestoreGlyph" Width="10" Height="10" Visibility="Collapsed">
                             <!-- Back square (top-right) -->
                             <Path Data="M 2,0 L 10,0 L 10,8 L 8,8 L 8,2 L 2,2 Z"
                                   Stroke="{TemplateBinding Foreground}"
                                   StrokeThickness="1"
-                                  Fill="Transparent" />
+                                  Stretch="None" />
                             <!-- Front square (bottom-left) -->
                             <Path Data="M 0,2 L 8,2 L 8,10 L 0,10 Z"
                                   Stroke="{TemplateBinding Foreground}"
                                   StrokeThickness="1"
+                                  Stretch="None"
                                   Fill="{TemplateBinding Background}" />
                         </Grid>
 
@@ -61,6 +64,7 @@
                               Data="M 0,0 L 10,10 M 10,0 L 0,10"
                               Stroke="{TemplateBinding Foreground}"
                               StrokeThickness="1"
+                              Stretch="None"
                               Visibility="Visible" />
                     </Grid>
                 </Border>
@@ -124,9 +128,10 @@
                         <Setter TargetName="PART_RootBorder" Property="Background" Value="{StaticResource TitleBarCloseButtonHover}" />
                     </MultiTrigger>
 
-                    <!-- Pressed state for non-close buttons -->
+                    <!-- Pressed state for non-close buttons (requires mouse over to allow cancel by dragging outside) -->
                     <MultiTrigger>
                         <MultiTrigger.Conditions>
+                            <Condition Property="IsMouseOver" Value="True" />
                             <Condition Property="IsPressed" Value="True" />
                             <Condition Property="Kind" Value="Minimize" />
                         </MultiTrigger.Conditions>
@@ -134,6 +139,7 @@
                     </MultiTrigger>
                     <MultiTrigger>
                         <MultiTrigger.Conditions>
+                            <Condition Property="IsMouseOver" Value="True" />
                             <Condition Property="IsPressed" Value="True" />
                             <Condition Property="Kind" Value="Maximize" />
                         </MultiTrigger.Conditions>
@@ -141,15 +147,17 @@
                     </MultiTrigger>
                     <MultiTrigger>
                         <MultiTrigger.Conditions>
+                            <Condition Property="IsMouseOver" Value="True" />
                             <Condition Property="IsPressed" Value="True" />
                             <Condition Property="Kind" Value="Restore" />
                         </MultiTrigger.Conditions>
                         <Setter TargetName="PART_RootBorder" Property="Background" Value="{StaticResource TitleBarButtonPressed}" />
                     </MultiTrigger>
 
-                    <!-- Pressed state for close button -->
+                    <!-- Pressed state for close button (requires mouse over to allow cancel by dragging outside) -->
                     <MultiTrigger>
                         <MultiTrigger.Conditions>
+                            <Condition Property="IsMouseOver" Value="True" />
                             <Condition Property="IsPressed" Value="True" />
                             <Condition Property="Kind" Value="Close" />
                         </MultiTrigger.Conditions>

--- a/src/managed/Jalium.UI.Controls/Thumb.cs
+++ b/src/managed/Jalium.UI.Controls/Thumb.cs
@@ -286,8 +286,6 @@ public class Thumb : Control
 
         var rect = new Rect(RenderSize);
         var cornerRadius = CornerRadius;
-        var hasCornerRadius = cornerRadius.TopLeft > 0 || cornerRadius.TopRight > 0 ||
-                              cornerRadius.BottomLeft > 0 || cornerRadius.BottomRight > 0;
 
         // Get visual state colors
         var bgBrush = Background ?? (IsDragging
@@ -297,27 +295,13 @@ public class Thumb : Control
         var borderBrush = BorderBrush;
 
         // Draw background
-        if (hasCornerRadius)
-        {
-            dc.DrawRoundedRectangle(bgBrush, null, rect, cornerRadius.TopLeft, cornerRadius.TopLeft);
-        }
-        else
-        {
-            dc.DrawRectangle(bgBrush, null, rect);
-        }
+        dc.DrawRoundedRectangle(bgBrush, null, rect, cornerRadius);
 
         // Draw border
         if (borderBrush != null && BorderThickness.TotalWidth > 0)
         {
             var pen = new Pen(borderBrush, BorderThickness.Left);
-            if (hasCornerRadius)
-            {
-                dc.DrawRoundedRectangle(null, pen, rect, cornerRadius.TopLeft, cornerRadius.TopLeft);
-            }
-            else
-            {
-                dc.DrawRectangle(null, pen, rect);
-            }
+            dc.DrawRoundedRectangle(null, pen, rect, cornerRadius);
         }
 
         // Draw grip lines for visual feedback (3 horizontal lines)

--- a/src/managed/Jalium.UI.Controls/TimePicker.cs
+++ b/src/managed/Jalium.UI.Controls/TimePicker.cs
@@ -298,14 +298,7 @@ public class TimePicker : Control
         // Draw background
         if (Background != null)
         {
-            if (hasCornerRadius)
-            {
-                dc.DrawRoundedRectangle(Background, null, inputRect, cornerRadius.TopLeft, cornerRadius.TopLeft);
-            }
-            else
-            {
-                dc.DrawRectangle(Background, null, inputRect);
-            }
+            dc.DrawRoundedRectangle(Background, null, inputRect, cornerRadius);
         }
 
         // Draw border
@@ -313,14 +306,7 @@ public class TimePicker : Control
         if (borderBrush != null && BorderThickness.TotalWidth > 0)
         {
             var pen = new Pen(borderBrush, BorderThickness.Left);
-            if (hasCornerRadius)
-            {
-                dc.DrawRoundedRectangle(null, pen, inputRect, cornerRadius.TopLeft, cornerRadius.TopLeft);
-            }
-            else
-            {
-                dc.DrawRectangle(null, pen, inputRect);
-            }
+            dc.DrawRoundedRectangle(null, pen, inputRect, cornerRadius);
         }
 
         // Draw time text or placeholder

--- a/src/managed/Jalium.UI.Controls/TitleBarButton.cs
+++ b/src/managed/Jalium.UI.Controls/TitleBarButton.cs
@@ -138,9 +138,22 @@ public class TitleBarButton : ButtonBase
     protected override Size MeasureOverride(Size availableSize)
     {
         // Title bar buttons have fixed size
-        return new Size(
+        var desiredSize = new Size(
             double.IsInfinity(availableSize.Width) ? Width : Math.Min(Width, availableSize.Width),
             double.IsInfinity(availableSize.Height) ? Height : Math.Min(Height, availableSize.Height));
+
+        // IMPORTANT: Still need to measure template content so children get proper RenderSize
+        // Call base to apply template and measure template root
+        base.MeasureOverride(desiredSize);
+
+        return desiredSize;
+    }
+
+    /// <inheritdoc />
+    protected override Size ArrangeOverride(Size finalSize)
+    {
+        // Let base class arrange the template content
+        return base.ArrangeOverride(finalSize);
     }
 
     #endregion

--- a/src/managed/Jalium.UI.Controls/Window.cs
+++ b/src/managed/Jalium.UI.Controls/Window.cs
@@ -985,6 +985,101 @@ public partial class Window : ContentControl, IWindowHost
     private static WndProcDelegate? _wndProcDelegate;
     private bool _isSizing; // True during drag resize
 
+    // Cursor cache - stores loaded cursor handles to avoid repeated LoadCursor calls
+    private static readonly Dictionary<CursorType, nint> _cursorCache = [];
+
+    /// <summary>
+    /// Gets the Windows cursor handle for a CursorType.
+    /// </summary>
+    private static nint GetCursorHandle(CursorType cursorType)
+    {
+        if (_cursorCache.TryGetValue(cursorType, out var handle))
+        {
+            return handle;
+        }
+
+        nint cursorId = cursorType switch
+        {
+            CursorType.Arrow => IDC_ARROW,
+            CursorType.IBeam => IDC_IBEAM,
+            CursorType.Wait => IDC_WAIT,
+            CursorType.Cross => IDC_CROSS,
+            CursorType.UpArrow => IDC_UPARROW,
+            CursorType.SizeNWSE => IDC_SIZENWSE,
+            CursorType.SizeNESW => IDC_SIZENESW,
+            CursorType.SizeWE => IDC_SIZEWE,
+            CursorType.SizeNS => IDC_SIZENS,
+            CursorType.SizeAll => IDC_SIZEALL,
+            CursorType.No => IDC_NO,
+            CursorType.Hand => IDC_HAND,
+            CursorType.AppStarting => IDC_APPSTARTING,
+            CursorType.Help => IDC_HELP,
+            CursorType.None => nint.Zero, // Will hide cursor
+            _ => IDC_ARROW
+        };
+
+        handle = cursorId != nint.Zero ? LoadCursor(nint.Zero, cursorId) : nint.Zero;
+        _cursorCache[cursorType] = handle;
+        return handle;
+    }
+
+    /// <summary>
+    /// Handles WM_SETCURSOR by finding the element under the cursor and setting the appropriate cursor.
+    /// </summary>
+    private bool OnSetCursor(nint lParam)
+    {
+        // Only handle if the cursor is in the client area
+        int hitTest = (short)(lParam.ToInt64() & 0xFFFF);
+        if (hitTest != HTCLIENT_SETCURSOR)
+        {
+            return false; // Let Windows handle non-client area cursors
+        }
+
+        // Get the current mouse position
+        if (!GetCursorPos(out POINT screenPt))
+        {
+            return false;
+        }
+
+        _ = ScreenToClient(Handle, ref screenPt);
+        Point clientPos = new(screenPt.X, screenPt.Y);
+
+        // Find the element under the cursor
+        var hitResult = HitTest(clientPos);
+        var element = hitResult?.VisualHit;
+
+        // Walk up the visual tree to find the first element with a non-null Cursor
+        Cursor? cursor = null;
+        while (element != null)
+        {
+            if (element is FrameworkElement fe && fe.Cursor != null)
+            {
+                cursor = fe.Cursor;
+                break;
+            }
+            element = element.VisualParent;
+        }
+
+        // Set the cursor
+        nint cursorHandle;
+        if (cursor != null)
+        {
+            cursorHandle = GetCursorHandle(cursor.CursorType);
+        }
+        else
+        {
+            cursorHandle = GetCursorHandle(CursorType.Arrow);
+        }
+
+        if (cursorHandle != nint.Zero)
+        {
+            _ = SetCursor(cursorHandle);
+            return true;
+        }
+
+        return false;
+    }
+
 #if DEBUG
     private DevToolsWindow? _devToolsWindow;
     internal DevToolsOverlay? DevToolsOverlay { get; set; }
@@ -1193,6 +1288,28 @@ public partial class Window : ContentControl, IWindowHost
                     _ = RedrawWindow(hWnd, nint.Zero, nint.Zero, RDW_INVALIDATE | RDW_UPDATENOW);
                     return nint.Zero;
 
+                case WM_SIZING:
+                    // WM_SIZING is sent continuously during drag resize - lParam points to RECT
+                    if (window._isSizing)
+                    {
+                        // Get the new size from the sizing rect
+                        var sizingRect = Marshal.PtrToStructure<RECT>(lParam);
+                        int newWidth = sizingRect.right - sizingRect.left;
+                        int newHeight = sizingRect.bottom - sizingRect.top;
+
+                        // Only resize if dimensions actually changed (avoid redundant operations)
+                        if (newWidth > 0 && newHeight > 0 &&
+                            (newWidth != (int)window.Width || newHeight != (int)window.Height))
+                        {
+                            window.Width = newWidth;
+                            window.Height = newHeight;
+                            window.RenderTarget?.Resize(newWidth, newHeight);
+                            // Force immediate repaint to prevent DWM from showing stale/stretched content
+                            _ = RedrawWindow(hWnd, nint.Zero, nint.Zero, RDW_INVALIDATE | RDW_UPDATENOW);
+                        }
+                    }
+                    break;
+
                 case WM_ENTERSIZEMOVE:
                     window._isSizing = true;
                     // Disable VSync during resize for faster frame updates
@@ -1253,6 +1370,14 @@ public partial class Window : ContentControl, IWindowHost
                 case WM_IME_CHAR:
                     // IME character - let it fall through to default processing
                     // or handle specially if needed
+                    break;
+
+                // Cursor
+                case WM_SETCURSOR:
+                    if (window.OnSetCursor(lParam))
+                    {
+                        return 1; // Return TRUE to indicate we handled the message
+                    }
                     break;
 
                 // Mouse input
@@ -1328,19 +1453,15 @@ public partial class Window : ContentControl, IWindowHost
         Width = width;
         Height = height;
 
-        // Always resize immediately on size change
-        RenderTarget?.Resize(width, height);
-
+        // During drag resize, WM_SIZING already handles resize and repaint.
+        // Only resize here for non-drag cases (maximize/restore/programmatic resize).
         if (!_isSizing)
         {
-            // Not dragging (maximize/restore) - also invalidate measure for layout
+            RenderTarget?.Resize(width, height);
             InvalidateMeasure();
         }
-        else
-        {
-            // During drag resize: repaint immediately
-            _ = RedrawWindow(Handle, nint.Zero, nint.Zero, RDW_INVALIDATE | RDW_UPDATENOW);
-        }
+        // Note: During drag resize, WM_SIZING handles the RenderTarget.Resize and repaint
+        // to prevent jitter from DWM stretching old frames.
     }
 
     private RenderTargetDrawingContext? _drawingContext;
@@ -2171,12 +2292,27 @@ public partial class Window : ContentControl, IWindowHost
     private const int DWMSBT_MAINWINDOW = 2;     // Mica
     private const int DWMSBT_TRANSIENTWINDOW = 3; // Acrylic
     private const int DWMSBT_TABBEDWINDOW = 4;   // Mica Alt
+    private const uint WM_SIZING = 0x0214;
     private const uint WM_ENTERSIZEMOVE = 0x0231;
     private const uint WM_EXITSIZEMOVE = 0x0232;
     private const uint CS_HREDRAW = 0x0002;
     private const uint CS_VREDRAW = 0x0001;
     private const int COLOR_WINDOW = 5;
     private const nint IDC_ARROW = 32512;
+    private const nint IDC_IBEAM = 32513;
+    private const nint IDC_WAIT = 32514;
+    private const nint IDC_CROSS = 32515;
+    private const nint IDC_UPARROW = 32516;
+    private const nint IDC_SIZE = 32640;      // Same as IDC_SIZEALL
+    private const nint IDC_SIZENWSE = 32642;
+    private const nint IDC_SIZENESW = 32643;
+    private const nint IDC_SIZEWE = 32644;
+    private const nint IDC_SIZENS = 32645;
+    private const nint IDC_SIZEALL = 32646;
+    private const nint IDC_NO = 32648;
+    private const nint IDC_HAND = 32649;
+    private const nint IDC_APPSTARTING = 32650;
+    private const nint IDC_HELP = 32651;
     private const uint RDW_INVALIDATE = 0x0001;
     private const uint RDW_UPDATENOW = 0x0100;
     private const uint WM_USER = 0x0400;
@@ -2220,6 +2356,10 @@ public partial class Window : ContentControl, IWindowHost
     // TrackMouseEvent flags
     private const uint TME_LEAVE = 0x00000002;
     private const uint TME_NONCLIENT = 0x00000010;
+
+    // Cursor message
+    private const uint WM_SETCURSOR = 0x0020;
+    private const int HTCLIENT_SETCURSOR = 1;
 
     // IME messages
     private const uint WM_IME_STARTCOMPOSITION = 0x010D;
@@ -2322,6 +2462,13 @@ public partial class Window : ContentControl, IWindowHost
 
     [LibraryImport("user32.dll", EntryPoint = "LoadCursorW")]
     private static partial nint LoadCursor(nint hInstance, nint lpCursorName);
+
+    [LibraryImport("user32.dll")]
+    private static partial nint SetCursor(nint hCursor);
+
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool GetCursorPos(out POINT lpPoint);
 
     [DllImport("user32.dll")]
     private static extern nint BeginPaint(nint hWnd, out PAINTSTRUCT lpPaint);

--- a/src/managed/Jalium.UI.Core/FrameworkElement.cs
+++ b/src/managed/Jalium.UI.Core/FrameworkElement.cs
@@ -107,6 +107,29 @@ public class FrameworkElement : UIElement
 
     #endregion
 
+    #region SizeChanged Event
+
+    /// <summary>
+    /// The previous render size, used to detect size changes.
+    /// </summary>
+    private Size _previousRenderSize;
+
+    /// <summary>
+    /// Occurs when either ActualWidth or ActualHeight properties change value.
+    /// </summary>
+    public event SizeChangedEventHandler? SizeChanged;
+
+    /// <summary>
+    /// Called when the render size changes.
+    /// </summary>
+    /// <param name="sizeInfo">Details of the size change.</param>
+    protected virtual void OnSizeChanged(SizeChangedInfo sizeInfo)
+    {
+        SizeChanged?.Invoke(this, new SizeChangedEventArgs(sizeInfo));
+    }
+
+    #endregion
+
     #region Internal Fields
 
     /// <summary>
@@ -649,6 +672,18 @@ public class FrameworkElement : UIElement
         // Set visual bounds for rendering
         _visualBounds = new Rect(x, y, renderSize.Width, renderSize.Height);
 
+        // Check for size change and raise SizeChanged event
+        if (renderSize != _previousRenderSize)
+        {
+            var widthChanged = renderSize.Width != _previousRenderSize.Width;
+            var heightChanged = renderSize.Height != _previousRenderSize.Height;
+
+            var sizeInfo = new SizeChangedInfo(this, _previousRenderSize, widthChanged, heightChanged);
+            _previousRenderSize = renderSize;
+
+            OnSizeChanged(sizeInfo);
+        }
+
         return renderSize;
     }
 
@@ -982,3 +1017,92 @@ public class RequestBringIntoViewEventArgs : RoutedEventArgs
 /// Delegate for handling RequestBringIntoView events.
 /// </summary>
 public delegate void RequestBringIntoViewEventHandler(object sender, RequestBringIntoViewEventArgs e);
+
+/// <summary>
+/// Delegate for handling SizeChanged events.
+/// </summary>
+public delegate void SizeChangedEventHandler(object sender, SizeChangedEventArgs e);
+
+/// <summary>
+/// Provides data for the SizeChanged event.
+/// </summary>
+public class SizeChangedEventArgs : EventArgs
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SizeChangedEventArgs"/> class.
+    /// </summary>
+    /// <param name="info">Information about the size change.</param>
+    public SizeChangedEventArgs(SizeChangedInfo info)
+    {
+        PreviousSize = info.PreviousSize;
+        NewSize = info.NewSize;
+        WidthChanged = info.WidthChanged;
+        HeightChanged = info.HeightChanged;
+    }
+
+    /// <summary>
+    /// Gets the previous size of the element.
+    /// </summary>
+    public Size PreviousSize { get; }
+
+    /// <summary>
+    /// Gets the new size of the element.
+    /// </summary>
+    public Size NewSize { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the width component changed.
+    /// </summary>
+    public bool WidthChanged { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the height component changed.
+    /// </summary>
+    public bool HeightChanged { get; }
+}
+
+/// <summary>
+/// Contains information about a size change.
+/// </summary>
+public class SizeChangedInfo
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SizeChangedInfo"/> class.
+    /// </summary>
+    /// <param name="element">The element whose size changed.</param>
+    /// <param name="previousSize">The previous size.</param>
+    /// <param name="widthChanged">Whether the width changed.</param>
+    /// <param name="heightChanged">Whether the height changed.</param>
+    public SizeChangedInfo(UIElement element, Size previousSize, bool widthChanged, bool heightChanged)
+    {
+        Element = element;
+        PreviousSize = previousSize;
+        WidthChanged = widthChanged;
+        HeightChanged = heightChanged;
+    }
+
+    /// <summary>
+    /// Gets the element that was measured.
+    /// </summary>
+    public UIElement Element { get; }
+
+    /// <summary>
+    /// Gets the previous size of the element before the size change.
+    /// </summary>
+    public Size PreviousSize { get; }
+
+    /// <summary>
+    /// Gets the new size of the element. This is the element's current RenderSize.
+    /// </summary>
+    public Size NewSize => Element.RenderSize;
+
+    /// <summary>
+    /// Gets a value indicating whether the Width component of the size changed.
+    /// </summary>
+    public bool WidthChanged { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the Height component of the size changed.
+    /// </summary>
+    public bool HeightChanged { get; }
+}

--- a/src/managed/Jalium.UI.Core/Style.cs
+++ b/src/managed/Jalium.UI.Core/Style.cs
@@ -166,15 +166,27 @@ public class Setter
         var target = GetTarget(element);
         if (target != null)
         {
+            // Resolve the actual property on the target type
+            // This handles the case where the property was resolved against the Style's TargetType
+            // but the setter targets a different element type via TargetName
+            var actualProperty = ResolvePropertyForTarget(Property, target);
+            if (actualProperty == null)
+                return;
+
+            // Don't override local values - WPF style behavior
+            // Local values have higher precedence than style values
+            if (target.HasLocalValue(actualProperty))
+                return;
+
             // Store original value for restoration
-            if (!target._styleOriginalValues.ContainsKey(Property))
+            if (!target._styleOriginalValues.ContainsKey(actualProperty))
             {
-                target._styleOriginalValues[Property] = target.GetValue(Property);
+                target._styleOriginalValues[actualProperty] = target.GetValue(actualProperty);
             }
 
             // Convert value to the correct type if needed
-            var valueToSet = ConvertValueIfNeeded(Value, Property.PropertyType);
-            target.SetValue(Property, valueToSet);
+            var valueToSet = ConvertValueIfNeeded(Value, actualProperty.PropertyType);
+            target.SetValue(actualProperty, valueToSet);
         }
     }
 
@@ -199,9 +211,52 @@ public class Setter
                 return bool.Parse(stringValue);
             if (targetType.IsEnum)
                 return Enum.Parse(targetType, stringValue, ignoreCase: true);
+            if (targetType == typeof(CornerRadius))
+                return ParseCornerRadius(stringValue);
+            if (targetType == typeof(Thickness))
+                return ParseThickness(stringValue);
         }
 
         return value;
+    }
+
+    /// <summary>
+    /// Parses a CornerRadius from a string value.
+    /// </summary>
+    private static CornerRadius ParseCornerRadius(string value)
+    {
+        var parts = value.Split(',', ' ').Where(s => !string.IsNullOrWhiteSpace(s)).ToArray();
+        return parts.Length switch
+        {
+            1 => new CornerRadius(double.Parse(parts[0], System.Globalization.CultureInfo.InvariantCulture)),
+            4 => new CornerRadius(
+                double.Parse(parts[0], System.Globalization.CultureInfo.InvariantCulture),
+                double.Parse(parts[1], System.Globalization.CultureInfo.InvariantCulture),
+                double.Parse(parts[2], System.Globalization.CultureInfo.InvariantCulture),
+                double.Parse(parts[3], System.Globalization.CultureInfo.InvariantCulture)),
+            _ => new CornerRadius(0)
+        };
+    }
+
+    /// <summary>
+    /// Parses a Thickness from a string value.
+    /// </summary>
+    private static Thickness ParseThickness(string value)
+    {
+        var parts = value.Split(',', ' ').Where(s => !string.IsNullOrWhiteSpace(s)).ToArray();
+        return parts.Length switch
+        {
+            1 => new Thickness(double.Parse(parts[0], System.Globalization.CultureInfo.InvariantCulture)),
+            2 => new Thickness(
+                double.Parse(parts[0], System.Globalization.CultureInfo.InvariantCulture),
+                double.Parse(parts[1], System.Globalization.CultureInfo.InvariantCulture)),
+            4 => new Thickness(
+                double.Parse(parts[0], System.Globalization.CultureInfo.InvariantCulture),
+                double.Parse(parts[1], System.Globalization.CultureInfo.InvariantCulture),
+                double.Parse(parts[2], System.Globalization.CultureInfo.InvariantCulture),
+                double.Parse(parts[3], System.Globalization.CultureInfo.InvariantCulture)),
+            _ => new Thickness(0)
+        };
     }
 
     /// <summary>
@@ -212,11 +267,52 @@ public class Setter
         if (Property == null) return;
 
         var target = GetTarget(element);
-        if (target != null && target._styleOriginalValues.TryGetValue(Property, out var originalValue))
+        if (target == null) return;
+
+        // Resolve the actual property on the target type
+        var actualProperty = ResolvePropertyForTarget(Property, target);
+        if (actualProperty == null) return;
+
+        if (target._styleOriginalValues.TryGetValue(actualProperty, out var originalValue))
         {
-            target.SetValue(Property, originalValue);
-            target._styleOriginalValues.Remove(Property);
+            target.SetValue(actualProperty, originalValue);
+            target._styleOriginalValues.Remove(actualProperty);
         }
+    }
+
+    /// <summary>
+    /// Resolves the actual DependencyProperty for the target element type.
+    /// This handles the case where the property was resolved against the Style's TargetType
+    /// but the setter targets a different element type via TargetName.
+    /// </summary>
+    private static DependencyProperty? ResolvePropertyForTarget(DependencyProperty originalProperty, FrameworkElement target)
+    {
+        var targetType = target.GetType();
+
+        // If the property is already from this type or an ancestor, use it directly
+        if (originalProperty.OwnerType.IsAssignableFrom(targetType))
+        {
+            return originalProperty;
+        }
+
+        // Try to find the property by name on the target type
+        var propertyName = originalProperty.Name;
+        var fieldName = $"{propertyName}Property";
+
+        var currentType = targetType;
+        while (currentType != null && currentType != typeof(object))
+        {
+            var dpField = currentType.GetField(fieldName,
+                System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.DeclaredOnly);
+            if (dpField != null && dpField.FieldType == typeof(DependencyProperty))
+            {
+                return dpField.GetValue(null) as DependencyProperty;
+            }
+            currentType = currentType.BaseType;
+        }
+
+        // Fallback to the original property
+        return originalProperty;
     }
 
     private FrameworkElement? GetTarget(FrameworkElement element)
@@ -288,6 +384,12 @@ public abstract class Trigger
     internal Style? ParentStyle { get; set; }
 
     /// <summary>
+    /// Gets or sets the parent template triggers collection.
+    /// This is set when the trigger is attached as part of a ControlTemplate.
+    /// </summary>
+    internal IList<Trigger>? ParentTemplateTriggers { get; set; }
+
+    /// <summary>
     /// Attaches this trigger to the specified element.
     /// </summary>
     internal abstract void Attach(FrameworkElement element);
@@ -319,7 +421,14 @@ public abstract class Trigger
             if (target == null)
                 continue;
 
-            var key = (target, setter.Property);
+            // Resolve the actual property on the target type
+            // This is important when TargetName is set and the target is a different type
+            // (e.g., Setter targets a Border but was parsed with Style TargetType=Button)
+            var actualProperty = ResolvePropertyForTarget(setter.Property, target);
+            if (actualProperty == null)
+                continue;
+
+            var key = (target, actualProperty);
 
             // Use the styled element's shared storage for original values
             // This ensures we store the value BEFORE any trigger modified it
@@ -331,7 +440,7 @@ public abstract class Trigger
             else
             {
                 // This is the first trigger affecting this property, store the original value
-                var originalValue = target.GetValue(setter.Property);
+                var originalValue = target.GetValue(actualProperty);
                 element._triggerOriginalValues[key] = (originalValue, 1);
             }
 
@@ -339,12 +448,47 @@ public abstract class Trigger
             _activeSetters.Add(key);
 
             // Convert value to the correct type if needed and apply
-            var valueToSet = ConvertValueIfNeeded(setter.Value, setter.Property.PropertyType);
-            target.SetValue(setter.Property, valueToSet);
+            var valueToSet = ConvertValueIfNeeded(setter.Value, actualProperty.PropertyType);
+            target.SetValue(actualProperty, valueToSet);
         }
 
         // Invalidate visual to ensure re-render
         element.InvalidateVisual();
+    }
+
+    /// <summary>
+    /// Resolves the actual DependencyProperty for the target element type.
+    /// This handles the case where the property was resolved against the Style's TargetType
+    /// but the setter targets a different element type via TargetName.
+    /// </summary>
+    private static DependencyProperty? ResolvePropertyForTarget(DependencyProperty originalProperty, FrameworkElement target)
+    {
+        var targetType = target.GetType();
+
+        // If the property is already from this type or an ancestor, use it directly
+        if (originalProperty.OwnerType.IsAssignableFrom(targetType))
+        {
+            return originalProperty;
+        }
+
+        // Try to find the property by name on the target type
+        var propertyName = originalProperty.Name;
+        var fieldName = $"{propertyName}Property";
+
+        var currentType = targetType;
+        while (currentType != null && currentType != typeof(object))
+        {
+            var dpField = currentType.GetField(fieldName,
+                System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.DeclaredOnly);
+            if (dpField != null && dpField.FieldType == typeof(DependencyProperty))
+            {
+                return dpField.GetValue(null) as DependencyProperty;
+            }
+            currentType = currentType.BaseType;
+        }
+
+        // Fallback to the original property
+        return originalProperty;
     }
 
     /// <summary>
@@ -372,9 +516,52 @@ public abstract class Trigger
                 return bool.Parse(stringValue);
             if (actualType.IsEnum)
                 return Enum.Parse(actualType, stringValue, ignoreCase: true);
+            if (actualType == typeof(CornerRadius))
+                return ParseCornerRadius(stringValue);
+            if (actualType == typeof(Thickness))
+                return ParseThickness(stringValue);
         }
 
         return value;
+    }
+
+    /// <summary>
+    /// Parses a CornerRadius from a string value.
+    /// </summary>
+    private static CornerRadius ParseCornerRadius(string value)
+    {
+        var parts = value.Split(',', ' ').Where(s => !string.IsNullOrWhiteSpace(s)).ToArray();
+        return parts.Length switch
+        {
+            1 => new CornerRadius(double.Parse(parts[0], System.Globalization.CultureInfo.InvariantCulture)),
+            4 => new CornerRadius(
+                double.Parse(parts[0], System.Globalization.CultureInfo.InvariantCulture),
+                double.Parse(parts[1], System.Globalization.CultureInfo.InvariantCulture),
+                double.Parse(parts[2], System.Globalization.CultureInfo.InvariantCulture),
+                double.Parse(parts[3], System.Globalization.CultureInfo.InvariantCulture)),
+            _ => new CornerRadius(0)
+        };
+    }
+
+    /// <summary>
+    /// Parses a Thickness from a string value.
+    /// </summary>
+    private static Thickness ParseThickness(string value)
+    {
+        var parts = value.Split(',', ' ').Where(s => !string.IsNullOrWhiteSpace(s)).ToArray();
+        return parts.Length switch
+        {
+            1 => new Thickness(double.Parse(parts[0], System.Globalization.CultureInfo.InvariantCulture)),
+            2 => new Thickness(
+                double.Parse(parts[0], System.Globalization.CultureInfo.InvariantCulture),
+                double.Parse(parts[1], System.Globalization.CultureInfo.InvariantCulture)),
+            4 => new Thickness(
+                double.Parse(parts[0], System.Globalization.CultureInfo.InvariantCulture),
+                double.Parse(parts[1], System.Globalization.CultureInfo.InvariantCulture),
+                double.Parse(parts[2], System.Globalization.CultureInfo.InvariantCulture),
+                double.Parse(parts[3], System.Globalization.CultureInfo.InvariantCulture)),
+            _ => new Thickness(0)
+        };
     }
 
     /// <summary>
@@ -397,7 +584,12 @@ public abstract class Trigger
             if (target == null)
                 continue;
 
-            var key = (target, setter.Property);
+            // Resolve the actual property on the target type
+            var actualProperty = ResolvePropertyForTarget(setter.Property, target);
+            if (actualProperty == null)
+                continue;
+
+            var key = (target, actualProperty);
 
             // Check if this trigger actually set this property
             if (!_activeSetters.Contains(key))
@@ -412,7 +604,7 @@ public abstract class Trigger
                 if (newCount <= 0)
                 {
                     // No more triggers affecting this property, restore original value
-                    target.SetValue(setter.Property, stored.OriginalValue);
+                    target.SetValue(actualProperty, stored.OriginalValue);
                     element._triggerOriginalValues.Remove(key);
                 }
                 else
@@ -427,26 +619,36 @@ public abstract class Trigger
         // Re-apply any other still-active triggers that affect the same properties
         // This ensures that if trigger A deactivates but trigger B is still active,
         // trigger B's values are re-applied
-        if (ParentStyle != null && needsReapply.Count > 0)
+        if (needsReapply.Count > 0)
         {
-            foreach (var otherTrigger in ParentStyle.Triggers)
+            // Collect triggers to check - from ParentStyle or from ParentTemplateTriggers
+            IEnumerable<Trigger>? triggersToCheck = ParentStyle?.Triggers ?? ParentTemplateTriggers;
+
+            if (triggersToCheck != null)
             {
-                if (otherTrigger == this) continue;
-                if (!otherTrigger.IsActiveForElement(element)) continue;
-
-                foreach (var setter in otherTrigger.Setters)
+                foreach (var otherTrigger in triggersToCheck)
                 {
-                    if (setter.Property == null) continue;
+                    if (otherTrigger == this) continue;
+                    if (!otherTrigger.IsActiveForElement(element)) continue;
 
-                    var target = GetSetterTarget(element, setter.TargetName);
-                    if (target == null) continue;
-
-                    var key = (target, setter.Property);
-                    if (needsReapply.Contains(key))
+                    foreach (var setter in otherTrigger.Setters)
                     {
-                        // This property needs another trigger's value re-applied
-                        var valueToSet = ConvertValueIfNeeded(setter.Value, setter.Property.PropertyType);
-                        target.SetValue(setter.Property, valueToSet);
+                        if (setter.Property == null) continue;
+
+                        var target = GetSetterTarget(element, setter.TargetName);
+                        if (target == null) continue;
+
+                        // Resolve the actual property on the target type
+                        var actualProperty = ResolvePropertyForTarget(setter.Property, target);
+                        if (actualProperty == null) continue;
+
+                        var key = (target, actualProperty);
+                        if (needsReapply.Contains(key))
+                        {
+                            // This property needs another trigger's value re-applied
+                            var valueToSet = ConvertValueIfNeeded(setter.Value, actualProperty.PropertyType);
+                            target.SetValue(actualProperty, valueToSet);
+                        }
                     }
                 }
             }

--- a/src/managed/Jalium.UI.Interop/RenderTargetDrawingContext.cs
+++ b/src/managed/Jalium.UI.Interop/RenderTargetDrawingContext.cs
@@ -349,9 +349,86 @@ public sealed class RenderTargetDrawingContext : DrawingContext, IOffsetDrawingC
 
     private List<Point> GetArcPoints(Point start, ArcSegment arc)
     {
-        // Simple approximation: connect with lines
-        // For full arc support, would need to compute arc points
-        var points = new List<Point> { arc.Point };
+        var points = new List<Point>();
+        var end = arc.Point;
+        var rx = arc.Size.Width;
+        var ry = arc.Size.Height;
+
+        // Handle degenerate cases
+        if (rx == 0 || ry == 0 || (start.X == end.X && start.Y == end.Y))
+        {
+            points.Add(end);
+            return points;
+        }
+
+        // Convert endpoint parameterization to center parameterization
+        // Based on SVG arc implementation algorithm
+        var dx = (start.X - end.X) / 2;
+        var dy = (start.Y - end.Y) / 2;
+
+        var rotationAngle = arc.RotationAngle * Math.PI / 180;
+        var cosAngle = Math.Cos(rotationAngle);
+        var sinAngle = Math.Sin(rotationAngle);
+
+        var x1p = cosAngle * dx + sinAngle * dy;
+        var y1p = -sinAngle * dx + cosAngle * dy;
+
+        // Ensure radii are large enough
+        var x1pSq = x1p * x1p;
+        var y1pSq = y1p * y1p;
+        var rxSq = rx * rx;
+        var rySq = ry * ry;
+
+        var lambda = x1pSq / rxSq + y1pSq / rySq;
+        if (lambda > 1)
+        {
+            var sqrtLambda = Math.Sqrt(lambda);
+            rx *= sqrtLambda;
+            ry *= sqrtLambda;
+            rxSq = rx * rx;
+            rySq = ry * ry;
+        }
+
+        // Calculate center point
+        // Per SVG spec: sign is positive when fA != fS
+        var sign = (arc.IsLargeArc != (arc.SweepDirection == SweepDirection.Clockwise)) ? 1 : -1;
+        var sq = Math.Max(0, (rxSq * rySq - rxSq * y1pSq - rySq * x1pSq) / (rxSq * y1pSq + rySq * x1pSq));
+        var coef = sign * Math.Sqrt(sq);
+
+        var cxp = coef * rx * y1p / ry;
+        var cyp = -coef * ry * x1p / rx;
+
+        var cx = cosAngle * cxp - sinAngle * cyp + (start.X + end.X) / 2;
+        var cy = sinAngle * cxp + cosAngle * cyp + (start.Y + end.Y) / 2;
+
+        // Calculate start and end angles
+        var startAngle = Math.Atan2((y1p - cyp) / ry, (x1p - cxp) / rx);
+        var endAngle = Math.Atan2((-y1p - cyp) / ry, (-x1p - cxp) / rx);
+
+        var deltaAngle = endAngle - startAngle;
+
+        // Adjust delta angle based on sweep direction
+        if (arc.SweepDirection == SweepDirection.Clockwise && deltaAngle < 0)
+            deltaAngle += 2 * Math.PI;
+        else if (arc.SweepDirection == SweepDirection.Counterclockwise && deltaAngle > 0)
+            deltaAngle -= 2 * Math.PI;
+
+        // Generate arc points
+        const int segments = 8;
+        for (int i = 1; i <= segments; i++)
+        {
+            var t = i / (double)segments;
+            var angle = startAngle + deltaAngle * t;
+
+            var px = rx * Math.Cos(angle);
+            var py = ry * Math.Sin(angle);
+
+            var x = cosAngle * px - sinAngle * py + cx;
+            var y = sinAngle * px + cosAngle * py + cy;
+
+            points.Add(new Point(x, y));
+        }
+
         return points;
     }
 

--- a/src/managed/Jalium.UI.Media/DrawingContext.cs
+++ b/src/managed/Jalium.UI.Media/DrawingContext.cs
@@ -56,6 +56,114 @@ public abstract class DrawingContext : IDisposable, IClipDrawingContext
     public abstract void DrawRoundedRectangle(Brush? brush, Pen? pen, Rect rectangle, double radiusX, double radiusY);
 
     /// <summary>
+    /// Draws a rounded rectangle with potentially non-uniform corner radii.
+    /// </summary>
+    /// <param name="brush">The brush to fill with, or null for no fill.</param>
+    /// <param name="pen">The pen for the outline, or null for no outline.</param>
+    /// <param name="rectangle">The rectangle to draw.</param>
+    /// <param name="cornerRadius">The corner radius for each corner.</param>
+    public void DrawRoundedRectangle(Brush? brush, Pen? pen, Rect rectangle, CornerRadius cornerRadius)
+    {
+        // Fast path: no corner radius
+        if (cornerRadius.TopLeft == 0 && cornerRadius.TopRight == 0 &&
+            cornerRadius.BottomLeft == 0 && cornerRadius.BottomRight == 0)
+        {
+            DrawRectangle(brush, pen, rectangle);
+            return;
+        }
+
+        // Fast path: uniform corner radius
+        if (cornerRadius.TopLeft == cornerRadius.TopRight &&
+            cornerRadius.TopLeft == cornerRadius.BottomRight &&
+            cornerRadius.TopLeft == cornerRadius.BottomLeft)
+        {
+            DrawRoundedRectangle(brush, pen, rectangle, cornerRadius.TopLeft, cornerRadius.TopLeft);
+            return;
+        }
+
+        // Non-uniform corner radius: use PathGeometry
+        var geometry = CreateRoundedRectGeometry(rectangle, cornerRadius);
+        DrawGeometry(brush, pen, geometry);
+    }
+
+    /// <summary>
+    /// Creates a PathGeometry for a rounded rectangle with non-uniform corner radii.
+    /// </summary>
+    private static PathGeometry CreateRoundedRectGeometry(Rect rect, CornerRadius cornerRadius)
+    {
+        var geometry = new PathGeometry();
+        var figure = new PathFigure();
+
+        double x = rect.X;
+        double y = rect.Y;
+        double w = rect.Width;
+        double h = rect.Height;
+
+        // Clamp corner radii to half the minimum dimension
+        double maxRadius = Math.Min(w, h) / 2;
+        double tl = Math.Min(cornerRadius.TopLeft, maxRadius);
+        double tr = Math.Min(cornerRadius.TopRight, maxRadius);
+        double br = Math.Min(cornerRadius.BottomRight, maxRadius);
+        double bl = Math.Min(cornerRadius.BottomLeft, maxRadius);
+
+        // Start at top-left corner, after the arc
+        figure.StartPoint = new Point(x + tl, y);
+        figure.IsClosed = true;
+        figure.IsFilled = true;
+
+        // Top edge
+        figure.Segments.Add(new LineSegment(new Point(x + w - tr, y), true));
+
+        // Top-right corner
+        if (tr > 0)
+        {
+            figure.Segments.Add(new ArcSegment(
+                new Point(x + w, y + tr),
+                new Size(tr, tr),
+                0, false, SweepDirection.Clockwise, true));
+        }
+
+        // Right edge
+        figure.Segments.Add(new LineSegment(new Point(x + w, y + h - br), true));
+
+        // Bottom-right corner
+        if (br > 0)
+        {
+            figure.Segments.Add(new ArcSegment(
+                new Point(x + w - br, y + h),
+                new Size(br, br),
+                0, false, SweepDirection.Clockwise, true));
+        }
+
+        // Bottom edge
+        figure.Segments.Add(new LineSegment(new Point(x + bl, y + h), true));
+
+        // Bottom-left corner
+        if (bl > 0)
+        {
+            figure.Segments.Add(new ArcSegment(
+                new Point(x, y + h - bl),
+                new Size(bl, bl),
+                0, false, SweepDirection.Clockwise, true));
+        }
+
+        // Left edge
+        figure.Segments.Add(new LineSegment(new Point(x, y + tl), true));
+
+        // Top-left corner
+        if (tl > 0)
+        {
+            figure.Segments.Add(new ArcSegment(
+                new Point(x + tl, y),
+                new Size(tl, tl),
+                0, false, SweepDirection.Clockwise, true));
+        }
+
+        geometry.Figures.Add(figure);
+        return geometry;
+    }
+
+    /// <summary>
     /// Draws an ellipse.
     /// </summary>
     /// <param name="brush">The brush to fill with, or null for no fill.</param>

--- a/src/managed/Jalium.UI.Xaml/XamlReader.cs
+++ b/src/managed/Jalium.UI.Xaml/XamlReader.cs
@@ -1576,6 +1576,7 @@ public static class XamlTypeRegistry
         Register<AutoCompleteBox>(types);
         Register<HyperlinkButton>(types);
         Register<Label>(types);
+        Register<InkCanvas>(types);
 
         // Jalium.UI.Controls.Primitives namespace
         Register<BulletDecorator>(types);

--- a/src/native/jalium.native.d3d12/src/d3d12_render_target.cpp
+++ b/src/native/jalium.native.d3d12/src/d3d12_render_target.cpp
@@ -97,7 +97,10 @@ bool D3D12RenderTarget::CreateSwapChain() {
     swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
     swapChainDesc.BufferCount = FrameCount;
     swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.Scaling = DXGI_SCALING_STRETCH;
+    // Use DXGI_SCALING_NONE to prevent DWM from stretching old frames during window resize,
+    // which causes visible jitter/trembling. With NONE, the swap chain content is displayed
+    // at its native size and DWM fills any unrendered areas with the background color.
+    swapChainDesc.Scaling = DXGI_SCALING_NONE;
     // Note: DXGI_ALPHA_MODE_PREMULTIPLIED is not supported for CreateSwapChainForHwnd
     // DWM backdrop effects work by treating black (0,0,0) as transparent in the extended frame area
     swapChainDesc.Flags = tearingSupported_ ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0;
@@ -569,7 +572,21 @@ void D3D12RenderTarget::DrawLine(float x1, float y1, float x2, float y2, Brush* 
 
     auto d2dBrush = GetD2DBrush(brush);
     if (d2dBrush) {
-        // Coordinates are pre-rounded in managed code
+        // For crisp 1px lines, offset by 0.5 to align to pixel grid
+        // This prevents anti-aliasing from making horizontal/vertical lines appear thicker
+        if (strokeWidth == 1.0f) {
+            // Horizontal line: offset Y by 0.5
+            if (y1 == y2) {
+                y1 += 0.5f;
+                y2 += 0.5f;
+            }
+            // Vertical line: offset X by 0.5
+            else if (x1 == x2) {
+                x1 += 0.5f;
+                x2 += 0.5f;
+            }
+            // Diagonal lines don't need offset
+        }
         d2dContext_->DrawLine(D2D1::Point2F(x1, y1), D2D1::Point2F(x2, y2), d2dBrush, strokeWidth);
     }
 }


### PR DESCRIPTION
## 窗口调整大小修复
- 将 SwapChain 缩放模式从 DXGI_SCALING_STRETCH 改为 DXGI_SCALING_NONE
- 添加 WM_SIZING 消息处理，在拖动调整大小时持续渲染
- 优化 WM_SIZE 处理避免重复 resize 操作

## 光标支持
- 添加 WM_SETCURSOR 消息处理
- 实现 CursorType 到 Windows 光标句柄的映射
- TextBoxBase 设置默认 IBeam 光标
- HyperlinkButton 设置 Hand 光标
- GridSplitter 根据调整方向设置 SizeWE/SizeNS 光标

## 其他改进
- Gallery 示例页面扩展
- 控件和主题优化