### PR TITLE
feat(razor): add $.Property and #.Property syntax

### DIFF
--- a/src/managed/Jalium.UI.Build/TransformJalxamlRazorTask.cs
+++ b/src/managed/Jalium.UI.Build/TransformJalxamlRazorTask.cs
@@ -1101,10 +1101,10 @@ public sealed class TransformJalxamlRazorTask : Microsoft.Build.Utilities.Task
     }
 
     private static bool IsPathStart(char c) =>
-        c == '_' || c == '$' || char.IsLetter(c);
+        c == '_' || c == '$' || c == '#' || char.IsLetter(c);
 
     private static bool IsPathPart(char c) =>
-        char.IsLetterOrDigit(c) || c == '.' || c == '_' || c == '[' || c == ']' || c == '$';
+        char.IsLetterOrDigit(c) || c == '.' || c == '_' || c == '[' || c == ']' || c == '$' || c == '#';
 
     /// <summary>
     /// Parses balanced delimited C# content (parens or braces), matching the runtime parser.

--- a/src/managed/Jalium.UI.Controls/Editor/Syntax/JalxamlSyntaxHighlighter.cs
+++ b/src/managed/Jalium.UI.Controls/Editor/Syntax/JalxamlSyntaxHighlighter.cs
@@ -1944,10 +1944,10 @@ public sealed class JalxamlSyntaxHighlighter : ISyntaxHighlighter
     }
 
     private static bool IsRazorIdentifierStart(char c) =>
-        c == '_' || c == '$' || char.IsLetter(c);
+        c == '_' || c == '$' || c == '#' || char.IsLetter(c);
 
     private static bool IsRazorIdentifierPart(char c) =>
-        char.IsLetterOrDigit(c) || c is '.' or '_' or '[' or ']' or '$';
+        char.IsLetterOrDigit(c) || c is '.' or '_' or '[' or ']' or '$' or '#';
 
     private static bool IsNameStartChar(char c) =>
         char.IsLetter(c) || c == '_';

