### PR TITLE
docs: update documentation for cross-platform and current repo structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,28 @@
-﻿﻿# Jalium.UI
+﻿# Jalium.UI
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/VeryJokerJal/Jalium.UI)
 
-Jalium.UI is a Windows-first, GPU-accelerated UI framework for .NET 10.
-It combines a WPF-style object model, JALXAML markup, and a DirectX 12 renderer.
-
-This repository contains the full framework stack: managed UI layers, native rendering backends,
-build-time tooling, packaging projects, and tests.
+Jalium.UI is a GPU-accelerated, cross-platform UI framework for .NET 10.
+It combines a WPF-style object model, JALXAML markup with Razor syntax extensions,
+and platform-native rendering backends (DirectX 12, Vulkan, Metal, Software).
 
 ## Project Status
 
-- Active development (APIs can still evolve between minor versions)
+- Active development — v26.10.0-preview (APIs can still evolve between minor versions)
 - Primary target: Windows 10/11 x64
-- Runtime target: .NET 10 (`net10.0-windows`)
-- Rendering backend: DirectX 12
+- Cross-platform: Android (arm64-v8a, x86_64), Linux (Vulkan), macOS (Metal)
+- Runtime target: .NET 10 (`net10.0-windows`, `net10.0-android`, `net10.0`)
+- Rendering: DirectX 12 (Windows), Vulkan (Linux/Android), Metal (macOS), Software fallback
 
 ## Why Jalium.UI
 
-- GPU-native rendering pipeline with native backend integration
-- Familiar UI programming model (`DependencyObject`, `UIElement`, panels, templates, resources)
-- JALXAML markup and runtime parser (`Jalium.UI.Markup.XamlReader`)
+- GPU-native rendering pipeline with ClearType sub-pixel text rendering
+- Familiar programming model (`DependencyObject`, `UIElement`, panels, templates, resources)
+- JALXAML markup with Razor syntax extensions (`@Path`, `@(expr)`, `@{ ... }`, `@if`)
+- Rich control library: 80+ controls including Charts, Ribbon, Docking, InkCanvas, WebView, Terminal
 - Build-time tooling via NuGet (`Jalium.UI.Build`, `Jalium.UI.Xaml.SourceGenerator`)
-- Broad control surface including layout, text/input, navigation, data, docking, ink, and web host controls
+- UIA accessibility support with automation peers
+- Visual effects: liquid glass, backdrop blur, acrylic, mica, transition shaders
 
 ## Framework Composition
 
@@ -29,52 +30,89 @@ build-time tooling, packaging projects, and tests.
 
 | Package | Responsibility |
 | --- | --- |
-| `Jalium.UI.Core` | dependency property system, visual tree, layout core, routed events, binding foundations |
-| `Jalium.UI.Media` | brushes, geometry, drawing primitives, animation/media infrastructure |
-| `Jalium.UI.Input` | mouse/keyboard/touch/stylus input abstractions and routing |
-| `Jalium.UI.Interop` | managed/native bridge and runtime native dependency packaging |
-| `Jalium.UI.Gpu` | GPU-side managed resource and render infrastructure |
-| `Jalium.UI.Controls` | controls, panels, templates, windowing, themes |
-| `Jalium.UI.Xaml` | JALXAML parse/load pipeline and markup services |
-| `Jalium.UI.Build` | MSBuild tasks and build assets for JALXAML workflow |
+| `Jalium.UI.Core` | Dependency property system, visual tree, layout, routed events, binding, animation |
+| `Jalium.UI.Media` | Brushes, geometry, drawing primitives, text formatting, imaging, visual effects |
+| `Jalium.UI.Input` | Mouse, keyboard, touch, stylus input abstractions and routing |
+| `Jalium.UI.Interop` | Managed/native bridge, P/Invoke, runtime native dependency packaging |
+| `Jalium.UI.Gpu` | GPU resource management, render graph, materials, shaders, backend abstraction |
+| `Jalium.UI.Controls` | Controls, panels, templates, windowing, themes, docking, charts |
+| `Jalium.UI.Xaml` | JALXAML parse/load pipeline, Razor syntax support, markup services |
+| `Jalium.UI.Build` | MSBuild tasks and build assets for JALXAML compilation workflow |
 | `Jalium.UI.Xaml.SourceGenerator` | Roslyn source generator for XAML/code-behind integration |
