### PR TITLE
chore: bump version to 26.10.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <!-- Versioning -->
-    <Version>26.10.0-preview.4</Version>
+    <Version>26.10.0</Version>
     <AssemblyVersion>26.10.0.0</AssemblyVersion>
     <FileVersion>26.10.0.0</FileVersion>
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ and platform-native rendering backends (DirectX 12, Vulkan, Metal, Software).
 
 ## Project Status
 
-- Active development — v26.10.0-preview (APIs can still evolve between minor versions)
+- Active development — v26.10.0 (APIs can still evolve between minor versions)
 - Primary target: Windows 10/11 x64
 - Cross-platform: Android (arm64-v8a, x86_64), Linux (Vulkan), macOS (Metal)
 - Runtime target: .NET 10 (`net10.0-windows`, `net10.0-android`, `net10.0`)

--- a/tests/Jalium.UI.NuGetTest.Android/Jalium.UI.NuGetTest.Android.csproj
+++ b/tests/Jalium.UI.NuGetTest.Android/Jalium.UI.NuGetTest.Android.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jalium.UI.Android" Version="26.10.0-preview" />
+    <PackageReference Include="Jalium.UI.Android" Version="26.10.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Promote version from `26.10.0-preview.4` to `26.10.0` stable release.

## Changes

- `Directory.Build.props`: `<Version>26.10.0-preview.4</Version>` → `<Version>26.10.0</Version>`
- `README.md`: project status label updated
- `tests/Jalium.UI.NuGetTest.Android/Jalium.UI.NuGetTest.Android.csproj`: package reference version updated

## Test plan

- [ ] Verify NuGet packages build with version `26.10.0`
- [ ] Publish packages to nuget.org
- [ ] Create GitHub release `v26.10.0`