### PR TITLE
fix(virtualization): notify panel on RefreshItems so late-bound ItemsSource renders

### DIFF
--- a/src/managed/Jalium.UI.Controls/ItemsControl.cs
+++ b/src/managed/Jalium.UI.Controls/ItemsControl.cs
@@ -289,6 +289,24 @@ public class ItemsControl : Control
             var generator = EnsureItemContainerGenerator();
             generator.RemoveAll();
             AttachGeneratorToPanel(panel, generator);
+
+            // Force the virtualizing panel to reset its cached item-count / height
+            // index / realization window. Without this, when ItemsSource is supplied
+            // by a Binding that resolves AFTER the first Measure pass (e.g. a Page
+            // whose DataContext is assigned in code-behind after InitializeComponent),
+            // the panel is left with state from the initial zero-item measure and
+            // refuses to realize anything until the user scrolls.
+            if (panel is VirtualizingPanel virtualizingPanel)
+            {
+                virtualizingPanel.NotifyItemsChanged(
+                    generator,
+                    new ItemsChangedEventArgs(
+                        NotifyCollectionChangedAction.Reset,
+                        new GeneratorPosition(-1, 0),
+                        0,
+                        0));
+            }
+
             panel.InvalidateMeasure();
             InvalidateMeasure();
             return;

--- a/tests/Jalium.UI.Tests/VirtualizationPipelineTests.cs
+++ b/tests/Jalium.UI.Tests/VirtualizationPipelineTests.cs
@@ -100,6 +100,40 @@ public class VirtualizationPipelineTests
             Assert.Equal($"Person {expectedIndex + 1}", lbi.Content);
     }
 
+    [Fact]
+    public void ListBox_ItemsSourceSetAfterFirstMeasure_ShouldRealize()
+    {
+        // Regression: when ItemsSource is initially null during the first Measure
+        // pass and is set afterwards (simulating the state a Binding produces
+        // when DataContext is assigned after InitializeComponent), the panel
+        // must realize items on the next Measure rather than wait for a scroll.
+        var listBox = new TestListBox
+        {
+            Width = 320,
+            Height = 240,
+        };
+
+        // First Measure/Arrange with ItemsSource = null.
+        listBox.Measure(new Size(320, 240));
+        listBox.Arrange(new Rect(0, 0, 320, 240));
+
+        var host = Assert.IsType<VirtualizingStackPanel>(listBox.Host);
+        Assert.Empty(host.Children);
+
+        // Simulate the binding resolving by assigning ItemsSource after first layout.
+        var items = Enumerable.Range(1, 500).Select(i => $"Item {i}").ToList();
+        listBox.ItemsSource = items;
+
+        // Re-layout — without the fix in ItemsControl.RefreshItems, the panel's
+        // virtualization state (realization window / height index) remained at the
+        // empty first-measure snapshot and realized nothing on this second pass.
+        listBox.Measure(new Size(320, 240));
+        listBox.Arrange(new Rect(0, 0, 320, 240));
+
+        Assert.True(host.Children.Count > 0, "Panel should realize items after ItemsSource becomes non-null");
+        Assert.NotNull(listBox.ItemContainerGenerator.ContainerFromIndex(0));
+    }
+
     private sealed class TestListBox : ListBox
     {
         public Panel? Host => ItemsHost;


### PR DESCRIPTION
## Summary

修复 `<ListBox ItemsSource=\"{Binding Persons}\">` 在首屏渲染时空白,滚动一次才显示内容的 bug。直接赋值 `listBox.ItemsSource = ...` 没有此问题。

## Root cause

`ItemsControl.RefreshItems` 的虚拟化路径只做了 `panel.InvalidateMeasure()`,没有重置 `VirtualizingStackPanel` 内部的 realization window / height index / realized containers 状态。

**时序**:
1. `InitializeComponent` 建立 Binding,DataContext 未设 → ItemsSource = null
2. 首次 Measure (ItemsPresenter 刚创建 panel) → RefreshItems → 按 0 items 初始化 panel 状态
3. code-behind 里 `DataContext = ...` → Binding 激活 → ItemsSource 被赋值 → `OnItemsSourceChanged` → `RefreshItems` 再跑
4. **但 panel 的 `_currentWindow=Empty` / `_heightIndex` 仍是首次 0-item 状态**,下次 Measure 沿用 empty window → 什么也不 realize
5. 用户滚动触发 `SetOffset` → 重新计算 window → 终于 realize

## Fix

`src/managed/Jalium.UI.Controls/ItemsControl.cs` — `RefreshItems` 虚拟化路径,`AttachGeneratorToPanel` 后增加 `NotifyItemsChanged(Reset)`,交给 `VirtualizingStackPanel.OnItemsChanged` 正确重置 (heightIndex.Reset + ClearRealizedContainers + currentWindow=Empty + InvalidateMeasure)。

## Regression test

`VirtualizationPipelineTests.ListBox_ItemsSourceSetAfterFirstMeasure_ShouldRealize` —
- 首 Measure 时 ItemsSource=null
- 赋 500 项后再 Measure
- 断言 `host.Children.Count > 0` 且 `ContainerFromIndex(0) != null`

修复前失败(Count=0),修复后通过。

## Test plan

- [x] xunit: `dotnet test --filter FullyQualifiedName~Virtualization` 4/4 通过
- [ ] 手动: 跑 samples/RazorVirtualDataRepro 确认首屏直接有 Person 1..N,无需滚动

🤖 Generated with [Claude Code](https://claude.com/claude-code)