-| `Jalium.UI` | metapackage that references the full framework stack |
+| `Jalium.UI.Compiler` | Standalone `jalxamlc.exe` compiler tool |
+| `Jalium.UI` | Metapackage that references the full framework stack |
 
 ### Native Modules
 
-| Module | Responsibility |
+| Module | Platforms | Responsibility |
+| --- | --- | --- |
+| `jalium.native.core` | All | Native core runtime, backend registry, context management |
+| `jalium.native.d3d12` | Windows | DirectX 12 render target and Vello GPU pipeline |
+| `jalium.native.vulkan` | Linux, Android | Vulkan render backend |
+| `jalium.native.metal` | macOS | Metal render backend |
+| `jalium.native.software` | All | CPU-based software rendering fallback |
+| `jalium.native.platform` | All | Platform abstraction (window, input, events) |
+| `jalium.native.text` | Linux, Android | Cross-platform text engine (FreeType + HarfBuzz) |
+| `jalium.native.browser` | Windows | WebView2 browser integration |
+
+### Platform Packages
+
+| Package | Target |
 | --- | --- |
-| `jalium.native.core` | native core runtime layer |
-| `jalium.native.d3d12` | DirectX 12 render target/backend |
-| `jalium.native.browser` | browser/WebView native integration layer |
+| `Jalium.UI.Desktop` | `net10.0-windows` — Desktop distribution with native DLLs |
+| `Jalium.UI.Android` | `net10.0-android` — Android distribution with native .so libraries |
 
 ## Capability Overview
 
 ### Layout and Visual Tree
 
 - Core panels: `Grid`, `StackPanel`, `Canvas`, `DockPanel`, `WrapPanel`, `UniformGrid`
-- Virtualization and presenters: `VirtualizingStackPanel`, DataGrid presenters/panels, tab/tool panels
+- Virtualization: `VirtualizingStackPanel`, DataGrid presenters/panels
+- Docking: `DockLayout`, `DockSplitPanel`, `DockTabPanel`, `Split`
 - Window-level layout host, overlay layer, title bar composition, chrome integration
 
 ### Controls
 
-- Inputs: `Button`, `TextBox`, `PasswordBox`, `NumberBox`, `AutoCompleteBox`, `ComboBox`, `Slider`
-- Data/navigation: `TreeView`, `NavigationView`, `TabControl`, `DataGrid`, menu/flyout family
-- Rich scenarios: `InkCanvas`, `DocumentViewer`, `WebView`/`WebBrowser`, `TitleBar`, docking components
+- **Input**: `Button`, `TextBox`, `PasswordBox`, `NumberBox`, `AutoCompleteBox`, `ComboBox`, `Slider`, `CheckBox`, `RadioButton`
+- **Data**: `TreeView`, `DataGrid`, `TreeDataGrid`, `ListBox`, `ListView`
+- **Navigation**: `NavigationView`, `TabControl`, `Ribbon`, `CommandBar`, `MenuBar`
+- **Documents**: `FlowDocumentViewer`, `FlowDocumentReader`, `FlowDocumentScrollViewer`, `Markdown`
+- **Charts**: Category, DateTime, Logarithmic axes with chart legend
+- **Rich**: `InkCanvas`, `WebView`/`WebBrowser`, `EditControl`, `QRCode`, `TitleBar`
+- **Notifications**: Toast-style notification system
+
+### Text Rendering
+
+- ClearType sub-pixel text rendering with dual-source blending
+- CPU rasterization fallback path
+- Cross-platform text shaping via FreeType + HarfBuzz (Linux/Android)
 
 ### Input Pipeline
 
-- Pointer and keyboard routing
-- Touch and stylus pathways with plugin-style stylus infrastructure
-- Scroll and manipulation related control behaviors
+- Pointer and keyboard routing with hit testing
+- Touch and stylus pathways with gesture recognition
+- Scroll and manipulation event handling
+
+### GPU Rendering & Effects
+
+- DirectX 12 with Vello GPU compute pipeline (path, clip, tile stages)
+- Backdrop effects: blur, acrylic, mica, frosted glass
+- Liquid glass with refraction, chromatic aberration
+- Transition shaders and element effects (blur, drop shadow)
+- Custom shader support via HLSL
+
+### Accessibility
+
+- UIA automation peers for core and specialized controls
+- Chart, DiffViewer, HexEditor, JsonTreeViewer, Map, PropertyGrid automation
 
 ### Markup and Tooling
 
 - Runtime parsing: `Jalium.UI.Markup.XamlReader`
 - Build integration through packaged MSBuild targets/tasks