--- a/src/managed/Jalium.UI.Xaml/RazorBinding.cs
+++ b/src/managed/Jalium.UI.Xaml/RazorBinding.cs
@@ -14,6 +14,34 @@ internal static class RazorValueResolver
         object? codeBehind,
         string path)
     {
+        // $.path — self-reference: resolve against the target element itself
+        if (path.Length >= 2 && path[0] == '$' && path[1] == '.')
+        {
+            var selfPath = path[2..];
+            if (TryResolvePath(targetObject, selfPath, out _, out var selfValue))
+                return selfValue;
+            return null;
+        }
+
+        if (path.Length == 1 && path[0] == '$')
+            return targetObject;
+
+        // #.path — data model reference: resolve against DataContext only, no codeBehind fallback
+        if (path.Length >= 2 && path[0] == '#' && path[1] == '.')
+        {
+            var dataPath = path[2..];
+            if (TryResolveDataContext(targetObject, dataPath, out var foundInData, out var dataValue) && foundInData)
+                return dataValue;
+            return null;
+        }
+
+        if (path.Length == 1 && path[0] == '#')
+        {
+            if (targetObject is FrameworkElement fe)
+                return fe.DataContext;
+            return null;
+        }
+
         // 1. Try DataContext on the target element or its visual ancestors
         if (TryResolveDataContext(targetObject, path, out var foundInDataContext, out var valueFromDataContext) && foundInDataContext)
         {
@@ -661,6 +689,25 @@ internal static class RazorBindingEngine
 
     private static BindingBase CreatePreferredPathBinding(string path, object? codeBehind)
     {
+        // $.path — self-reference: bind to the element's own property via RelativeSource.Self
+        if (path.Length >= 2 && path[0] == '$' && path[1] == '.')
+        {
+            return new Binding(path[2..])
+            {
+                RelativeSource = RelativeSource.Self,
+                FallbackValue = DependencyProperty.UnsetValue
+            };
+        }
+
+        // #.path — data model: bind to DataContext only, no codeBehind fallback
+        if (path.Length >= 2 && path[0] == '#' && path[1] == '.')
+        {
+            return new Binding(path[2..])
+            {
+                FallbackValue = DependencyProperty.UnsetValue
+            };
+        }
+
         var dataContextBinding = new Binding(path)
         {
             FallbackValue = DependencyProperty.UnsetValue

--- a/src/managed/Jalium.UI.Xaml/RazorLightweightDependencyAnalyzer.cs
+++ b/src/managed/Jalium.UI.Xaml/RazorLightweightDependencyAnalyzer.cs
@@ -11,7 +11,7 @@ namespace Jalium.UI.Markup;
 internal static class RazorLightweightDependencyAnalyzer
 {
     private static readonly Regex IdentifierRegex = new(
-        @"(?<![.""\w])(?<id>[_a-zA-Z]\w*(?:\.[_a-zA-Z]\w*)*)",
+        @"(?<![.""\w])(?<id>(?:[$#]\.)?[_a-zA-Z]\w*(?:\.[_a-zA-Z]\w*)*)",
         RegexOptions.Compiled);
 
     private static readonly HashSet<string> ReservedIdentifiers = new(StringComparer.Ordinal)

--- a/src/managed/Jalium.UI.Xaml/RazorLightweightInterpreter.cs
+++ b/src/managed/Jalium.UI.Xaml/RazorLightweightInterpreter.cs
@@ -126,6 +126,10 @@ internal sealed class RazorTokenizer
         if (char.IsDigit(c) || (c == '.' && _pos + 1 < _source.Length && char.IsDigit(_source[_pos + 1])))
             return ReadNumber(start);
 
+        // $.path or #.path — Razor prefix identifiers (self-reference / data model)
+        if ((c == '$' || c == '#') && _pos + 1 < _source.Length && _source[_pos + 1] == '.')
+            return ReadPrefixedIdentifier(start);
+
         // @identifier (verbatim identifier: @class, @event)
         if (c == '@' && _pos < _source.Length && (char.IsLetter(_source[_pos]) || _source[_pos] == '_'))
             return ReadVerbatimIdentifier(start);
@@ -135,6 +139,14 @@ internal sealed class RazorTokenizer
 
         // Operators & delimiters
         return ReadOperator(start);
+    }
+
+    private RazorToken ReadPrefixedIdentifier(int start)
+    {
+        _pos += 2; // skip $ or # and the dot
+        while (_pos < _source.Length && (char.IsLetterOrDigit(_source[_pos]) || _source[_pos] is '_' or '.' or '[' or ']'))
+            _pos++;
+        return new RazorToken(RazorTokenKind.Identifier, _source[start.._pos], start);
     }
 
     private RazorToken ReadStringLiteral(int start)

--- a/src/managed/Jalium.UI.Xaml/RazorRoslynScriptCompiler.cs
+++ b/src/managed/Jalium.UI.Xaml/RazorRoslynScriptCompiler.cs
@@ -26,16 +26,50 @@ internal static partial class RazorCSharpDependencyAnalyzer
         "var", "virtual", "void", "volatile", "when", "while", "with"
     };
 
+    private const string SelfPlaceholder = "__razor_self__";
+    private const string DataPlaceholder = "__razor_data__";
+
     public static RazorCSharpDependencyAnalysis AnalyzeExpression(string expression)
     {
-        var syntax = SyntaxFactory.ParseExpression(expression);
-        return AnalyzeCore(syntax);
+        var preprocessed = PreprocessPrefixes(expression);
+        var syntax = SyntaxFactory.ParseExpression(preprocessed);
+        return RestorePrefixes(AnalyzeCore(syntax));
     }
 
     public static RazorCSharpDependencyAnalysis AnalyzeCodeBlock(string code)
     {
-        var tree = CSharpSyntaxTree.ParseText(code, ScriptParseOptions);
-        return AnalyzeCore(tree.GetRoot());
+        var preprocessed = PreprocessPrefixes(code);
+        var tree = CSharpSyntaxTree.ParseText(preprocessed, ScriptParseOptions);
+        return RestorePrefixes(AnalyzeCore(tree.GetRoot()));
+    }
+
+    private static string PreprocessPrefixes(string input)
+    {
+        // Replace $.path and #.path with placeholder identifiers so Roslyn can parse them
+        var result = input;
+        result = result.Replace("$.", SelfPlaceholder + ".", StringComparison.Ordinal);
+        result = result.Replace("#.", DataPlaceholder + ".", StringComparison.Ordinal);
+        return result;
+    }
+
+    private static RazorCSharpDependencyAnalysis RestorePrefixes(RazorCSharpDependencyAnalysis analysis)
+    {
+        var dependencies = analysis.Dependencies
+            .Select(static d => d
+                .Replace(SelfPlaceholder + ".", "$.", StringComparison.Ordinal)
+                .Replace(DataPlaceholder + ".", "#.", StringComparison.Ordinal))
+            .ToArray();
+
+        var rootIdentifiers = analysis.RootIdentifiers
+            .Select(static r => r switch
+            {
+                SelfPlaceholder => "$",
+                DataPlaceholder => "#",
+                _ => r
+            })
+            .ToArray();
+
+        return new RazorCSharpDependencyAnalysis(dependencies, rootIdentifiers, analysis.DeclaredIdentifiers);
     }
 
     private static RazorCSharpDependencyAnalysis AnalyzeCore(SyntaxNode root)

--- a/src/managed/Jalium.UI.Xaml/RazorTemplateParser.cs
+++ b/src/managed/Jalium.UI.Xaml/RazorTemplateParser.cs
@@ -182,7 +182,7 @@ internal static class RazorTemplateParser
 {
     private static readonly HashSet<char> PathChars = new(
     [
-        '.', '_', '[', ']', '$'
+        '.', '_', '[', ']', '$', '#'
     ]);
 
     public static RazorTemplate Parse(string value)
@@ -294,7 +294,7 @@ internal static class RazorTemplateParser
     }
 
     private static bool IsPathStart(char c) =>
-        c == '_' || c == '$' || char.IsLetter(c);
+        c == '_' || c == '$' || c == '#' || char.IsLetter(c);
 
     private static bool IsPathPart(char c) =>
         char.IsLetterOrDigit(c) || PathChars.Contains(c);


### PR DESCRIPTION
## Summary

- Add `$.Property` syntax for self-referencing the control's own properties (equivalent to `RelativeSource.Self` binding)
- Add `#.Property` syntax for direct DataContext access without codeBehind fallback (ideal for ItemTemplate)
- Changes span all 7 files across the full Razor pipeline: parsing, dependency analysis, value resolution, binding creation, and expression evaluation

## Details

**`$.Property` — Self-Reference**
- `@$.Background` reads the control's own `Background` property
- `@($.FontSize > 12 ? "Large" : "Small")` uses own property in expressions
- Creates `Binding` with `RelativeSource.Self` for reactive updates

**`#.Property` — Data Model Reference**
- `@#.Name` reads the DataContext's `Name` property directly
- `@(#.ItemCount > 5)` uses DataContext property in expressions
- Pure DataContext binding without codeBehind PriorityBinding fallback

**Modified files:**
- `RazorTemplateParser.cs` — path character set (`#` added)
- `TransformJalxamlRazorTask.cs` — build-time parser mirror
- `JalxamlSyntaxHighlighter.cs` — syntax highlighting mirror
- `RazorLightweightDependencyAnalyzer.cs` — regex for `$.`/`#.` dependency extraction
- `RazorRoslynScriptCompiler.cs` — Roslyn preprocessing with placeholder substitution
- `RazorBinding.cs` — `RazorValueResolver.Resolve()` + `CreatePreferredPathBinding()`
- `RazorLightweightInterpreter.cs` — `RazorTokenizer.ReadPrefixedIdentifier()`

## Test plan

- [x] `dotnet build` — Jalium.UI.Xaml, Jalium.UI.Controls compile with 0 C# errors
- [ ] Run Gallery and verify `@$.ActualWidth`, `@#.UserName` render correctly
- [ ] Verify `@($.IsEnabled)` expression evaluation in `@if` conditions
- [ ] Confirm existing Razor syntax (`@path`, `@(expr)`, `@if`, `@foreach`) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)