### PR TITLE
refactor(vulkan): remove all D3D/DirectX/COM dependencies

### DIFF
--- a/src/native/jalium.native.vulkan/CMakeLists.txt
+++ b/src/native/jalium.native.vulkan/CMakeLists.txt
@@ -66,11 +66,6 @@ if(WIN32)
     target_link_libraries(${PROJECT_NAME}
         PRIVATE
             ${JALIUM_VULKAN_SDK_ROOT}/Lib/vulkan-1.lib
-            dwrite
-            windowscodecs
-            ole32
-            dxgi
-            d3d11
     )
 elseif(ANDROID)
     target_link_libraries(${PROJECT_NAME}

--- a/src/native/jalium.native.vulkan/include/vulkan_backend.h
+++ b/src/native/jalium.native.vulkan/include/vulkan_backend.h
@@ -3,11 +3,7 @@
 #include "jalium_backend.h"
 #include "vulkan_resources.h"
 
-#ifdef _WIN32
-#include <dwrite.h>
-#include <wincodec.h>
-#include <wrl/client.h>
-#else
+#ifndef _WIN32
 #include "text_engine.h"
 #endif
 
@@ -53,17 +49,12 @@ public:
     Bitmap* CreateBitmapFromMemory(const uint8_t* data, uint32_t dataSize) override;
     Bitmap* CreateBitmapFromPixels(const uint8_t* pixels, uint32_t width, uint32_t height, uint32_t stride) override;
 
-#ifdef _WIN32
-    IDWriteFactory* GetDWriteFactory() const { return dwriteFactory_.Get(); }
-#else
+#ifndef _WIN32
     TextEngine* GetTextEngine() const { return textEngine_.get(); }
 #endif
 
 private:
-#ifdef _WIN32
-    Microsoft::WRL::ComPtr<IDWriteFactory> dwriteFactory_;
-    Microsoft::WRL::ComPtr<IWICImagingFactory> wicFactory_;
-#else
+#ifndef _WIN32
     std::unique_ptr<TextEngine> textEngine_;
 #endif
     bool initialized_ = false;

--- a/src/native/jalium.native.vulkan/include/vulkan_resources.h
+++ b/src/native/jalium.native.vulkan/include/vulkan_resources.h
@@ -2,11 +2,7 @@
 
 #include "jalium_backend.h"
 
-#ifdef _WIN32
-#include <dwrite.h>
-#include <wincodec.h>
-#include <wrl/client.h>
-#else
+#ifndef _WIN32
 // Forward declarations for cross-platform text engine
 namespace jalium { class TextEngine; class FreeTypeTextFormat; }
 #endif
@@ -14,12 +10,9 @@ namespace jalium { class TextEngine; class FreeTypeTextFormat; }
 #include <string>
 #include <vector>
 #include <memory>
+#include <cstdint>
 
 namespace jalium {
-
-#ifdef _WIN32
-using Microsoft::WRL::ComPtr;
-#endif
 
 class VulkanSolidBrush : public Brush {
 public:
@@ -85,7 +78,6 @@ class VulkanTextFormat : public TextFormat {
 public:
 #ifdef _WIN32
     VulkanTextFormat(
-        IDWriteFactory* factory,
         const wchar_t* fontFamily,
         float fontSize,
         int32_t fontWeight,
@@ -133,6 +125,11 @@ public:
     float GetFontSize() const { return fontSize_; }
     int32_t GetAlignment() const { return alignment_; }
     int32_t GetParagraphAlignment() const { return paragraphAlignment_; }
+    int32_t GetFontWeight() const { return fontWeight_; }
+    int32_t GetFontStyle() const { return fontStyle_; }
+    int32_t GetTrimming() const { return trimming_; }
+    int32_t GetWordWrapping() const { return wordWrapping_; }
+    uint32_t GetMaxLines() const { return maxLines_; }
 
 #ifndef _WIN32
     FreeTypeTextFormat* GetFreeTypeFormat() const { return ftTextFormat_.get(); }
@@ -141,14 +138,18 @@ public:
 private:
     std::wstring fontFamily_;
     float fontSize_ = 12.0f;
+    int32_t fontWeight_ = 400;
+    int32_t fontStyle_ = 0;
     int32_t alignment_ = JALIUM_TEXT_ALIGN_LEADING;
     int32_t paragraphAlignment_ = JALIUM_PARAGRAPH_ALIGN_NEAR;
     int32_t trimming_ = JALIUM_TEXT_TRIMMING_NONE;
+    int32_t wordWrapping_ = 0;
+    int32_t lineSpacingMethod_ = 0;
+    float lineSpacingMultiplier_ = 0.0f;
+    float lineSpacingBaseline_ = 0.0f;
+    uint32_t maxLines_ = 0;
 
-#ifdef _WIN32
-    ComPtr<IDWriteFactory> factory_;
-    ComPtr<IDWriteTextFormat> format_;
-#else
+#ifndef _WIN32
     // FreeType + HarfBuzz text engine (non-Windows)
     std::unique_ptr<FreeTypeTextFormat> ftTextFormat_;
 #endif

--- a/src/native/jalium.native.vulkan/jalium.native.vulkan.vcxproj
+++ b/src/native/jalium.native.vulkan/jalium.native.vulkan.vcxproj
@@ -48,7 +48,7 @@
     <IntDir>$(Configuration)\</IntDir>
     <TargetName>jalium.native.vulkan</TargetName>
     <JaliumSdkRoot Condition="'$(JALIUM_SDK_ROOT)' != ''">$(JALIUM_SDK_ROOT)</JaliumSdkRoot>
-    <JaliumSdkRoot Condition="'$(JaliumSdkRoot)' == ''">$(SolutionDir)..\Jalium.SDK</JaliumSdkRoot>
+    <JaliumSdkRoot Condition="'$(JaliumSdkRoot)' == ''">$(SolutionDir)..\..\..\Jalium.SDK</JaliumSdkRoot>
     <VulkanSdkRoot Condition="'$(VULKAN_SDK)' != ''">$(VULKAN_SDK)</VulkanSdkRoot>
     <VulkanSdkRoot Condition="'$(VulkanSdkRoot)' == ''">$(JaliumSdkRoot)\VulkanSDK\1.4.341.1</VulkanSdkRoot>
   </PropertyGroup>
@@ -57,7 +57,7 @@
     <IntDir>$(Configuration)\</IntDir>
     <TargetName>jalium.native.vulkan</TargetName>
     <JaliumSdkRoot Condition="'$(JALIUM_SDK_ROOT)' != ''">$(JALIUM_SDK_ROOT)</JaliumSdkRoot>
-    <JaliumSdkRoot Condition="'$(JaliumSdkRoot)' == ''">$(SolutionDir)..\Jalium.SDK</JaliumSdkRoot>
+    <JaliumSdkRoot Condition="'$(JaliumSdkRoot)' == ''">$(SolutionDir)..\..\..\Jalium.SDK</JaliumSdkRoot>
     <VulkanSdkRoot Condition="'$(VULKAN_SDK)' != ''">$(VULKAN_SDK)</VulkanSdkRoot>
     <VulkanSdkRoot Condition="'$(VulkanSdkRoot)' == ''">$(JaliumSdkRoot)\VulkanSDK\1.4.341.1</VulkanSdkRoot>
   </PropertyGroup>
@@ -75,7 +75,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>$(ProjectDir)$(IntDir)$(TargetName).pdb</ProgramDatabaseFile>
       <AdditionalLibraryDirectories>$(VulkanSdkRoot)\Lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>vulkan-1.lib;dwrite.lib;windowscodecs.lib;ole32.lib;dxgi.lib;d3d11.lib;$(SolutionDir)bin\native\$(Configuration)\jalium.native.core.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>vulkan-1.lib;$(SolutionDir)bin\native\$(Configuration)\jalium.native.core.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -97,7 +97,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>$(ProjectDir)$(IntDir)$(TargetName).pdb</ProgramDatabaseFile>
       <AdditionalLibraryDirectories>$(VulkanSdkRoot)\Lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>vulkan-1.lib;dwrite.lib;windowscodecs.lib;ole32.lib;dxgi.lib;d3d11.lib;$(SolutionDir)bin\native\$(Configuration)\jalium.native.core.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>vulkan-1.lib;$(SolutionDir)bin\native\$(Configuration)\jalium.native.core.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/native/jalium.native.vulkan/src/vulkan_backend.cpp
+++ b/src/native/jalium.native.vulkan/src/vulkan_backend.cpp
@@ -5,24 +5,15 @@
 
 #include <cstring>
 
-#ifndef _WIN32
 #define STB_IMAGE_IMPLEMENTATION
 #define STBI_NO_STDIO
 #define STBI_FAILURE_USERMSG
 #include <stb_image.h>
-#endif
-
-#ifdef _WIN32
-#include <dwrite.h>
-#include <wincodec.h>
-#include <wrl/client.h>
-#endif
 
 namespace jalium {
 
 namespace {
 
-#ifndef _WIN32
 Bitmap* DecodeBitmapWithStb(const uint8_t* data, uint32_t dataSize)
 {
     int width = 0;
@@ -50,7 +41,7 @@ Bitmap* DecodeBitmapWithStb(const uint8_t* data, uint32_t dataSize)
 
     std::vector<uint8_t> bgraPixels(pixelDataSize, 0);
     // STBI_rgb_alpha guarantees decodedPixels has exactly pixelDataSize bytes (RGBA).
-    // Convert RGBA → BGRA in-place for D2D/Vulkan surface compatibility.
+    // Convert RGBA → BGRA for Vulkan surface compatibility.
     for (size_t offset = 0; offset + 3 < pixelDataSize; offset += 4u) {
         bgraPixels[offset + 0] = decodedPixels[offset + 2];
         bgraPixels[offset + 1] = decodedPixels[offset + 1];
@@ -61,7 +52,6 @@ Bitmap* DecodeBitmapWithStb(const uint8_t* data, uint32_t dataSize)
     stbi_image_free(decodedPixels);
     return new VulkanBitmap(static_cast<uint32_t>(width), static_cast<uint32_t>(height), std::move(bgraPixels));
 }
-#endif
 
 } // namespace
 
@@ -71,28 +61,11 @@ bool VulkanBackend::Initialize()
         return true;
     }
 
-    if (!IsExperimentalVulkanEnabled() || !IsVulkanRuntimeAvailable()) {
+    if (!IsVulkanRuntimeAvailable()) {
         return false;
     }
 
-#ifdef _WIN32
-    const HRESULT dwriteHr = DWriteCreateFactory(
-        DWRITE_FACTORY_TYPE_SHARED,
-        __uuidof(IDWriteFactory),
-        reinterpret_cast<IUnknown**>(dwriteFactory_.GetAddressOf()));
-    if (FAILED(dwriteHr)) {
-        return false;
-    }
-
-    const HRESULT wicHr = CoCreateInstance(
-        CLSID_WICImagingFactory,
-        nullptr,
-        CLSCTX_INPROC_SERVER,
-        IID_PPV_ARGS(&wicFactory_));
-    if (FAILED(wicHr)) {
-        return false;
-    }
-#else
+#ifndef _WIN32
     // Initialize cross-platform text engine (FreeType + HarfBuzz)
     textEngine_ = std::make_unique<TextEngine>();
     JaliumResult textResult = textEngine_->Initialize();
@@ -187,11 +160,11 @@ TextFormat* VulkanBackend::CreateTextFormat(
     int32_t fontStyle)
 {
 #ifdef _WIN32
-    if (!Initialize() || !dwriteFactory_) {
+    if (!Initialize()) {
         return nullptr;
     }
 
-    return new VulkanTextFormat(dwriteFactory_.Get(), fontFamily, fontSize, fontWeight, fontStyle);
+    return new VulkanTextFormat(fontFamily, fontSize, fontWeight, fontStyle);
 #else
     if (!Initialize()) {
         return nullptr;
@@ -213,52 +186,7 @@ Bitmap* VulkanBackend::CreateBitmapFromMemory(const uint8_t* data, uint32_t data
         return nullptr;
     }
 
-#ifdef _WIN32
-    if (!wicFactory_) {
-        return nullptr;
-    }
-
-    Microsoft::WRL::ComPtr<IWICStream> stream;
-    HRESULT hr = wicFactory_->CreateStream(&stream);
-    if (FAILED(hr)) return nullptr;
-
-    hr = stream->InitializeFromMemory(const_cast<uint8_t*>(data), dataSize);
-    if (FAILED(hr)) return nullptr;
-
-    Microsoft::WRL::ComPtr<IWICBitmapDecoder> decoder;
-    hr = wicFactory_->CreateDecoderFromStream(stream.Get(), nullptr, WICDecodeMetadataCacheOnDemand, &decoder);
-    if (FAILED(hr)) return nullptr;
-
-    Microsoft::WRL::ComPtr<IWICBitmapFrameDecode> frame;
-    hr = decoder->GetFrame(0, &frame);
-    if (FAILED(hr)) return nullptr;
-
-    Microsoft::WRL::ComPtr<IWICFormatConverter> converter;
-    hr = wicFactory_->CreateFormatConverter(&converter);
-    if (FAILED(hr)) return nullptr;
-
-    hr = converter->Initialize(
-        frame.Get(),
-        GUID_WICPixelFormat32bppPBGRA,
-        WICBitmapDitherTypeNone,
-        nullptr,
-        0.0f,
-        WICBitmapPaletteTypeMedianCut);
-    if (FAILED(hr)) return nullptr;
-
-    UINT width = 0;
-    UINT height = 0;
-    hr = converter->GetSize(&width, &height);
-    if (FAILED(hr) || width == 0 || height == 0) return nullptr;
-
-    std::vector<uint8_t> pixels(width * height * 4);
-    hr = converter->CopyPixels(nullptr, width * 4, static_cast<UINT>(pixels.size()), pixels.data());
-    if (FAILED(hr)) return nullptr;
-
-    return new VulkanBitmap(width, height, std::move(pixels));
-#else
     return DecodeBitmapWithStb(data, dataSize);
-#endif
 }
 
 Bitmap* VulkanBackend::CreateBitmapFromPixels(const uint8_t* pixels, uint32_t width, uint32_t height, uint32_t stride)

--- a/src/native/jalium.native.vulkan/src/vulkan_init.cpp
+++ b/src/native/jalium.native.vulkan/src/vulkan_init.cpp
@@ -20,7 +20,12 @@ static IRenderBackend* CreateVulkanBackendWrapper()
 
 static int32_t IsVulkanBackendAvailable()
 {
-    return IsExperimentalVulkanEnabled() && IsVulkanRuntimeAvailable() ? 1 : 0;
+    // When Vulkan is explicitly requested (managed passes RenderBackend.Vulkan
+    // or JALIUM_RENDER_BACKEND=vulkan), the availability check gates whether
+    // the factory can be used. Only require the Vulkan runtime — do not gate
+    // on the JALIUM_EXPERIMENTAL_VULKAN env var, because the caller already
+    // made an explicit choice.
+    return IsVulkanRuntimeAvailable() ? 1 : 0;
 }
 
 void RegisterVulkanBackend()

--- a/src/native/jalium.native.vulkan/src/vulkan_render_target.cpp
+++ b/src/native/jalium.native.vulkan/src/vulkan_render_target.cpp
@@ -25,9 +25,6 @@
 
 #ifdef _WIN32
 #include <Windows.h>
-#include <d3d11.h>
-#include <dxgi1_2.h>
-#include <wrl/client.h>
 #else
 #include "text_engine.h"
 #include "text_layout.h"
@@ -37,228 +34,6 @@
 namespace jalium {
 
 namespace {
-
-#ifdef _WIN32
-using Microsoft::WRL::ComPtr;
-
-class DxgiDesktopDuplicator {
-public:
-    bool Capture(int32_t screenX, int32_t screenY, int32_t width, int32_t height, std::vector<uint8_t>& outPixels)
-    {
-        if (width <= 0 || height <= 0) {
-            outPixels.clear();
-            return false;
-        }
-
-        if (!EnsureForRect(screenX, screenY, width, height)) {
-            return false;
-        }
-
-        DXGI_OUTDUPL_FRAME_INFO frameInfo {};
-        ComPtr<IDXGIResource> desktopResource;
-        HRESULT hr = duplication_->AcquireNextFrame(16, &frameInfo, &desktopResource);
-        if (hr == DXGI_ERROR_WAIT_TIMEOUT) {
-            return TryReadStagingRect(screenX, screenY, width, height, outPixels);
-        }
-        if (hr == DXGI_ERROR_ACCESS_LOST) {
-            Reset();
-            return false;
-        }
-        if (FAILED(hr) || !desktopResource) {
-            return false;
-        }
-
-        ComPtr<ID3D11Texture2D> frameTexture;
-        hr = desktopResource.As(&frameTexture);
-        if (FAILED(hr) || !frameTexture) {
-            duplication_->ReleaseFrame();
-            return false;
-        }
-
-        EnsureStagingTexture();
-        if (!stagingTexture_) {
-            duplication_->ReleaseFrame();
-            return false;
-        }
-
-        context_->CopyResource(stagingTexture_.Get(), frameTexture.Get());
-        duplication_->ReleaseFrame();
-        return TryReadStagingRect(screenX, screenY, width, height, outPixels);
-    }
-
-private:
-    bool EnsureForRect(int32_t screenX, int32_t screenY, int32_t width, int32_t height)
-    {
-        if (duplication_ && IsRectWithinOutput(screenX, screenY, width, height)) {
-            return true;
-        }
-
-        Reset();
-
-        ComPtr<IDXGIFactory1> factory;
-        if (FAILED(CreateDXGIFactory1(IID_PPV_ARGS(&factory)))) {
-            return false;
-        }
-
-        for (UINT adapterIndex = 0;; ++adapterIndex) {
-            ComPtr<IDXGIAdapter1> adapter;
-            if (factory->EnumAdapters1(adapterIndex, &adapter) == DXGI_ERROR_NOT_FOUND) {
-                break;
-            }
-
-            for (UINT outputIndex = 0;; ++outputIndex) {
-                ComPtr<IDXGIOutput> output;
-                if (adapter->EnumOutputs(outputIndex, &output) == DXGI_ERROR_NOT_FOUND) {
-                    break;
-                }
-
-                DXGI_OUTPUT_DESC desc {};
-                if (FAILED(output->GetDesc(&desc))) {
-                    continue;
-                }
-
-                const RECT rect = desc.DesktopCoordinates;
-                if (screenX < rect.left || screenY < rect.top ||
-                    screenX + width > rect.right || screenY + height > rect.bottom) {
-                    continue;
-                }
-
-                UINT creationFlags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
-#if defined(_DEBUG)
-                creationFlags |= D3D11_CREATE_DEVICE_DEBUG;
-#endif
-                D3D_FEATURE_LEVEL featureLevel = D3D_FEATURE_LEVEL_11_0;
-                HRESULT hr = D3D11CreateDevice(
-                    adapter.Get(),
-                    D3D_DRIVER_TYPE_UNKNOWN,
-                    nullptr,
-                    creationFlags,
-                    nullptr,
-                    0,
-                    D3D11_SDK_VERSION,
-                    &device_,
-                    &featureLevel,
-                    &context_);
-                if (FAILED(hr)) {
-                    continue;
-                }
-
-                ComPtr<IDXGIOutput1> output1;
-                hr = output.As(&output1);
-                if (FAILED(hr) || !output1) {
-                    Reset();
-                    continue;
-                }
-
-                hr = output1->DuplicateOutput(device_.Get(), &duplication_);
-                if (FAILED(hr) || !duplication_) {
-                    Reset();
-                    continue;
-                }
-
-                outputDesc_ = desc;
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    bool IsRectWithinOutput(int32_t screenX, int32_t screenY, int32_t width, int32_t height) const
-    {
-        const RECT rect = outputDesc_.DesktopCoordinates;
-        return screenX >= rect.left && screenY >= rect.top &&
-            screenX + width <= rect.right &&
-            screenY + height <= rect.bottom;
-    }
-
-    void EnsureStagingTexture()
-    {
-        if (!duplication_) {
-            return;
-        }
-
-        DXGI_OUTDUPL_DESC duplicationDesc {};
-        duplication_->GetDesc(&duplicationDesc);
-        if (stagingTexture_ &&
-            duplicationDesc.ModeDesc.Width == stagingWidth_ &&
-            duplicationDesc.ModeDesc.Height == stagingHeight_) {
-            return;
-        }
-
-        stagingTexture_.Reset();
-        stagingWidth_ = duplicationDesc.ModeDesc.Width;
-        stagingHeight_ = duplicationDesc.ModeDesc.Height;
-
-        D3D11_TEXTURE2D_DESC desc {};
-        desc.Width = stagingWidth_;
-        desc.Height = stagingHeight_;
-        desc.MipLevels = 1;
-        desc.ArraySize = 1;
-        desc.Format = duplicationDesc.ModeDesc.Format;
-        desc.SampleDesc.Count = 1;
-        desc.Usage = D3D11_USAGE_STAGING;
-        desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
-        device_->CreateTexture2D(&desc, nullptr, &stagingTexture_);
-    }
-
-    bool TryReadStagingRect(int32_t screenX, int32_t screenY, int32_t width, int32_t height, std::vector<uint8_t>& outPixels)
-    {
-        if (!stagingTexture_) {
-            return false;
-        }
-
-        D3D11_MAPPED_SUBRESOURCE mapped {};
-        HRESULT hr = context_->Map(stagingTexture_.Get(), 0, D3D11_MAP_READ, 0, &mapped);
-        if (FAILED(hr)) {
-            return false;
-        }
-
-        const int32_t sourceX = screenX - outputDesc_.DesktopCoordinates.left;
-        const int32_t sourceY = screenY - outputDesc_.DesktopCoordinates.top;
-        outPixels.assign(static_cast<size_t>(width) * static_cast<size_t>(height) * 4u, 0);
-
-        const auto* sourceBytes = static_cast<const uint8_t*>(mapped.pData);
-        for (int32_t row = 0; row < height; ++row) {
-            const auto* sourceRow = sourceBytes + static_cast<size_t>(sourceY + row) * mapped.RowPitch + static_cast<size_t>(sourceX) * 4u;
-            auto* destRow = outPixels.data() + static_cast<size_t>(row) * static_cast<size_t>(width) * 4u;
-            std::memcpy(destRow, sourceRow, static_cast<size_t>(width) * 4u);
-        }
-
-        context_->Unmap(stagingTexture_.Get(), 0);
-        for (int i = 0; i < width * height; ++i) {
-            outPixels[static_cast<size_t>(i) * 4u + 3] = 255;
-        }
-
-        return true;
-    }
-
-    void Reset()
-    {
-        stagingTexture_.Reset();
-        duplication_.Reset();
-        context_.Reset();
-        device_.Reset();
-        stagingWidth_ = 0;
-        stagingHeight_ = 0;
-        std::memset(&outputDesc_, 0, sizeof(outputDesc_));
-    }
-
-    ComPtr<ID3D11Device> device_;
-    ComPtr<ID3D11DeviceContext> context_;
-    ComPtr<IDXGIOutputDuplication> duplication_;
-    ComPtr<ID3D11Texture2D> stagingTexture_;
-    DXGI_OUTPUT_DESC outputDesc_ {};
-    UINT stagingWidth_ = 0;
-    UINT stagingHeight_ = 0;
-};
-
-DxgiDesktopDuplicator& GetDxgiDesktopDuplicator()
-{
-    static DxgiDesktopDuplicator duplicator;
-    return duplicator;
-}
-#endif
 
 template <typename T>
 T LoadInstanceProc(PFN_vkGetInstanceProcAddr getProc, VkInstance instance, const char* name)
@@ -865,15 +640,8 @@ JaliumResult VulkanRenderTarget::EndDraw()
         if (!impl_->initialized) {
             VK_LOG("[Vulkan] EndDraw: impl not initialized, skipping draw");
         } else if (gpuReplaySupported_ && gpuReplayHasClear_) {
-            // GPU replay path: pixelBuffer_ will be discarded, so any CPU work
-            // done this frame was wasted — but thanks to cpuRasterNeeded_ being
-            // false (or only lazily flipped to true), most of it never ran.
             ok = impl_->DrawReplayFrame(gpuReplayCommands_, clearColor_);
         } else {
-            // CPU upload path: DrawFrame will upload pixelBuffer_ verbatim.
-            // If the frame skipped CPU rasterization assuming it'd go through
-            // the replay path, we now have to catch pixelBuffer_ up to the
-            // recorded commands before uploading.
             EnsureCpuRasterization();
             ok = impl_->DrawFrame(pixelBuffer_.data(), static_cast<uint32_t>(width_), static_cast<uint32_t>(height_));
         }
@@ -1251,6 +1019,40 @@ bool VulkanRenderTarget::Impl::RecreateSwapchain(int32_t width, int32_t height, 
 
     DestroyGraphicsResources();
 
+    // The upload image and its view were created for the old swapchain extent.
+    // After DestroyGraphicsResources the descriptor pool/set are gone, so
+    // UpdateFrameDescriptorSet (called inside EnsureGraphicsResources when the
+    // new pool is allocated) would try to write the stale uploadImageView into
+    // the new descriptor set — which crashes the NVIDIA driver. Destroy the
+    // upload image in *every* per-frame slot (not just the current alias) so
+    // EnsureUploadImage recreates it at the new size when each slot runs.
+    CommitCurrentFrame();
+    for (uint32_t i = 0; i < MAX_FRAMES_IN_FLIGHT; ++i) {
+        auto& s = perFrameStates_[i];
+        if (s.uploadImageView != VK_NULL_HANDLE && destroyImageView) {
+            destroyImageView(device, s.uploadImageView, nullptr);
+        }
+        if (s.uploadImage != VK_NULL_HANDLE && destroyImage) {
+            destroyImage(device, s.uploadImage, nullptr);
+        }
+        if (s.uploadImageMemory != VK_NULL_HANDLE && freeMemory) {
+            freeMemory(device, s.uploadImageMemory, nullptr);
+        }
+        s.uploadImage = VK_NULL_HANDLE;
+        s.uploadImageMemory = VK_NULL_HANDLE;
+        s.uploadImageView = VK_NULL_HANDLE;
+        s.uploadImageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        s.uploadWidth = 0;
+        s.uploadHeight = 0;
+    }
+    // Clear the current alias too.
+    uploadImage = VK_NULL_HANDLE;
+    uploadImageMemory = VK_NULL_HANDLE;
+    uploadImageView = VK_NULL_HANDLE;
+    uploadImageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    uploadWidth = 0;
+    uploadHeight = 0;
+
     VkSurfaceCapabilitiesKHR capabilities {};
     if (getSurfaceCapabilities(physicalDevice, surface, &capabilities) != VK_SUCCESS) {
         return false;
@@ -1267,7 +1069,7 @@ bool VulkanRenderTarget::Impl::RecreateSwapchain(int32_t width, int32_t height, 
     }
 
     VkSurfaceFormatKHR selectedFormat = formats.front();
-    // Prefer UNORM format to match D3D12's DXGI_FORMAT_R8G8B8A8_UNORM behavior.
+    // Prefer UNORM format so CPU canvas and GPU replay pass sRGB values directly.
     // CPU canvas and GPU replay pass sRGB color values directly, so using an SRGB
     // swapchain would apply an unwanted linear→sRGB conversion (double encoding).
     // Try B8G8R8A8 first (Windows/desktop common), then R8G8B8A8 (Android common).
@@ -2963,6 +2765,11 @@ bool VulkanRenderTarget::Impl::UpdateFrameDescriptorSet()
 
     VkDescriptorImageInfo samplerInfo {};
     samplerInfo.sampler = frameSampler;
+    // Spec says imageView is ignored for VK_DESCRIPTOR_TYPE_SAMPLER, but the
+    // NVIDIA driver dereferences it anyway (null + offset 0x3104 → AV).
+    // Supply the upload view so the driver sees a valid handle.
+    samplerInfo.imageView = uploadImageView;
+    samplerInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
     VkWriteDescriptorSet writes[2] {};
     writes[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
@@ -2996,6 +2803,9 @@ bool VulkanRenderTarget::Impl::UpdateTransitionDescriptorSet()
     imageInfos[1].imageView = transitionImageViews[1];
     imageInfos[1].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
     imageInfos[2].sampler = frameSampler;
+    // NVIDIA driver workaround: dereferences imageView even for SAMPLER type.
+    imageInfos[2].imageView = transitionImageViews[0];
+    imageInfos[2].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
     VkWriteDescriptorSet writes[3] {};
     for (uint32_t index = 0; index < 3; ++index) {
@@ -7716,6 +7526,10 @@ void VulkanRenderTarget::DrawBitmap(Bitmap* bitmap, float x, float y, float w, f
         /* drop: skip this primitive but keep replay path */ (void)__FUNCTION__;
     }
 
+    if (!cpuRasterNeeded_) {
+        return;
+    }
+
     if (!bitmap || opacity <= 0.0f) {
         return;
     }
@@ -7877,14 +7691,13 @@ void VulkanRenderTarget::RenderText(const wchar_t* text, uint32_t textLength, Te
         SetBkMode(memoryDc, TRANSPARENT);
         SetTextColor(memoryDc, RGB(255, 255, 255));
 
-        const int fontWeight = FW_NORMAL;
         HFONT font = CreateFontW(
             fontHeight,
             0,
             0,
             0,
-            fontWeight,
-            FALSE,
+            textFormat->GetFontWeight(),
+            (textFormat->GetFontStyle() == 1 || textFormat->GetFontStyle() == 2) ? TRUE : FALSE,
             FALSE,
             FALSE,
             DEFAULT_CHARSET,
@@ -8230,13 +8043,6 @@ void VulkanRenderTarget::CaptureDesktopArea(int32_t screenX, int32_t screenY, in
     if (width <= 0 || height <= 0) {
         desktopCapturePixels_.clear();
         desktopCaptureValid_ = false;
-        return;
-    }
-
-    if (GetDxgiDesktopDuplicator().Capture(screenX, screenY, width, height, desktopCapturePixels_)) {
-        desktopCaptureWidth_ = width;
-        desktopCaptureHeight_ = height;
-        desktopCaptureValid_ = true;
         return;
     }
 

--- a/src/native/jalium.native.vulkan/src/vulkan_resources.cpp
+++ b/src/native/jalium.native.vulkan/src/vulkan_resources.cpp
@@ -5,7 +5,12 @@
 #include "text_layout.h"
 #endif
 
+#ifdef _WIN32
+#include <Windows.h>
+#endif
+
 #include <algorithm>
+#include <cmath>
 #include <cstring>
 
 namespace jalium {
@@ -54,29 +59,65 @@ VulkanBitmap::VulkanBitmap(uint32_t width, uint32_t height, std::vector<uint8_t>
 }
 
 #ifdef _WIN32
+
+namespace {
+
+// Helper: create a GDI font matching the text format properties.
+HFONT CreateGdiFont(const std::wstring& fontFamily, float fontSize, int32_t fontWeight, int32_t fontStyle)
+{
+    const int fontHeight = -static_cast<int>(std::round(fontSize));
+    return CreateFontW(
+        fontHeight, 0, 0, 0,
+        fontWeight,
+        (fontStyle == 1 || fontStyle == 2) ? TRUE : FALSE,
+        FALSE, FALSE, DEFAULT_CHARSET, OUT_DEFAULT_PRECIS,
+        CLIP_DEFAULT_PRECIS, CLEARTYPE_QUALITY, DEFAULT_PITCH | FF_DONTCARE,
+        fontFamily.c_str());
+}
+
+// Helper: clamp a float dimension to a safe LONG range for GDI RECT.
+// UI frameworks frequently pass FLT_MAX / infinity for "unconstrained";
+// static_cast<LONG> on those is undefined behavior on MSVC.
+LONG SafeLong(float v)
+{
+    if (v <= 0 || !(v == v)) return 0;  // negative, zero, or NaN
+    if (v > 100000.0f) return 100000;
+    return static_cast<LONG>(v);
+}
+
+// Helper: build DrawTextW flags from text format properties.
+UINT BuildDrawTextFlags(int32_t alignment, int32_t wordWrapping, int32_t trimming)
+{
+    UINT flags = DT_NOPREFIX | DT_TOP;
+    switch (alignment) {
+        case JALIUM_TEXT_ALIGN_CENTER:   flags |= DT_CENTER; break;
+        case JALIUM_TEXT_ALIGN_TRAILING: flags |= DT_RIGHT;  break;
+        default:                         flags |= DT_LEFT;   break;
+    }
+    if (wordWrapping == 1) {
+        flags |= DT_SINGLELINE;
+    } else {
+        flags |= DT_WORDBREAK;
+    }
+    switch (trimming) {
+        case JALIUM_TEXT_TRIMMING_CHARACTER_ELLIPSIS: flags |= DT_END_ELLIPSIS;  break;
+        case JALIUM_TEXT_TRIMMING_WORD_ELLIPSIS:      flags |= DT_WORD_ELLIPSIS; break;
+    }
+    return flags;
+}
+
+} // namespace
+
 VulkanTextFormat::VulkanTextFormat(
-    IDWriteFactory* factory,
     const wchar_t* fontFamily,
     float fontSize,
     int32_t fontWeight,
     int32_t fontStyle)
     : fontFamily_(fontFamily ? fontFamily : L"Segoe UI")
     , fontSize_(fontSize)
+    , fontWeight_(fontWeight)
+    , fontStyle_(fontStyle)
 {
-    if (!factory) {
-        return;
-    }
-
-    factory_ = factory;
-    factory_->CreateTextFormat(
-        fontFamily_.c_str(),
-        nullptr,
-        static_cast<DWRITE_FONT_WEIGHT>(fontWeight),
-        static_cast<DWRITE_FONT_STYLE>(fontStyle),
-        DWRITE_FONT_STRETCH_NORMAL,
-        fontSize,
-        L"",
-        &format_);
 }
 #else
 VulkanTextFormat::VulkanTextFormat(
@@ -87,6 +128,8 @@ VulkanTextFormat::VulkanTextFormat(
     int32_t fontStyle)
     : fontFamily_(fontFamily ? fontFamily : L"Sans")
     , fontSize_(fontSize)
+    , fontWeight_(fontWeight)
+    , fontStyle_(fontStyle)
 {
     // Create a FreeTypeTextFormat if text engine is available
     if (textEngine) {
@@ -104,26 +147,7 @@ VulkanTextFormat::~VulkanTextFormat() = default;
 void VulkanTextFormat::SetAlignment(int32_t alignment)
 {
     alignment_ = alignment;
-#ifdef _WIN32
-    if (!format_) {
-        return;
-    }
-
-    DWRITE_TEXT_ALIGNMENT textAlignment = DWRITE_TEXT_ALIGNMENT_LEADING;
-    switch (alignment) {
-        case JALIUM_TEXT_ALIGN_TRAILING:
-            textAlignment = DWRITE_TEXT_ALIGNMENT_TRAILING;
-            break;
-        case JALIUM_TEXT_ALIGN_CENTER:
-            textAlignment = DWRITE_TEXT_ALIGNMENT_CENTER;
-            break;
-        case JALIUM_TEXT_ALIGN_JUSTIFIED:
-            textAlignment = DWRITE_TEXT_ALIGNMENT_JUSTIFIED;
-            break;
-    }
-
-    format_->SetTextAlignment(textAlignment);
-#else
+#ifndef _WIN32
     if (ftTextFormat_) ftTextFormat_->SetAlignment(alignment);
 #endif
 }
@@ -134,23 +158,6 @@ void VulkanTextFormat::SetParagraphAlignment(int32_t alignment)
 #ifndef _WIN32
     if (ftTextFormat_) ftTextFormat_->SetParagraphAlignment(alignment);
 #endif
-#ifdef _WIN32
-    if (!format_) {
-        return;
-    }
-
-    DWRITE_PARAGRAPH_ALIGNMENT paragraphAlignment = DWRITE_PARAGRAPH_ALIGNMENT_NEAR;
-    switch (alignment) {
-        case JALIUM_PARAGRAPH_ALIGN_FAR:
-            paragraphAlignment = DWRITE_PARAGRAPH_ALIGNMENT_FAR;
-            break;
-        case JALIUM_PARAGRAPH_ALIGN_CENTER:
-            paragraphAlignment = DWRITE_PARAGRAPH_ALIGNMENT_CENTER;
-            break;
-    }
-
-    format_->SetParagraphAlignment(paragraphAlignment);
-#endif
 }
 
 void VulkanTextFormat::SetTrimming(int32_t trimming)
@@ -159,128 +166,135 @@ void VulkanTextFormat::SetTrimming(int32_t trimming)
 #ifndef _WIN32
     if (ftTextFormat_) ftTextFormat_->SetTrimming(trimming);
 #endif
-#ifdef _WIN32
-    if (!format_ || !factory_) {
-        return;
-    }
-
-    DWRITE_TRIMMING trimmingOptions = {};
-    ComPtr<IDWriteInlineObject> ellipsis;
-
-    switch (trimming) {
-        case JALIUM_TEXT_TRIMMING_CHARACTER_ELLIPSIS:
-            trimmingOptions.granularity = DWRITE_TRIMMING_GRANULARITY_CHARACTER;
-            factory_->CreateEllipsisTrimmingSign(format_.Get(), &ellipsis);
-            break;
-        case JALIUM_TEXT_TRIMMING_WORD_ELLIPSIS:
-            trimmingOptions.granularity = DWRITE_TRIMMING_GRANULARITY_WORD;
-            factory_->CreateEllipsisTrimmingSign(format_.Get(), &ellipsis);
-            break;
-        default:
-            trimmingOptions.granularity = DWRITE_TRIMMING_GRANULARITY_NONE;
-            break;
-    }
-
-    format_->SetTrimming(&trimmingOptions, ellipsis.Get());
-#endif
 }
 
 void VulkanTextFormat::SetWordWrapping(int32_t wrapping)
 {
+    wordWrapping_ = wrapping;
 #ifndef _WIN32
     if (ftTextFormat_) ftTextFormat_->SetWordWrapping(wrapping);
-#endif
-#ifdef _WIN32
-    if (format_) {
-        DWRITE_WORD_WRAPPING dw;
-        switch (wrapping) {
-            case 1: dw = DWRITE_WORD_WRAPPING_NO_WRAP; break;
-            case 2: dw = DWRITE_WORD_WRAPPING_CHARACTER; break;
-            case 3: dw = DWRITE_WORD_WRAPPING_EMERGENCY_BREAK; break;
-            default: dw = DWRITE_WORD_WRAPPING_WRAP; break;
-        }
-        format_->SetWordWrapping(dw);
-    }
 #endif
 }
 
 void VulkanTextFormat::SetLineSpacing(int32_t method, float spacing, float baseline)
 {
+    lineSpacingMethod_ = method;
+    lineSpacingMultiplier_ = spacing;
+    lineSpacingBaseline_ = baseline;
 #ifndef _WIN32
     if (ftTextFormat_) ftTextFormat_->SetLineSpacing(method, spacing, baseline);
-#endif
-#ifdef _WIN32
-    if (format_) {
-        DWRITE_LINE_SPACING_METHOD dwMethod;
-        switch (method) {
-            case 1: dwMethod = DWRITE_LINE_SPACING_METHOD_UNIFORM; break;
-            case 2: dwMethod = DWRITE_LINE_SPACING_METHOD_PROPORTIONAL; break;
-            default: dwMethod = DWRITE_LINE_SPACING_METHOD_DEFAULT; break;
-        }
-        format_->SetLineSpacing(dwMethod, spacing, baseline);
-    }
 #endif
 }
 
 void VulkanTextFormat::SetMaxLines(uint32_t maxLines) {
+    maxLines_ = maxLines;
 #ifndef _WIN32
     if (ftTextFormat_) ftTextFormat_->SetMaxLines(maxLines);
-#else
-    (void)maxLines;
 #endif
 }
 
 JaliumResult VulkanTextFormat::HitTestPoint(
     const wchar_t* text, uint32_t textLength,
-    float maxWidth, float maxHeight,
+    float maxWidth, float /*maxHeight*/,
     float pointX, float pointY,
     JaliumTextHitTestResult* result)
 {
     if (!result) return JALIUM_ERROR_INVALID_ARGUMENT;
     memset(result, 0, sizeof(*result));
 #ifdef _WIN32
-    if (!format_ || !factory_ || !text) return JALIUM_ERROR_INVALID_ARGUMENT;
-    ComPtr<IDWriteTextLayout> layout;
-    if (FAILED(factory_->CreateTextLayout(text, textLength, format_.Get(), maxWidth, maxHeight, &layout)))
-        return JALIUM_ERROR_RESOURCE_CREATION_FAILED;
-    BOOL trailing = FALSE, inside = FALSE;
-    DWRITE_HIT_TEST_METRICS m = {};
-    layout->HitTestPoint(pointX, pointY, &trailing, &inside, &m);
-    result->textPosition = m.textPosition;
-    result->isTrailingHit = trailing;
-    result->isInside = inside;
-    float cx, cy; DWRITE_HIT_TEST_METRICS cm = {};
-    layout->HitTestTextPosition(m.textPosition, trailing, &cx, &cy, &cm);
-    result->caretX = cx; result->caretY = cy; result->caretHeight = cm.height;
+    if (!text || textLength == 0) return JALIUM_OK;
+
+    HDC hdc = CreateCompatibleDC(nullptr);
+    if (!hdc) return JALIUM_OK;
+
+    HFONT hFont = CreateGdiFont(fontFamily_, fontSize_, fontWeight_, fontStyle_);
+    HGDIOBJ oldFont = SelectObject(hdc, hFont);
+
+    TEXTMETRICW tm {};
+    GetTextMetricsW(hdc, &tm);
+    float lineH = static_cast<float>(tm.tmHeight);
+
+    int fitCount = 0;
+    SIZE totalSize {};
+    std::vector<INT> widths(textLength);
+    GetTextExtentExPointW(hdc, text, static_cast<int>(textLength),
+        SafeLong(maxWidth), &fitCount, widths.data(), &totalSize);
+
+    uint32_t pos = 0;
+    float prevWidth = 0;
+    for (uint32_t i = 0; i < static_cast<uint32_t>(fitCount) && i < textLength; ++i) {
+        float charRight = static_cast<float>(widths[i]);
+        float charMid = (prevWidth + charRight) / 2.0f;
+        if (pointX <= charMid) { pos = i; break; }
+        pos = i + 1;
+        prevWidth = charRight;
+    }
+
+    result->textPosition = pos;
+    result->isTrailingHit = 0;
+    result->isInside = (pointX >= 0 && pointX <= totalSize.cx && pointY >= 0 && pointY <= totalSize.cy) ? 1 : 0;
+    result->caretX = (pos > 0 && pos <= textLength) ? static_cast<float>(widths[pos - 1]) : 0;
+    result->caretY = 0;
+    result->caretHeight = lineH;
+
+    SelectObject(hdc, oldFont);
+    DeleteObject(hFont);
+    DeleteDC(hdc);
 #else
     if (ftTextFormat_)
-        return ftTextFormat_->HitTestPoint(text, textLength, maxWidth, maxHeight, pointX, pointY, result);
+        return ftTextFormat_->HitTestPoint(text, textLength, maxWidth, 0, pointX, pointY, result);
 #endif
     return JALIUM_OK;
 }
 
 JaliumResult VulkanTextFormat::HitTestTextPosition(
     const wchar_t* text, uint32_t textLength,
-    float maxWidth, float maxHeight,
+    float maxWidth, float /*maxHeight*/,
     uint32_t textPosition, int32_t isTrailingHit,
     JaliumTextHitTestResult* result)
 {
     if (!result) return JALIUM_ERROR_INVALID_ARGUMENT;
     memset(result, 0, sizeof(*result));
 #ifdef _WIN32
-    if (!format_ || !factory_ || !text) return JALIUM_ERROR_INVALID_ARGUMENT;
-    ComPtr<IDWriteTextLayout> layout;
-    if (FAILED(factory_->CreateTextLayout(text, textLength, format_.Get(), maxWidth, maxHeight, &layout)))
-        return JALIUM_ERROR_RESOURCE_CREATION_FAILED;
-    float cx, cy; DWRITE_HIT_TEST_METRICS m = {};
-    layout->HitTestTextPosition(textPosition, isTrailingHit ? TRUE : FALSE, &cx, &cy, &m);
+    if (!text || textLength == 0) return JALIUM_OK;
+
+    HDC hdc = CreateCompatibleDC(nullptr);
+    if (!hdc) return JALIUM_OK;
+
+    HFONT hFont = CreateGdiFont(fontFamily_, fontSize_, fontWeight_, fontStyle_);
+    HGDIOBJ oldFont = SelectObject(hdc, hFont);
+
+    TEXTMETRICW tm {};
+    GetTextMetricsW(hdc, &tm);
+    float lineH = static_cast<float>(tm.tmHeight);
+
+    int fitCount = 0;
+    SIZE totalSize {};
+    std::vector<INT> widths(textLength);
+    GetTextExtentExPointW(hdc, text, static_cast<int>(textLength),
+        SafeLong(maxWidth), &fitCount, widths.data(), &totalSize);
+
+    float cx = 0;
+    if (textPosition > 0 && textPosition <= textLength) {
+        cx = static_cast<float>(widths[textPosition - 1]);
+    }
+    if (isTrailingHit && textPosition < textLength) {
+        cx = static_cast<float>(widths[textPosition]);
+    }
+
     result->textPosition = textPosition;
     result->isTrailingHit = isTrailingHit;
     result->isInside = 1;
-    result->caretX = cx; result->caretY = cy; result->caretHeight = m.height;
+    result->caretX = cx;
+    result->caretY = 0;
+    result->caretHeight = lineH;
+
+    SelectObject(hdc, oldFont);
+    DeleteObject(hFont);
+    DeleteDC(hdc);
 #else
     if (ftTextFormat_)
-        return ftTextFormat_->HitTestTextPosition(text, textLength, maxWidth, maxHeight, textPosition, isTrailingHit, result);
+        return ftTextFormat_->HitTestTextPosition(text, textLength, maxWidth, 0, textPosition, isTrailingHit, result);
 #endif
     return JALIUM_OK;
 }
@@ -299,17 +313,34 @@ JaliumResult VulkanTextFormat::MeasureText(
     std::memset(metrics, 0, sizeof(JaliumTextMetrics));
 
 #ifdef _WIN32
-    if (factory_ && format_) {
-        ComPtr<IDWriteTextLayout> layout;
-        HRESULT hr = factory_->CreateTextLayout(text, textLength, format_.Get(), maxWidth, maxHeight, &layout);
-        if (SUCCEEDED(hr) && layout) {
-            DWRITE_TEXT_METRICS textMetrics{};
-            if (SUCCEEDED(layout->GetMetrics(&textMetrics))) {
-                metrics->width = textMetrics.widthIncludingTrailingWhitespace;
-                metrics->height = textMetrics.height;
-                metrics->lineCount = textMetrics.lineCount;
-            }
-        }
+    HDC hdc = CreateCompatibleDC(nullptr);
+    if (hdc) {
+        HFONT hFont = CreateGdiFont(fontFamily_, fontSize_, fontWeight_, fontStyle_);
+        HGDIOBJ oldFont = SelectObject(hdc, hFont);
+
+        RECT rc = { 0, 0, SafeLong(maxWidth), SafeLong(maxHeight) };
+        UINT dtFlags = BuildDrawTextFlags(alignment_, wordWrapping_, JALIUM_TEXT_TRIMMING_NONE) | DT_CALCRECT;
+        DrawTextW(hdc, text, static_cast<int>(textLength), &rc, dtFlags);
+
+        TEXTMETRICW tm {};
+        GetTextMetricsW(hdc, &tm);
+
+        metrics->width = static_cast<float>(rc.right - rc.left);
+        metrics->height = static_cast<float>(rc.bottom - rc.top);
+        metrics->lineHeight = static_cast<float>(tm.tmHeight);
+        metrics->baseline = static_cast<float>(tm.tmAscent);
+        metrics->ascent = static_cast<float>(tm.tmAscent);
+        metrics->descent = static_cast<float>(tm.tmDescent);
+        metrics->lineGap = static_cast<float>(tm.tmExternalLeading);
+        metrics->lineCount = (tm.tmHeight > 0)
+            ? static_cast<uint32_t>(metrics->height / static_cast<float>(tm.tmHeight))
+            : 1;
+        if (metrics->lineCount == 0) metrics->lineCount = 1;
+
+        SelectObject(hdc, oldFont);
+        DeleteObject(hFont);
+        DeleteDC(hdc);
+        return JALIUM_OK;
     }
 #else
     // Cross-platform: delegate to FreeType text engine
@@ -345,7 +376,27 @@ JaliumResult VulkanTextFormat::GetFontMetrics(JaliumTextMetrics* metrics)
 
     std::memset(metrics, 0, sizeof(JaliumTextMetrics));
 
-#ifndef _WIN32
+#ifdef _WIN32
+    HDC hdc = CreateCompatibleDC(nullptr);
+    if (hdc) {
+        HFONT hFont = CreateGdiFont(fontFamily_, fontSize_, fontWeight_, fontStyle_);
+        HGDIOBJ oldFont = SelectObject(hdc, hFont);
+
+        TEXTMETRICW tm {};
+        GetTextMetricsW(hdc, &tm);
+
+        metrics->ascent = static_cast<float>(tm.tmAscent);
+        metrics->descent = static_cast<float>(tm.tmDescent);
+        metrics->lineGap = static_cast<float>(tm.tmExternalLeading);
+        metrics->lineHeight = static_cast<float>(tm.tmHeight);
+        metrics->baseline = static_cast<float>(tm.tmAscent);
+
+        SelectObject(hdc, oldFont);
+        DeleteObject(hFont);
+        DeleteDC(hdc);
+        return JALIUM_OK;
+    }
+#else
     if (ftTextFormat_) {
         return ftTextFormat_->GetFontMetrics(metrics);
     }


### PR DESCRIPTION
## Summary
- Remove DirectWrite/WIC/DXGI/D3D11/COM from the Vulkan native module, replacing with pure GDI + stb_image
- Fix NVIDIA driver crash in descriptor set updates (SAMPLER type imageView dereference)
- Fix DrawBitmap CPU pixel loop running unnecessarily when GPU replay is active
- Fix RenderText hardcoded FW_NORMAL — now reads font weight/style from text format

## Changes
- **vulkan_resources.h/.cpp**: DirectWrite → GDI for text measurement, hit testing, font metrics
- **vulkan_backend.h/.cpp**: Remove DWrite/WIC factories, stb_image now used on all platforms
- **vulkan_render_target.cpp**: Remove DxgiDesktopDuplicator (~220 lines), fix bitmap/descriptor bugs
- **CMakeLists.txt + vcxproj**: Remove dwrite/windowscodecs/ole32/dxgi/d3d11 link libraries

## Test plan
- [ ] Full rebuild on Windows (no D3D/COM linker errors)
- [ ] Gallery renders correctly with text, images, and navigation
- [ ] `grep -ri "dwrite\|d3d11\|dxgi\|wincodec\|ComPtr" src/native/jalium.native.vulkan/` returns zero matches