-- Source-generator package for compile-time assistance in JALXAML workflows
+- Source generator for compile-time JALXAML code-behind
 
-## Razor Syntax In JALXAML
+## Razor Syntax in JALXAML
 
 JALXAML supports Razor-style syntax as additive sugar on top of existing `{Binding ...}`:
 
@@ -100,6 +138,16 @@ For syntax details and rules, see [`docs/razor-syntax.md`](docs/razor-syntax.md)
 
 ```bash
 dotnet add package Jalium.UI
+```
+
+### Platform-specific
+
+```bash
+# Windows Desktop
+dotnet add package Jalium.UI.Desktop
+
+# Android
+dotnet add package Jalium.UI.Android
 ```
 
 ### Granular install (advanced)
@@ -168,22 +216,37 @@ app.Run(window);
 
 ## Build From Source
 
+### Prerequisites
+
+- .NET 10 SDK (`net10.0-windows`)
+- Visual Studio with C++ workload (for native modules)
+- Vulkan SDK (optional, for Vulkan backend)
+- Android NDK (optional, for Android builds)
+
+### Build
+
 ```bash
-# Build the framework (through metapackage dependency graph)
-dotnet build src/packaging/Jalium.UI.csproj -c Release
+# Build the full framework
+dotnet build src/packaging/Jalium.UI/Jalium.UI.csproj -c Release
 
 # Run tests
 dotnet test tests/Jalium.UI.Tests/Jalium.UI.Tests.csproj -c Release
+
+# Build native modules (in VS Developer Command Prompt)
+msbuild src/native/Jalium.Native.sln /m /p:Configuration=Release /p:Platform=x64
+
+# Build for Android
+bash src/native/build-android-deps.sh  # FreeType + HarfBuzz
+bash src/native/build-android.sh       # Native libraries
 ```
 
-## NuGet Packaging
+### NuGet Packaging
 
 ```bash
-# Pack metapackage + referenced packable projects
-dotnet pack src/packaging/Jalium.UI.csproj -c Release -o artifacts/nuget
+dotnet pack src/packaging/Jalium.UI/Jalium.UI.csproj -c Release -o artifacts/nuget
 ```
 
-For per-project package output, run `dotnet pack` on each packable project under `src/managed/Jalium.UI.*` and `src/packaging`.
+For detailed build configuration, see [`docs/manual-build-configuration.md`](docs/manual-build-configuration.md).
 
 ## Repository Layout
 
@@ -191,49 +254,68 @@ For per-project package output, run `dotnet pack` on each packable project under
 Jalium.UI/
   src/
     managed/
-      Jalium.UI/
-      Jalium.UI.Core/
-      Jalium.UI.Media/
-      Jalium.UI.Input/
-      Jalium.UI.Interop/
-      Jalium.UI.Gpu/
-      Jalium.UI.Controls/
-      Jalium.UI.Xaml/
-      Jalium.UI.Build/
-      Jalium.UI.Xaml.SourceGenerator/
-      Jalium.UI.Compiler/
+      Jalium.UI.Core/          # Dependency property system, visual tree, layout
+      Jalium.UI.Media/         # Brushes, geometry, drawing, text, imaging
+      Jalium.UI.Input/         # Input abstractions and routing
+      Jalium.UI.Interop/       # Native bridge and P/Invoke
+      Jalium.UI.Gpu/           # GPU resources, render graph, shaders
+      Jalium.UI.Controls/      # Controls, panels, themes, docking, charts
+      Jalium.UI.Xaml/          # JALXAML parser and Razor support
+      Jalium.UI.Build/         # MSBuild tasks for JALXAML compilation
+      Jalium.UI.Xaml.SourceGenerator/  # Roslyn source generator
+      Jalium.UI.Compiler/      # Standalone JALXAML compiler
     native/
