### PR TITLE
fix(razor): detect $./# . bindings and @(expr) in .uic fallback check

### DIFF
--- a/src/managed/Jalium.UI.Xaml/JalxamlLoader.cs
+++ b/src/managed/Jalium.UI.Xaml/JalxamlLoader.cs
@@ -111,7 +111,10 @@ public static class JalxamlLoader
 
         using var reader = new System.IO.StreamReader(stream);
         var content = reader.ReadToEnd();
-        return content.Contains("@if(", StringComparison.Ordinal)
+        return content.Contains("@$.", StringComparison.Ordinal)
+            || content.Contains("@#.", StringComparison.Ordinal)
+            || content.Contains("@(", StringComparison.Ordinal)
+            || content.Contains("@if(", StringComparison.Ordinal)
             || content.Contains("@if (", StringComparison.Ordinal)
             || content.Contains("@for(", StringComparison.Ordinal)
             || content.Contains("@for (", StringComparison.Ordinal)


### PR DESCRIPTION
## Summary
- 修复 `JalxamlLoader.HasRazorDirectives()` 漏检 commit 3c9aa57 新增的 `@$.Property`（自引用绑定）和 `@#.Property`（数据模型绑定）语法,以及注释里声明应支持的 `@(expr)` 通用内联表达式
- 漏检会导致含这些绑定的 `.jalxaml` 错误走 `.uic` 编译二进制路径,而 `UICompiler` 在编译时会剥离 Razor 语法,绑定被静默丢弃
- 补齐后,此类文件会正确回退到运行时 `XamlReader`,行为与 `@if`/`@for` 等已支持的指令一致

## Why
Commit 3c9aa57 新增了 `$.Property` / `#.Property` Razor 绑定前缀,但只改动了 parser / analyzer / resolver / binding creator 等运行时链路,没有同步更新 `.uic` 回退检测器。结果:

```xml
<TextBlock Text="@$.IsEnabled" />
```

在 `HasRazorDirectives()` 中不匹配任何条件 → 返回 `false` → 走 `.uic` 二进制路径 → `BundleSerializer.Load` 里没有绑定元数据 → 属性静默使用默认值,用户无法感知绑定失败。

## Changes
`src/managed/Jalium.UI.Xaml/JalxamlLoader.cs` — 在 `HasRazorDirectives()` 返回表达式最前面增加三个检测:

```csharp
return content.Contains("@$.", StringComparison.Ordinal)
    || content.Contains("@#.", StringComparison.Ordinal)
    || content.Contains("@(", StringComparison.Ordinal)
    || content.Contains("@if(", StringComparison.Ordinal)
    // ... 其余保持不变
```

放最前面是利用 `||` 短路求值,让最常见的绑定场景更快返回。

## Test plan
- [ ] 在测试项目中新增含 `@$.Property` 绑定的 `.jalxaml`,确认运行时绑定生效(而非默认值)
- [ ] 在测试项目中新增含 `@#.Property` 绑定的 `.jalxaml`,确认绑定到 DataContext
- [ ] 在测试项目中新增含 `@(expr)` 内联表达式的 `.jalxaml`,确认表达式求值
- [ ] 不含 Razor 语法的纯静态 `.jalxaml` 仍走 `.uic` 路径(未触发回退)
- [ ] 现有 `@if`/`@for` 测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)