### PR TITLE
fix(xaml): auto-discover user XmlnsDefinition attributes without touching types

### DIFF
--- a/src/managed/Jalium.UI.Xaml/XmlnsDefinitionRegistry.cs
+++ b/src/managed/Jalium.UI.Xaml/XmlnsDefinitionRegistry.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Reflection;
 
 namespace Jalium.UI.Markup;
@@ -56,10 +57,206 @@ public static class XmlnsDefinitionRegistry
 
         AppDomain.CurrentDomain.AssemblyLoad += static (_, args) => ScanAssembly(args.LoadedAssembly);
 
+        // .NET 有两层 "看不见" 的机制会让声明了 [XmlnsDefinition] 的用户程序集
+        // 对 registry 不可见:
+        //   1) C# 编译器的 reference pruning:如果 consumer 代码没 touch 该程序集
+        //      的任何类型,编译器会把 AssemblyRef 从最终 metadata 里剔除,
+        //      GetReferencedAssemblies() 也看不到它,只靠传递引用 BFS 找不到。
+        //   2) .NET runtime 的 lazy-load:即便 metadata 里有 AssemblyRef,运行时
+        //      也只有在首次用到该程序集的类型时才会 Load。
+        // 这两层结合意味着"仅靠 <ProjectReference> + [assembly: XmlnsDefinition]"
+        // 的声明式用法无法让 user 控件被 XAML 识别。
+        //
+        // 根治策略:扫 entry exe 所在目录和所有已加载程序集所在目录的 *.dll,
+        // 逐个通过默认 load context 做 Assembly.Load,让 AssemblyLoad 事件把它们
+        // 带进 ScanAssembly。这正是 WPF 的做法。
+        ForceLoadProbingDirectories();
+        ForceLoadTransitiveReferences();
+
         foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
         {
             ScanAssembly(assembly);
         }