-      jalium.native.core/
-      jalium.native.d3d12/
-      jalium.native.browser/
+      jalium.native.core/      # Native runtime core
+      jalium.native.d3d12/     # DirectX 12 + Vello GPU backend
+      jalium.native.vulkan/    # Vulkan backend
+      jalium.native.metal/     # Metal backend (macOS)
+      jalium.native.software/  # CPU software renderer
+      jalium.native.platform/  # Platform abstraction layer
+      jalium.native.text/      # FreeType + HarfBuzz text engine
+      jalium.native.browser/   # WebView2 integration
     packaging/
-      Jalium.UI.csproj
+      Jalium.UI/               # Main metapackage
+      Jalium.UI.Desktop/       # Windows desktop package
+      Jalium.UI.Android/       # Android package
   tests/
-    Jalium.UI.Tests/
+    Jalium.UI.Tests/           # xUnit test suite (70+ test classes)
+    Jalium.UI.ShaderDemo/      # Shader effects demo
+  docs/
+    razor-syntax.md            # Razor syntax reference
+    drawing-api.md             # Drawing API documentation
+    manual-build-configuration.md  # Build configuration guide
 ```
+
+## Documentation
+
+| Document | Description |
+| --- | --- |
+| [`docs/razor-syntax.md`](docs/razor-syntax.md) | Razor syntax reference for JALXAML |
+| [`docs/drawing-api.md`](docs/drawing-api.md) | Drawing API (DrawingContext, GPU effects, rendering) |
+| [`docs/manual-build-configuration.md`](docs/manual-build-configuration.md) | Manual build configuration guide |
 
 ## Visual Studio Extension Notes
 
 The VSIX can be installed into either:
 
-- Normal instance: `%LOCALAPPDATA%\\Microsoft\\VisualStudio\\18.0_<instanceId>\\Extensions`
-- Experimental instance (`/rootsuffix Exp`): `%LOCALAPPDATA%\\Microsoft\\VisualStudio\\18.0_<instanceId>Exp\\Extensions`
+- Normal instance: `%LOCALAPPDATA%\Microsoft\VisualStudio\18.0_<instanceId>\Extensions`
+- Experimental instance (`/rootsuffix Exp`): `%LOCALAPPDATA%\Microsoft\VisualStudio\18.0_<instanceId>Exp\Extensions`
 
 If `.jalxaml` IntelliSense only shows raw XML suggestions, verify the extension is installed in the same instance you are using.
 
 ## Compatibility Notes
 
 - Jalium.UI is not positioned as a drop-in WPF replacement yet.
-- API names and behavior are intentionally close to familiar WPF concepts in many areas, but differences exist.
+- API names and behavior are intentionally close to familiar WPF concepts, but differences exist.
 - Keep package versions aligned across all `Jalium.UI.*` packages.
 
 ## Contributing
 
 Issues and pull requests are welcome. For large changes, include:
 
-- motivation and design summary
-- behavioral impact/risk
-- validation steps (tests or manual verification)
+- Motivation and design summary
+- Behavioral impact/risk
+- Validation steps (tests or manual verification)
 
 ## Community
 

--- a/docs/manual-build-configuration.md
+++ b/docs/manual-build-configuration.md
@@ -152,9 +152,10 @@ dotnet build .\src\managed\Jalium.UI.Xaml\Jalium.UI.Xaml.csproj `
 
 - Visual Studio C++ 工具链
 - Windows SDK
-- Vulkan SDK
+- Vulkan SDK（Vulkan 后端必需）
+- Android NDK（Android 构建必需）
 
-### 6.2 推荐命令
+### 6.2 Windows 构建
 
 请在 **VS Developer Command Prompt** 或等效的 MSVC 环境中执行：
 
@@ -162,36 +163,45 @@ dotnet build .\src\managed\Jalium.UI.Xaml\Jalium.UI.Xaml.csproj `
 msbuild .\src\native\Jalium.Native.sln /m /p:Configuration=Debug /p:Platform=x64 /v:minimal
 ```
 
-### 6.3 说明
+### 6.3 Android 构建
 
-- `browser`、`core`、`metal`、`d3d12` 后端可以作为手动构建目标。
+```bash
+# 先构建依赖（FreeType + HarfBuzz）
+bash src/native/build-android-deps.sh
+
+# 构建原生库（输出到 src/native/out/android/<abi>/）
+bash src/native/build-android.sh        # 构建所有 ABI
+bash src/native/build-android.sh arm64-v8a  # 仅 arm64
+bash src/native/build-android.sh x86_64     # 仅 x86_64
+```
+
+构建输出位于 `src/native/out/android/` 下，按 ABI 分目录存放。
+
+### 6.4 说明
+
+- `browser`、`core`、`platform`、`software`、`d3d12` 后端可以作为手动构建目标。
 - `vulkan` 后端依赖 Vulkan SDK；未安装时会报 `vulkan/vulkan.h` 缺失。