+    }
+
+    [UnconditionalSuppressMessage("AOT", "IL2026:RequiresUnreferencedCode",
+        Justification = "Probing-directory load is best-effort; failures are swallowed.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+        Justification = "No dynamic code generation — only name-based Assembly.Load calls.")]
+    private static void ForceLoadProbingDirectories()
+    {
+        // 候选目录:entry exe 目录 + 每个已加载程序集所在目录。
+        var directories = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        var entryAsm = Assembly.GetEntryAssembly();
+        TryAddDirectory(entryAsm, directories);
+
+        foreach (var loaded in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            TryAddDirectory(loaded, directories);
+        }
+
+        var alreadyLoaded = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var loaded in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            var name = loaded.GetName().Name;
+            if (name is not null)
+            {
+                alreadyLoaded.Add(name);
+            }
+        }
+
+        foreach (var directory in directories)
+        {
+            IEnumerable<string> dlls;
+            try
+            {
+                dlls = Directory.EnumerateFiles(directory, "*.dll", SearchOption.TopDirectoryOnly);
+            }
+            catch
+            {
+                continue;
+            }
+
+            foreach (var dllPath in dlls)
+            {
+                AssemblyName name;
+                try
+                {
+                    name = AssemblyName.GetAssemblyName(dllPath);
+                }
+                catch
+                {
+                    // 非托管 DLL / 损坏 / 权限问题 — 跳过。
+                    continue;
+                }
+
+                if (name.Name is null || !alreadyLoaded.Add(name.Name))
+                {
+                    continue;
+                }
+
+                if (IsFrameworkAssembly(name.Name))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    // 走默认 load context 的按名 Load,避免 LoadFrom 导致的 identity 冲突。
+                    Assembly.Load(name);
+                }
+                catch
+                {
+                    // 依赖解析失败、TFM 不兼容等 — 跳过,不阻塞 XAML 解析。
+                }
+            }
+        }
+    }
+
+    private static void TryAddDirectory(Assembly? assembly, HashSet<string> sink)
+    {
+        if (assembly is null || assembly.IsDynamic)
+        {
+            return;
+        }
+
+        string? location;
+        try
+        {
+            location = assembly.Location;
+        }
+        catch
+        {
+            return;
+        }
+
+        if (string.IsNullOrEmpty(location))
+        {
+            return;
+        }
+
+        var directory = Path.GetDirectoryName(location);
+        if (!string.IsNullOrEmpty(directory) && Directory.Exists(directory))
+        {
+            sink.Add(directory!);
+        }
+    }
+
+    [UnconditionalSuppressMessage("AOT", "IL2026:RequiresUnreferencedCode",
+        Justification = "Transitive load is best-effort; missing references are swallowed.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+        Justification = "No dynamic code generation — only reference-based Assembly.Load calls.")]
+    private static void ForceLoadTransitiveReferences()
+    {
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var queue = new Queue<Assembly>();
+
+        foreach (var loaded in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            if (loaded.IsDynamic)
+            {
+                continue;
+            }
+
+            var name = loaded.GetName().Name;
+            if (name is not null && visited.Add(name))
+            {
+                queue.Enqueue(loaded);
+            }
+        }
+
+        while (queue.Count > 0)
+        {
+            var current = queue.Dequeue();
+
+            AssemblyName[] references;
+            try
+            {
+                references = current.GetReferencedAssemblies();
+            }
+            catch
+            {
+                continue;
+            }
+
+            foreach (var reference in references)
+            {
+                if (reference.Name is null || !visited.Add(reference.Name))
+                {
+                    continue;
+                }
+
+                if (IsFrameworkAssembly(reference.Name))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    var loaded = Assembly.Load(reference);
+                    queue.Enqueue(loaded);
+                }
+                catch
+                {
+                    // 找不到、签名不匹配、安全策略阻止等情况跳过,不阻塞 XAML 解析。
+                }
+            }
+        }
+    }
+
+    private static bool IsFrameworkAssembly(string simpleName)
+    {
+        // BCL / runtime / 编译器内部程序集不可能声明 XmlnsDefinition,跳过显著降低启动开销。
+        return simpleName.StartsWith("System.", StringComparison.Ordinal)
+            || simpleName.StartsWith("Microsoft.", StringComparison.Ordinal)
+            || simpleName.StartsWith("runtime.", StringComparison.Ordinal)
+            || simpleName.Equals("mscorlib", StringComparison.Ordinal)
+            || simpleName.Equals("System", StringComparison.Ordinal)
+            || simpleName.Equals("netstandard", StringComparison.Ordinal)
+            || simpleName.Equals("WindowsBase", StringComparison.Ordinal)
+            || simpleName.Equals("PresentationCore", StringComparison.Ordinal)
+            || simpleName.Equals("PresentationFramework", StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/tests/Jalium.UI.Tests.XmlnsFixture/AssemblyInfo.cs
+++ b/tests/Jalium.UI.Tests.XmlnsFixture/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+using Jalium.UI.Markup;
+
+// 这个程序集被 Jalium.UI.Tests 以 <ProjectReference> 形式引入,但测试代码**不 touch**
+// 其中任何类型。用途:验证 XmlnsDefinitionRegistry.EnsureInitialized 的 force-load
+// 路径能在 .NET lazy-load 行为下把 user assembly 拉进 AppDomain,从而扫到它上面声明的
+// [XmlnsDefinition]。
+[assembly: XmlnsDefinition("urn:test:jalium:xmlns-lazy-fixture", "Jalium.UI.Tests.XmlnsFixture")]
+[assembly: XmlnsPrefix("urn:test:jalium:xmlns-lazy-fixture", "lazy")]

--- a/tests/Jalium.UI.Tests.XmlnsFixture/Jalium.UI.Tests.XmlnsFixture.csproj
+++ b/tests/Jalium.UI.Tests.XmlnsFixture/Jalium.UI.Tests.XmlnsFixture.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>false</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\managed\Jalium.UI.Core\Jalium.UI.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Jalium.UI.Tests.XmlnsFixture/LazyFixtureMarker.cs
+++ b/tests/Jalium.UI.Tests.XmlnsFixture/LazyFixtureMarker.cs
@@ -1,0 +1,7 @@
+namespace Jalium.UI.Tests.XmlnsFixture;
+
+/// <summary>
+/// 占位类型,确保程序集至少有一个公有类型可被 XmlnsDefinition 映射到的 CLR namespace 找到。
+/// 测试代码**不直接引用**这个类型,它完全靠 force-load 机制被发现。
+/// </summary>
+public sealed class LazyFixtureMarker;

--- a/tests/Jalium.UI.Tests/Jalium.UI.Tests.csproj
+++ b/tests/Jalium.UI.Tests/Jalium.UI.Tests.csproj
@@ -34,6 +34,9 @@
     <ProjectReference Include="..\..\src\managed\Jalium.UI.Interop\Jalium.UI.Interop.csproj" />
     <ProjectReference Include="..\..\src\managed\Jalium.UI.Media\Jalium.UI.Media.csproj" />
     <ProjectReference Include="..\..\src\managed\Jalium.UI.Xaml\Jalium.UI.Xaml.csproj" />
+    <!-- 仅引用,不在测试代码里 touch 任何类型 — 用于验证 XmlnsDefinitionRegistry
+         的 force-load 路径在 .NET lazy-load 行为下仍能扫到 [XmlnsDefinition]。 -->
+    <ProjectReference Include="..\Jalium.UI.Tests.XmlnsFixture\Jalium.UI.Tests.XmlnsFixture.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Jalium.UI.Tests/XmlnsDefinitionRegistryTests.cs
+++ b/tests/Jalium.UI.Tests/XmlnsDefinitionRegistryTests.cs
@@ -57,4 +57,20 @@ public class XmlnsDefinitionRegistryTests
     {
         Assert.Equal("ui", XmlnsDefinitionRegistry.GetPreferredPrefix(JalxamlNamespaces.Presentation));
     }
+
+    [Fact]
+    public void LazyLoadedUserAssembly_IsForceLoadedAndScanned()
+    {
+        // Jalium.UI.Tests.XmlnsFixture 被 <ProjectReference> 引入但测试代码没 touch 任何类型 —
+        // 在 .NET lazy-load 行为下,如果 EnsureInitialized 不主动递归 Assembly.Load
+        // 传递引用,它就不会出现在 AppDomain 里,attribute 也扫不到。这个测试锁住
+        // 新实现的 force-load 路径不会回归。
+        const string fixtureNs = "urn:test:jalium:xmlns-lazy-fixture";
+
+        var mappings = XmlnsDefinitionRegistry.GetMappings(fixtureNs);
+
+        Assert.NotEmpty(mappings);
+        Assert.Contains(mappings, m => m.ClrNamespace == "Jalium.UI.Tests.XmlnsFixture");
+        Assert.Equal("lazy", XmlnsDefinitionRegistry.GetPreferredPrefix(fixtureNs));
+    }
 }


### PR DESCRIPTION
## Summary

- `XmlnsDefinitionRegistry` now force-loads every DLL in the entry exe directory (and each loaded assembly's directory) during `EnsureInitialized`, so user assemblies that declare `[assembly: XmlnsDefinition(...)]` are discovered even when the host project never `new`s any of their types.
- BCL skip list (`System.*` / `Microsoft.*` / `runtime.*` / `mscorlib` / `netstandard` / `WindowsBase` / `Presentation*`) keeps startup cost bounded.
- Adds `tests/Jalium.UI.Tests.XmlnsFixture/` — a project referenced only via `<ProjectReference>` and never touched by test code — plus `LazyLoadedUserAssembly_IsForceLoadedAndScanned` to lock the fix in.

## Why

Two mechanisms silently break the declarative `[ProjectReference] + [XmlnsDefinition]` flow:

1. **C# compiler reference pruning** — if consumer code never references a type from the user assembly, the compiler strips the `AssemblyRef` from metadata. Transitive `GetReferencedAssemblies()` BFS can't find it.
2. **.NET runtime lazy-load** — even when the `AssemblyRef` is present, CLR doesn't load the DLL until a type from it is actually used.

Combined, this forced users to either keep a throwaway `var _ = new ThirdControl.LogoControl();` in startup code, or fall back to `XmlnsDefinitionRegistry.AddXmlnsDefinition(..., typeof(MyControl).Assembly)` — both just exist to coerce the assembly into the AppDomain. After this fix the attribute-only path works on its own.

## For reviewers

- The probing-directory scan uses `AssemblyName.GetAssemblyName(path)` + `Assembly.Load(AssemblyName)`, so assemblies go through the default load context (no `LoadFrom` identity issues).
- `ScanAssembly` is idempotent (`_scannedAssemblies.TryAdd`), so the overlap between the probing-directory pass, the transitive-reference BFS, and the subsequent `GetAssemblies()` sweep doesn't double-scan.
- Transitive `GetReferencedAssemblies()` BFS is retained as a secondary path for assemblies that are referenced but not physically adjacent on disk.
- **Known pre-existing unrelated issue**: a full `dotnet test` run aborts on a stack overflow in `JalxamlReader.Tokenizer` (confirmed reproducible on `master` without this change). `XmlnsDefinitionRegistryTests` (6/6) pass cleanly.

## Test plan

- [x] `dotnet test tests/Jalium.UI.Tests/Jalium.UI.Tests.csproj --filter "FullyQualifiedName~XmlnsDefinitionRegistryTests"` → 6/6 pass
- [x] New `LazyLoadedUserAssembly_IsForceLoadedAndScanned` test fails before the fix (`Collection was empty`) and passes after, verifying the fix without needing to touch fixture types from test code

🤖 Generated with [Claude Code](https://claude.com/claude-code)