+- `text` 后端在 Android/Linux 上使用 FreeType + HarfBuzz，需先运行 `build-android-deps.sh`。
 - 在普通 PowerShell 里直接跑 CMake/NMake，不保证具备完整的 `rc` / `mt` / MSVC 环境。
 
 ## 7. 当前支持矩阵
 
-- `dotnet restore .\Jalium.UI.slnx -p:GenerateAssemblyInfo=true`
-  可以
-- `Jalium.UI.Input`
-  可以
-- `Jalium.UI.Media`
-  可以
-- `Jalium.UI.Interop`
-  可以
-- `Jalium.UI.Controls`
-  可以
-- `Jalium.UI.Xaml`
-  可以
-- `src\native\Jalium.Native.sln`
-  部分可以
-  `vulkan` 需要额外安装 Vulkan SDK
-- `src\managed\Jalium.UI.Build\Jalium.UI.Build.csproj`
-  不建议用 `dotnet build`
-  需要 `MSBuild.exe`
-- `src\packaging\Jalium.UI.csproj`
-  当前不作为手动配置目标
-- `tests\Jalium.UI.Tests\Jalium.UI.Tests.csproj`
-  当前不作为手动配置目标
+| 目标 | 状态 | 备注 |
+| --- | --- | --- |
+| `dotnet restore .\Jalium.UI.slnx` | 可以 | 加 `-p:GenerateAssemblyInfo=true` |
+| `Jalium.UI.Input` | 可以 | |
+| `Jalium.UI.Media` | 可以 | |
+| `Jalium.UI.Interop` | 可以 | |
+| `Jalium.UI.Controls` | 可以 | |
+| `Jalium.UI.Xaml` | 可以 | |
+| `Jalium.UI.Gpu` | 可以 | |
+| `src\native\Jalium.Native.sln` | 部分 | `vulkan` 需 Vulkan SDK，`text` Android 需先构建依赖 |
+| `src\native\build-android.sh` | 可以 | 需 Android NDK，输出到 `out/android/` |
+| `Jalium.UI.Build` | 需 MSBuild | 不建议用 `dotnet build` |
+| `src\packaging\Jalium.UI\` | 可以 | 主 metapackage |
+| `src\packaging\Jalium.UI.Desktop\` | 可以 | Windows 桌面包 |
+| `src\packaging\Jalium.UI.Android\` | 可以 | Android 包 |
+| `tests\Jalium.UI.Tests\` | 可以 | xUnit 测试套件 |
 
 ## 8. 给用户的最小操作建议
 
@@ -203,7 +213,8 @@ msbuild .\src\native\Jalium.Native.sln /m /p:Configuration=Debug /p:Platform=x64
 4. 在仓库根目录创建 `packages\build`
 5. 执行 `dotnet restore .\Jalium.UI.slnx -p:GenerateAssemblyInfo=true`
 6. 按顺序执行 `Input`、`Media`、`Interop`、`Controls`、`Xaml`
-7. 如需 native，再用 `MSBuild` 执行 `src\native\Jalium.Native.sln`
+7. 如需 native，用 `MSBuild` 执行 `src\native\Jalium.Native.sln`
+8. 如需 Android native，执行 `build-android-deps.sh` 后再 `build-android.sh`
 
 不要承诺：
 


### PR DESCRIPTION
## Summary

- **README.md**: 全面更新项目文档，反映跨平台支持、所有 native 模块、新增控件和能力、修正构建路径和目录结构
- **docs/manual-build-configuration.md**: 新增 Android 构建章节，更新支持矩阵为表格格式

## Changes

- 项目定位更新为跨平台 (Windows/Android/Linux/macOS)
- 补全 8 个 native 模块（之前仅列 3 个）
- 新增 ClearType、Charts、UIA 无障碍、通知系统、GPU 特效等能力描述
- 修正构建路径和仓库目录结构树
- 新增 Android native 构建指引和文档索引

## Test plan

- [ ] 验证 README 中的构建命令可执行
- [ ] 确认仓库目录结构与实际一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)