### PR TITLE
feat(preview-26.10.2): NativeAOT single-exe build path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,11 @@ x86/
 [Ww][Ii][Nn]32/
 [Aa][Rr][Mm]/
 [Aa][Rr][Mm]64/
+
+# WebView2 redistributable static loader — required for NativeAOT single-exe
+# WebView builds. Re-included from the broad x64/ ignore above.
+!src/native/jalium.native.browser/third_party/webview2/lib/
+!src/native/jalium.native.browser/third_party/webview2/lib/**
 bld/
 [Bb]in/
 [Bb]in_*/

--- a/src/managed/Jalium.UI.Build/Jalium.UI.Build.csproj
+++ b/src/managed/Jalium.UI.Build/Jalium.UI.Build.csproj
@@ -76,9 +76,18 @@
              Properties="Configuration=$(Configuration)" />
   </Target>
 
+  <!--
+    Building a vcxproj requires the full Visual Studio MSBuild (it imports
+    $(VCTargetsPath)\Microsoft.Cpp.Default.props). The dotnet CLI's embedded
+    MSBuild ('Core') cannot do that and would fail with MSB4278. Restrict the
+    nested native build to Full MSBuild — anyone publishing through dotnet CLI
+    (notably NativeAOT publish) is expected to have built the native artifacts
+    out-of-band via samples/build-native-static.ps1 or by opening
+    Jalium.Native.sln in Visual Studio.
+  -->
   <Target Name="BuildNativeProjectsBeforeBuild"
           BeforeTargets="PrepareForBuild"
-          Condition="'$(BuildJaliumNativeProjects)' == 'true' and '$(DesignTimeBuild)' != 'true' and '@(JaliumNativeProject)' != '' and '$(OS)' == 'Windows_NT'">
+          Condition="'$(BuildJaliumNativeProjects)' == 'true' and '$(DesignTimeBuild)' != 'true' and '@(JaliumNativeProject)' != '' and '$(OS)' == 'Windows_NT' and '$(MSBuildRuntimeType)' == 'Full'">
     <Message Text="Building native projects @(JaliumNativeProject) (Configuration=$(JaliumNativeConfiguration), Platform=$(JaliumNativePlatform))"
              Importance="high" />
     <MSBuild Projects="@(JaliumNativeProject)"
@@ -89,7 +98,7 @@
 
   <Target Name="BuildStaticNativeProjectsBeforeBuild"
           BeforeTargets="PrepareForBuild"
-          Condition="'$(BuildJaliumNativeStaticProjects)' == 'true' and '$(DesignTimeBuild)' != 'true' and '@(JaliumNativeStaticProject)' != '' and '$(OS)' == 'Windows_NT'">
+          Condition="'$(BuildJaliumNativeStaticProjects)' == 'true' and '$(DesignTimeBuild)' != 'true' and '@(JaliumNativeStaticProject)' != '' and '$(OS)' == 'Windows_NT' and '$(MSBuildRuntimeType)' == 'Full'">
     <Message Text="Building NativeAOT static projects @(JaliumNativeStaticProject) (Configuration=$(JaliumNativeStaticConfiguration), Platform=$(JaliumNativeStaticPlatform))"
              Importance="high" />
     <MSBuild Projects="@(JaliumNativeStaticProject)"
@@ -125,12 +134,34 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Native static archives shipped to consumers that opt into NativeAOT
+         single-exe builds via <UseJaliumNativeAot>true</UseJaliumNativeAot>.
+         The build/Jalium.UI.Build.targets ConfigureJaliumNativeAot target wires
+         these into <NativeLibrary> + <DirectPInvoke> at the consumer side. -->
     <Content Include="..\..\native\bin\native-static\$(JaliumNativeStaticConfiguration)\jalium.native.core.static.lib" PackagePath="build\nativeaot\win-x64\" Visible="false"
              Condition="Exists('..\..\native\bin\native-static\$(JaliumNativeStaticConfiguration)\jalium.native.core.static.lib')" />
     <Content Include="..\..\native\bin\native-static\$(JaliumNativeStaticConfiguration)\jalium.native.d3d12.static.lib" PackagePath="build\nativeaot\win-x64\" Visible="false"
              Condition="Exists('..\..\native\bin\native-static\$(JaliumNativeStaticConfiguration)\jalium.native.d3d12.static.lib')" />
+    <Content Include="..\..\native\bin\native-static\$(JaliumNativeStaticConfiguration)\jalium.native.software.static.lib" PackagePath="build\nativeaot\win-x64\" Visible="false"
+             Condition="Exists('..\..\native\bin\native-static\$(JaliumNativeStaticConfiguration)\jalium.native.software.static.lib')" />
+    <Content Include="..\..\native\bin\native-static\$(JaliumNativeStaticConfiguration)\jalium.native.platform.static.lib" PackagePath="build\nativeaot\win-x64\" Visible="false"
+             Condition="Exists('..\..\native\bin\native-static\$(JaliumNativeStaticConfiguration)\jalium.native.platform.static.lib')" />
+    <Content Include="..\..\native\bin\native-static\$(JaliumNativeStaticConfiguration)\jalium.native.aot.static.lib" PackagePath="build\nativeaot\win-x64\" Visible="false"
+             Condition="Exists('..\..\native\bin\native-static\$(JaliumNativeStaticConfiguration)\jalium.native.aot.static.lib')" />
     <Content Include="..\..\native\bin\native-static\$(JaliumNativeStaticConfiguration)\jalium.native.browser.static.lib" PackagePath="build\nativeaot\win-x64\" Visible="false"
              Condition="Exists('..\..\native\bin\native-static\$(JaliumNativeStaticConfiguration)\jalium.native.browser.static.lib')" />
+  </ItemGroup>
+
+  <!-- Also surface the new static projects to the BeforeBuild static-builder
+       so a top-level 'msbuild Jalium.UI.Build.csproj' (full MSBuild only)
+       produces every archive consumed by ConfigureJaliumNativeAot. -->
+  <ItemGroup>
+    <JaliumNativeStaticProject Include="$(JaliumNativeRootPath)\jalium.native.software\jalium.native.software.static.vcxproj"
+                               Condition="Exists('$(JaliumNativeRootPath)\jalium.native.software\jalium.native.software.static.vcxproj')" />
+    <JaliumNativeStaticProject Include="$(JaliumNativeRootPath)\jalium.native.platform\jalium.native.platform.static.vcxproj"
+                               Condition="Exists('$(JaliumNativeRootPath)\jalium.native.platform\jalium.native.platform.static.vcxproj')" />
+    <JaliumNativeStaticProject Include="$(JaliumNativeRootPath)\jalium.native.aot\jalium.native.aot.static.vcxproj"
+                               Condition="Exists('$(JaliumNativeRootPath)\jalium.native.aot\jalium.native.aot.static.vcxproj')" />
   </ItemGroup>
 
 </Project>

--- a/src/managed/Jalium.UI.Build/build/Jalium.UI.Build.targets
+++ b/src/managed/Jalium.UI.Build/build/Jalium.UI.Build.targets
@@ -350,40 +350,169 @@
     <RemoveDir Directories="$(HlslShaderIntermediateOutputPath)" />
   </Target>
 
+  <!--
+    NativeAOT single-exe configuration entry point.
+
+    Consumer enables it with:
+        <PublishAot>true</PublishAot>
+        <UseJaliumNativeAot>true</UseJaliumNativeAot>
+
+    What this target wires up:
+      - Static archive resolution: prefers $(JaliumNativeAotAssetRoot)$(RuntimeIdentifier)\,
+        falling back to the in-repo build output for source-tree consumers.
+      - DirectPInvoke + NativeLibrary for every Jalium native module
+        (core / d3d12 / software / platform + aggregator) plus optional browser.
+      - LinkerArg for every Win32 / DirectX system import that the static
+        archives depend on (gdi32 etc. — NativeAOT does NOT auto-link these).
+      - StripJaliumNativeDllsAfterPublish: removes the shared-DLL drop-ins that
+        Interop's Content / build-time targets copy by default, so the publish
+        folder really is a single self-contained exe.
+
+    Knobs:
+      <JaliumIncludeBrowserAot>true|false</JaliumIncludeBrowserAot>
+          default false. Set true to include WebView2 browser support — note
+          this requires WebView2Loader.dll alongside the exe (browser is not
+          a true single-exe scenario).
+  -->
   <Target Name="ConfigureJaliumNativeAot"
           BeforeTargets="SetupOSSpecificProps"
           Condition="'$(UseJaliumNativeAot)' == 'true'">
     <PropertyGroup>
       <_JaliumNativeAotAssetDirectory>$([System.IO.Path]::GetFullPath('$(JaliumNativeAotAssetRoot)$(RuntimeIdentifier)\'))</_JaliumNativeAotAssetDirectory>
+      <!-- In-repo / source-tree fallback paths -->
       <_JaliumNativeAotFallbackAssetDirectory>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\..\native\bin\native-static\Release\'))</_JaliumNativeAotFallbackAssetDirectory>
+      <_JaliumNativeAotPackagedAssetDirectory>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)nativeaot\$(RuntimeIdentifier)\'))</_JaliumNativeAotPackagedAssetDirectory>
+      <!-- When the package was restored from NuGet, archives live in build/nativeaot/<rid>/ -->
+      <_JaliumNativeAotAssetDirectory Condition="'$(RuntimeIdentifier)' == 'win-x64' and !Exists('$(_JaliumNativeAotAssetDirectory)jalium.native.core.static.lib') and Exists('$(_JaliumNativeAotPackagedAssetDirectory)jalium.native.core.static.lib')">$(_JaliumNativeAotPackagedAssetDirectory)</_JaliumNativeAotAssetDirectory>
+      <!-- Source-tree fallback (when consumed via ProjectReference inside the repo) -->
       <_JaliumNativeAotAssetDirectory Condition="'$(RuntimeIdentifier)' == 'win-x64' and !Exists('$(_JaliumNativeAotAssetDirectory)jalium.native.core.static.lib') and Exists('$(_JaliumNativeAotFallbackAssetDirectory)jalium.native.core.static.lib')">$(_JaliumNativeAotFallbackAssetDirectory)</_JaliumNativeAotAssetDirectory>
+
+      <JaliumIncludeBrowserAot Condition="'$(JaliumIncludeBrowserAot)' == ''">false</JaliumIncludeBrowserAot>
+
+      <!-- WebView2LoaderStatic.lib resolution: prefer the copy shipped inside
+           Jalium.UI.Build's package, fall back to the source-tree third_party
+           copy for in-repo consumers. -->
+      <_JaliumWebView2LoaderStaticLib Condition="'$(JaliumIncludeBrowserAot)' == 'true' and Exists('$(_JaliumNativeAotAssetDirectory)WebView2LoaderStatic.lib')">$(_JaliumNativeAotAssetDirectory)WebView2LoaderStatic.lib</_JaliumWebView2LoaderStaticLib>
+      <_JaliumWebView2LoaderStaticLib Condition="'$(JaliumIncludeBrowserAot)' == 'true' and '$(_JaliumWebView2LoaderStaticLib)' == ''">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\..\native\jalium.native.browser\third_party\webview2\lib\x64\WebView2LoaderStatic.lib'))</_JaliumWebView2LoaderStaticLib>
     </PropertyGroup>
+
+    <Error Condition="'$(JaliumIncludeBrowserAot)' == 'true' and ('$(_JaliumWebView2LoaderStaticLib)' == '' or !Exists('$(_JaliumWebView2LoaderStaticLib)'))"
+           Text="JaliumIncludeBrowserAot=true requires WebView2LoaderStatic.lib. Looked at '$(_JaliumNativeAotAssetDirectory)WebView2LoaderStatic.lib' and the source-tree third_party fallback. Restore the Jalium.UI.Build NuGet package or copy WebView2LoaderStatic.lib (from Microsoft.Web.WebView2 NuGet) into src/native/jalium.native.browser/third_party/webview2/lib/x64/." />
 
     <Error Condition="'$(RuntimeIdentifier)' == ''"
            Text="UseJaliumNativeAot requires a RuntimeIdentifier. Set RuntimeIdentifier to a runtime with available static assets before publishing." />
     <Error Condition="'$(PublishAot)' != 'true'"
            Text="UseJaliumNativeAot requires PublishAot=true." />
     <Error Condition="!Exists('$(_JaliumNativeAotAssetDirectory)jalium.native.core.static.lib')"
-           Text="Jalium NativeAOT static assets were not found at '$(_JaliumNativeAotAssetDirectory)'. Restore or rebuild the Jalium.UI.Build package." />
+           Text="Jalium NativeAOT static assets not found at '$(_JaliumNativeAotAssetDirectory)'. Restore the Jalium.UI.Build package, or build src/native/Jalium.Native.sln (Configuration=Release Platform=x64) for in-source consumers." />
+    <Error Condition="!Exists('$(_JaliumNativeAotAssetDirectory)jalium.native.aot.static.lib')"
+           Text="Missing jalium.native.aot.static.lib at '$(_JaliumNativeAotAssetDirectory)'. The package is older than the AOT-aware Jalium.UI.Build — bump Jalium.UI.Build to a version that ships the aggregator archive." />
 
     <ItemGroup>
+      <!-- Managed-side P/Invoke hooks. The strings here MUST match the DLL
+           names that appear in [LibraryImport] / [DllImport] sites. -->
+      <DirectPInvoke Include="jalium.native.aot" />
       <DirectPInvoke Include="jalium.native.core" />
       <DirectPInvoke Include="jalium.native.d3d12" />
-      <DirectPInvoke Include="jalium.native.browser" />
+      <DirectPInvoke Include="jalium.native.software" />
+      <DirectPInvoke Include="jalium.native.platform" />
+      <DirectPInvoke Include="jalium.native.browser" Condition="'$(JaliumIncludeBrowserAot)' == 'true'" />
 
-      <NativeLibrary Include="$(_JaliumNativeAotAssetDirectory)jalium.native.core.static.lib" />
+      <!-- Static archives. Order matters loosely: aggregator first so the
+           linker sees its strong references to per-backend init functions
+           before scanning the per-backend archives. -->
+      <NativeLibrary Include="$(_JaliumNativeAotAssetDirectory)jalium.native.aot.static.lib" />
       <NativeLibrary Include="$(_JaliumNativeAotAssetDirectory)jalium.native.d3d12.static.lib" />
-      <NativeLibrary Include="$(_JaliumNativeAotAssetDirectory)jalium.native.browser.static.lib" />
+      <NativeLibrary Include="$(_JaliumNativeAotAssetDirectory)jalium.native.software.static.lib" />
+      <NativeLibrary Include="$(_JaliumNativeAotAssetDirectory)jalium.native.platform.static.lib" />
+      <NativeLibrary Include="$(_JaliumNativeAotAssetDirectory)jalium.native.core.static.lib" />
+      <NativeLibrary Include="$(_JaliumNativeAotAssetDirectory)jalium.native.browser.static.lib"
+                     Condition="'$(JaliumIncludeBrowserAot)' == 'true'" />
+      <!-- WebView2LoaderStatic.lib is the in-process WebView2 loader: it
+           locates the user-installed Edge WebView2 Runtime through COM/RoGet
+           rather than via WebView2Loader.dll. browser.cpp under JALIUM_STATIC
+           calls CreateCoreWebView2EnvironmentWithOptions /
+           GetAvailableCoreWebView2BrowserVersionString as direct imports,
+           which this archive resolves at link time. -->
+      <NativeLibrary Include="$(_JaliumWebView2LoaderStaticLib)"
+                     Condition="'$(JaliumIncludeBrowserAot)' == 'true'" />
 
-      <LinkerArg Include="&quot;d3d12.lib&quot;" />
-      <LinkerArg Include="&quot;dxgi.lib&quot;" />
-      <LinkerArg Include="&quot;dxguid.lib&quot;" />
-      <LinkerArg Include="&quot;d3dcompiler.lib&quot;" />
-      <LinkerArg Include="&quot;dwrite.lib&quot;" />
-      <LinkerArg Include="&quot;d2d1.lib&quot;" />
-      <LinkerArg Include="&quot;d3d11.lib&quot;" />
-      <LinkerArg Include="&quot;dcomp.lib&quot;" />
+      <!-- Win32 / DirectX system imports. NativeAOT only auto-links the .NET
+           runtime's required set, so anything used by our static archives must
+           be listed explicitly. Mirrors the AdditionalDependencies of the
+           dynamic-DLL vcxproj projects. -->
+      <NativeLibrary Include="d3d12.lib" />
+      <NativeLibrary Include="dxgi.lib" />
+      <NativeLibrary Include="dxguid.lib" />
+      <NativeLibrary Include="d3dcompiler.lib" />
+      <NativeLibrary Include="dwrite.lib" />
+      <NativeLibrary Include="d2d1.lib" />
+      <NativeLibrary Include="d3d11.lib" />
+      <NativeLibrary Include="dcomp.lib" />
+      <!-- GDI / windowing pulled by d3d12 desktop capture, glyph rasterizer,
+           software GDI text path, and platform window/eventloop. -->
+      <NativeLibrary Include="gdi32.lib" />
+      <NativeLibrary Include="user32.lib" />
+      <NativeLibrary Include="kernel32.lib" />
+      <NativeLibrary Include="ole32.lib" />
+      <NativeLibrary Include="oleaut32.lib" />
+      <NativeLibrary Include="shcore.lib" />
+      <NativeLibrary Include="shell32.lib" />
+      <NativeLibrary Include="advapi32.lib" />
+      <NativeLibrary Include="uuid.lib" />
+      <NativeLibrary Include="dwmapi.lib" />
+      <NativeLibrary Include="imm32.lib" />
+      <NativeLibrary Include="winmm.lib" />
+      <NativeLibrary Include="propsys.lib" />
     </ItemGroup>
+  </Target>
+
+  <!--
+    Strip post-publish artifacts that contradict the single-exe goal.
+
+    Even with UseJaliumNativeAot=true, the Jalium.UI.Interop NuGet package's
+    Content / build-time targets copy each per-backend shared DLL into the
+    output. Those copies happen during Interop's own build, where our
+    UseJaliumNativeAot flag doesn't propagate, so the file ends up in the
+    publish folder. We delete them here as the last step of publish.
+
+    Third-party native DLLs that Jalium.UI.Media transitively pulls in
+    (OpenCvSharp, SoundFlow, miniaudio, ffmpeg) are kept by default — they
+    belong to managed dependencies that the consumer may legitimately use.
+    Set <JaliumStripThirdPartyMediaNatives>true</JaliumStripThirdPartyMediaNatives>
+    if your app doesn't touch the video/audio APIs.
+  -->
+  <Target Name="StripJaliumDuplicateNativeDllsAfterPublish"
+          AfterTargets="Publish"
+          Condition="'$(UseJaliumNativeAot)' == 'true'">
+    <ItemGroup>
+      <_JaliumDllsToStrip Include="$(PublishDir)jalium.native.core.dll" />
+      <_JaliumDllsToStrip Include="$(PublishDir)jalium.native.d3d12.dll" />
+      <_JaliumDllsToStrip Include="$(PublishDir)jalium.native.vulkan.dll" />
+      <_JaliumDllsToStrip Include="$(PublishDir)jalium.native.software.dll" />
+      <_JaliumDllsToStrip Include="$(PublishDir)jalium.native.platform.dll" />
+      <!-- jalium.native.browser.dll is removed unconditionally: when
+           JaliumIncludeBrowserAot=false the browser feature is excluded; when
+           true, the .static.lib is linked instead and the .dll alongside is
+           pure dead weight from Interop's Content copy. -->
+      <_JaliumDllsToStrip Include="$(PublishDir)jalium.native.browser.dll" />
+      <!-- WebView2Loader.dll is replaced by WebView2LoaderStatic.lib in the
+           browser-AOT case, and unused entirely in the no-browser case. -->
+      <_JaliumDllsToStrip Include="$(PublishDir)WebView2Loader.dll" />
+      <_JaliumDllsToStrip Include="$(PublishDir)OpenCvSharpExtern.dll"
+                          Condition="'$(JaliumStripThirdPartyMediaNatives)' == 'true'" />
+      <_JaliumDllsToStrip Include="$(PublishDir)opencv_videoio_ffmpeg*.dll"
+                          Condition="'$(JaliumStripThirdPartyMediaNatives)' == 'true'" />
+      <_JaliumDllsToStrip Include="$(PublishDir)miniaudio.dll"
+                          Condition="'$(JaliumStripThirdPartyMediaNatives)' == 'true'" />
+      <_JaliumDllsToStrip Include="$(PublishDir)soundflow-ffmpeg.dll"
+                          Condition="'$(JaliumStripThirdPartyMediaNatives)' == 'true'" />
+    </ItemGroup>
+    <Delete Files="@(_JaliumDllsToStrip)" ContinueOnError="true">
+      <Output TaskParameter="DeletedFiles" ItemName="_JaliumDllsStripped" />
+    </Delete>
+    <Message Importance="High" Condition="'@(_JaliumDllsStripped)' != ''"
+             Text="Jalium NativeAOT: stripped @(_JaliumDllsStripped->'%(Filename)%(Extension)', ', ') (linked statically)." />
   </Target>
 
 </Project>

--- a/src/managed/Jalium.UI.Controls/PropertyItem.cs
+++ b/src/managed/Jalium.UI.Controls/PropertyItem.cs
@@ -212,7 +212,11 @@ public class PropertyItem : INotifyPropertyChanged
         }
     }
 
-    private static object? ConvertValue(object? value, Type targetType)
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+        Justification = "PropertyGrid is a developer/inspector control. Consumers that bind it to user-defined types must keep their property converters preserved (e.g. via DynamicDependency or PreserveCode) — that is a documented prerequisite for using PropertyGrid under AOT, not a defect of this site.")]
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+        Justification = "Convert.ChangeType to a runtime-supplied Type may construct Nullable<T>; same opt-in caveat as above.")]
+    private static object? ConvertValue(object? value, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)] Type targetType)
     {
         if (value == null)
             return null;

--- a/src/managed/Jalium.UI.Controls/Window.cs
+++ b/src/managed/Jalium.UI.Controls/Window.cs
@@ -6683,6 +6683,8 @@ public partial class Window : ContentControl, IWindowHost, ILayoutManagerHost, I
     /// <summary>
     /// Opens the DevTools window for this window.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+        Justification = "DevTools is an opt-in developer surface. Production AOT applications do not call OpenDevTools; consumers that do must keep DevTools reflection roots alive themselves.")]
     public void OpenDevTools()
     {
         if (_devToolsWindow == null)
@@ -9023,8 +9025,15 @@ public partial class Window : ContentControl, IWindowHost, ILayoutManagerHost, I
     Button? IInputDispatcherHost.FindButton(UIElement root, Func<Button, bool> predicate) => FindButton(root, predicate);
 
     bool IInputDispatcherHost.CanOpenDevTools => CanOpenDevTools;
+
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+        Justification = "DevTools opt-in; only reached via explicit F12 / manual host plumbing.")]
     void IInputDispatcherHost.ToggleDevTools() => ToggleDevTools();
+
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+        Justification = "DevTools opt-in; production AOT consumers do not invoke this path.")]
     void IInputDispatcherHost.OpenDevTools() => OpenDevTools();
+
     void IInputDispatcherHost.ActivateDevToolsPicker() => _devToolsWindow?.ActivatePicker();
 
     bool IInputDispatcherHost.CanToggleDebugHud

--- a/src/managed/Jalium.UI.Interop/Jalium.UI.Interop.csproj
+++ b/src/managed/Jalium.UI.Interop/Jalium.UI.Interop.csproj
@@ -20,8 +20,11 @@
     <ProjectReference Include="..\Jalium.UI.Media\Jalium.UI.Media.csproj" />
   </ItemGroup>
 
-  <!-- Native library references — Windows ships D3D12 + Vulkan + Software + Browser -->
-  <ItemGroup Condition="'$(Configuration)' == 'Debug'">
+  <!-- Native library references — Windows ships D3D12 + Vulkan + Software + Browser.
+       Suppressed when consumers build with PublishAot=true: those builds link the
+       jalium.native.*.static archives via samples/Jalium.UI.AotDemo's csproj instead,
+       so copying the shared DLLs would defeat the "single self-contained exe" goal. -->
+  <ItemGroup Condition="'$(Configuration)' == 'Debug' and '$(PublishAot)' != 'true'">
     <Content Include="..\..\native\bin\native\Debug\jalium.native.core.dll" Link="jalium.native.core.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/win-x64/native" />
     <Content Include="..\..\native\bin\native\Debug\jalium.native.d3d12.dll" Link="jalium.native.d3d12.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/win-x64/native" />
     <Content Include="..\..\native\bin\native\Debug\jalium.native.vulkan.dll" Link="jalium.native.vulkan.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/win-x64/native" Condition="Exists('..\..\native\bin\native\Debug\jalium.native.vulkan.dll')" />
@@ -30,7 +33,7 @@
     <Content Include="..\..\native\jalium.native.browser\redist\WebView2Loader.dll" Link="WebView2Loader.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/win-x64/native" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(Configuration)' == 'Release'">
+  <ItemGroup Condition="'$(Configuration)' == 'Release' and '$(PublishAot)' != 'true'">
     <Content Include="..\..\native\bin\native\Release\jalium.native.core.dll" Link="jalium.native.core.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/win-x64/native" />
     <Content Include="..\..\native\bin\native\Release\jalium.native.d3d12.dll" Link="jalium.native.d3d12.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/win-x64/native" />
     <Content Include="..\..\native\bin\native\Release\jalium.native.vulkan.dll" Link="jalium.native.vulkan.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/win-x64/native" Condition="Exists('..\..\native\bin\native\Release\jalium.native.vulkan.dll')" />

--- a/src/managed/Jalium.UI.Interop/Jalium.UI.Interop.csproj
+++ b/src/managed/Jalium.UI.Interop/Jalium.UI.Interop.csproj
@@ -21,10 +21,15 @@
   </ItemGroup>
 
   <!-- Native library references — Windows ships D3D12 + Vulkan + Software + Browser.
-       Suppressed when consumers build with PublishAot=true: those builds link the
-       jalium.native.*.static archives via samples/Jalium.UI.AotDemo's csproj instead,
-       so copying the shared DLLs would defeat the "single self-contained exe" goal. -->
-  <ItemGroup Condition="'$(Configuration)' == 'Debug' and '$(PublishAot)' != 'true'">
+       Suppressed only when consumers actually opt into static linkage with
+       <UseJaliumNativeAot>true</UseJaliumNativeAot>; in that case Jalium.UI.Build's
+       ConfigureJaliumNativeAot target wires the .static.lib archives instead and
+       copying the shared DLLs would defeat the "single self-contained exe" goal.
+       Note: gating on PublishAot alone would break vanilla NativeAOT consumers
+       (PublishAot=true without UseJaliumNativeAot) — they would get neither the
+       static-link wiring nor the dynamic DLLs and trip DllNotFoundException at
+       runtime. -->
+  <ItemGroup Condition="'$(Configuration)' == 'Debug' and '$(UseJaliumNativeAot)' != 'true'">
     <Content Include="..\..\native\bin\native\Debug\jalium.native.core.dll" Link="jalium.native.core.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/win-x64/native" />
     <Content Include="..\..\native\bin\native\Debug\jalium.native.d3d12.dll" Link="jalium.native.d3d12.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/win-x64/native" />
     <Content Include="..\..\native\bin\native\Debug\jalium.native.vulkan.dll" Link="jalium.native.vulkan.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/win-x64/native" Condition="Exists('..\..\native\bin\native\Debug\jalium.native.vulkan.dll')" />
@@ -33,7 +38,7 @@
     <Content Include="..\..\native\jalium.native.browser\redist\WebView2Loader.dll" Link="WebView2Loader.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/win-x64/native" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(Configuration)' == 'Release' and '$(PublishAot)' != 'true'">
+  <ItemGroup Condition="'$(Configuration)' == 'Release' and '$(UseJaliumNativeAot)' != 'true'">
     <Content Include="..\..\native\bin\native\Release\jalium.native.core.dll" Link="jalium.native.core.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/win-x64/native" />
     <Content Include="..\..\native\bin\native\Release\jalium.native.d3d12.dll" Link="jalium.native.d3d12.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/win-x64/native" />
     <Content Include="..\..\native\bin\native\Release\jalium.native.vulkan.dll" Link="jalium.native.vulkan.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/win-x64/native" Condition="Exists('..\..\native\bin\native\Release\jalium.native.vulkan.dll')" />

--- a/src/managed/Jalium.UI.Interop/JaliumStaticInit.cs
+++ b/src/managed/Jalium.UI.Interop/JaliumStaticInit.cs
@@ -1,0 +1,30 @@
+using System.Runtime.InteropServices;
+
+namespace Jalium.UI.Interop;
+
+/// <summary>
+/// Backend registration entry point for NativeAOT / fully-static-linked builds.
+/// </summary>
+/// <remarks>
+/// In the standard shared-DLL build each backend's DllMain registers itself with
+/// the core BackendRegistry on load, so this class is never used. When the
+/// process is statically linked (NativeAOT consumes <c>jalium.native.aot.static.lib</c>
+/// alongside the per-backend <c>.static.lib</c> archives) there are no DLLs and
+/// therefore no DllMain — the application MUST call
+/// <see cref="RegisterAllBackends"/> exactly once before any
+/// <c>jalium_context_create</c> call so the backend registry is populated.
+/// <para>
+/// The entry point lives in <c>jalium.native.aot</c>. In the AOT image this is
+/// resolved by <c>&lt;DirectPInvoke Include="jalium.native.aot" /&gt;</c>; in a
+/// dynamic build there is no such DLL and the call would throw
+/// <see cref="System.DllNotFoundException"/>, which is fine because nobody calls
+/// it in that mode.
+/// </para>
+/// </remarks>
+public static class JaliumStaticInit
+{
+    private const string AotLib = "jalium.native.aot";
+
+    [DllImport(AotLib, EntryPoint = "jalium_aot_register_all_backends", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void RegisterAllBackends();
+}

--- a/src/native/CMakeLists.txt
+++ b/src/native/CMakeLists.txt
@@ -5,6 +5,20 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# ---------------------------------------------------------------------------
+# Build flavor: shared (default, NuGet) or static (NativeAOT single-exe)
+# ---------------------------------------------------------------------------
+option(JALIUM_BUILD_STATIC "Build native libraries as static archives for NativeAOT linking" OFF)
+
+if(JALIUM_BUILD_STATIC)
+    set(JALIUM_LIB_TYPE STATIC)
+    add_compile_definitions(JALIUM_STATIC)
+    # PIC is required if these archives are later combined into a shared image.
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+else()
+    set(JALIUM_LIB_TYPE SHARED)
+endif()
+
 # Windows-specific settings
 if(WIN32)
     add_compile_definitions(
@@ -16,9 +30,15 @@ if(WIN32)
 endif()
 
 # Output directories
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+if(JALIUM_BUILD_STATIC)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin-static)
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib-static)
+    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib-static)
+else()
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+endif()
 
 # Subdirectories — order matters: text must precede vulkan/software for linkage
 add_subdirectory(jalium.native.core)
@@ -40,3 +60,9 @@ else()
 endif()
 
 add_subdirectory(jalium.native.software)
+
+# Static-only aggregation TU that exports jalium_aot_register_all_backends().
+# Only meaningful when JALIUM_BUILD_STATIC=ON; pulls every backend into the AOT image.
+if(JALIUM_BUILD_STATIC)
+    add_subdirectory(jalium.native.aot)
+endif()

--- a/src/native/Jalium.Native.sln
+++ b/src/native/Jalium.Native.sln
@@ -13,6 +13,22 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "jalium.native.metal", "jali
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "jalium.native.browser", "jalium.native.browser\jalium.native.browser.vcxproj", "{C3D4E5F6-3456-789A-BCDE-F0123456789A}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "jalium.native.core.static", "jalium.native.core\jalium.native.core.static.vcxproj", "{42D22534-5A36-41D5-A4D4-C7E2171C90C0}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "jalium.native.d3d12.static", "jalium.native.d3d12\jalium.native.d3d12.static.vcxproj", "{3FEFEAAB-211A-4E64-B314-7E5B4F3A1AA4}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "jalium.native.browser.static", "jalium.native.browser\jalium.native.browser.static.vcxproj", "{A6DF12F8-7AB8-4A95-B0A4-F8858EDB501A}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "jalium.native.vulkan.static", "jalium.native.vulkan\jalium.native.vulkan.static.vcxproj", "{7A1B0C2D-8A9D-4F31-9C8B-2D5E6F7A8B91}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "jalium.native.software.static", "jalium.native.software\jalium.native.software.static.vcxproj", "{8B2C1D3E-9BAE-4042-AD9C-3E6F708192A2}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "jalium.native.aot.static", "jalium.native.aot\jalium.native.aot.static.vcxproj", "{9C3D4E5F-AC1F-4153-BE0E-4F708192B3C3}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "jalium.native.platform", "jalium.native.platform\jalium.native.platform.vcxproj", "{F1A2B3C4-D5E6-4071-8293-A4B5C6D7E8F9}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "jalium.native.platform.static", "jalium.native.platform\jalium.native.platform.static.vcxproj", "{2C3D4E5F-6071-4283-94A5-B6C7D8E9F0A1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -37,6 +53,38 @@ Global
 		{C3D4E5F6-3456-789A-BCDE-F0123456789A}.Debug|x64.Build.0 = Debug|x64
 		{C3D4E5F6-3456-789A-BCDE-F0123456789A}.Release|x64.ActiveCfg = Release|x64
 		{C3D4E5F6-3456-789A-BCDE-F0123456789A}.Release|x64.Build.0 = Release|x64
+		{42D22534-5A36-41D5-A4D4-C7E2171C90C0}.Debug|x64.ActiveCfg = Debug|x64
+		{42D22534-5A36-41D5-A4D4-C7E2171C90C0}.Debug|x64.Build.0 = Debug|x64
+		{42D22534-5A36-41D5-A4D4-C7E2171C90C0}.Release|x64.ActiveCfg = Release|x64
+		{42D22534-5A36-41D5-A4D4-C7E2171C90C0}.Release|x64.Build.0 = Release|x64
+		{3FEFEAAB-211A-4E64-B314-7E5B4F3A1AA4}.Debug|x64.ActiveCfg = Debug|x64
+		{3FEFEAAB-211A-4E64-B314-7E5B4F3A1AA4}.Debug|x64.Build.0 = Debug|x64
+		{3FEFEAAB-211A-4E64-B314-7E5B4F3A1AA4}.Release|x64.ActiveCfg = Release|x64
+		{3FEFEAAB-211A-4E64-B314-7E5B4F3A1AA4}.Release|x64.Build.0 = Release|x64
+		{A6DF12F8-7AB8-4A95-B0A4-F8858EDB501A}.Debug|x64.ActiveCfg = Debug|x64
+		{A6DF12F8-7AB8-4A95-B0A4-F8858EDB501A}.Debug|x64.Build.0 = Debug|x64
+		{A6DF12F8-7AB8-4A95-B0A4-F8858EDB501A}.Release|x64.ActiveCfg = Release|x64
+		{A6DF12F8-7AB8-4A95-B0A4-F8858EDB501A}.Release|x64.Build.0 = Release|x64
+		{7A1B0C2D-8A9D-4F31-9C8B-2D5E6F7A8B91}.Debug|x64.ActiveCfg = Debug|x64
+		{7A1B0C2D-8A9D-4F31-9C8B-2D5E6F7A8B91}.Debug|x64.Build.0 = Debug|x64
+		{7A1B0C2D-8A9D-4F31-9C8B-2D5E6F7A8B91}.Release|x64.ActiveCfg = Release|x64
+		{7A1B0C2D-8A9D-4F31-9C8B-2D5E6F7A8B91}.Release|x64.Build.0 = Release|x64
+		{8B2C1D3E-9BAE-4042-AD9C-3E6F708192A2}.Debug|x64.ActiveCfg = Debug|x64
+		{8B2C1D3E-9BAE-4042-AD9C-3E6F708192A2}.Debug|x64.Build.0 = Debug|x64
+		{8B2C1D3E-9BAE-4042-AD9C-3E6F708192A2}.Release|x64.ActiveCfg = Release|x64
+		{8B2C1D3E-9BAE-4042-AD9C-3E6F708192A2}.Release|x64.Build.0 = Release|x64
+		{9C3D4E5F-AC1F-4153-BE0E-4F708192B3C3}.Debug|x64.ActiveCfg = Debug|x64
+		{9C3D4E5F-AC1F-4153-BE0E-4F708192B3C3}.Debug|x64.Build.0 = Debug|x64
+		{9C3D4E5F-AC1F-4153-BE0E-4F708192B3C3}.Release|x64.ActiveCfg = Release|x64
+		{9C3D4E5F-AC1F-4153-BE0E-4F708192B3C3}.Release|x64.Build.0 = Release|x64
+		{F1A2B3C4-D5E6-4071-8293-A4B5C6D7E8F9}.Debug|x64.ActiveCfg = Debug|x64
+		{F1A2B3C4-D5E6-4071-8293-A4B5C6D7E8F9}.Debug|x64.Build.0 = Debug|x64
+		{F1A2B3C4-D5E6-4071-8293-A4B5C6D7E8F9}.Release|x64.ActiveCfg = Release|x64
+		{F1A2B3C4-D5E6-4071-8293-A4B5C6D7E8F9}.Release|x64.Build.0 = Release|x64
+		{2C3D4E5F-6071-4283-94A5-B6C7D8E9F0A1}.Debug|x64.ActiveCfg = Debug|x64
+		{2C3D4E5F-6071-4283-94A5-B6C7D8E9F0A1}.Debug|x64.Build.0 = Debug|x64
+		{2C3D4E5F-6071-4283-94A5-B6C7D8E9F0A1}.Release|x64.ActiveCfg = Release|x64
+		{2C3D4E5F-6071-4283-94A5-B6C7D8E9F0A1}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/native/jalium.native.aot/CMakeLists.txt
+++ b/src/native/jalium.native.aot/CMakeLists.txt
@@ -1,0 +1,45 @@
+project(jalium.native.aot)
+
+# This module only makes sense in static-flavor builds. The shared-DLL build
+# never reaches this CMakeLists at all (the parent guards the add_subdirectory).
+
+set(HEADERS
+    include/jalium_aot.h
+)
+
+set(SOURCES
+    aot_register.cpp
+)
+
+add_library(${PROJECT_NAME} STATIC ${HEADERS} ${SOURCES})
+
+target_include_directories(${PROJECT_NAME}
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../jalium.native.core/include
+)
+
+# Force-pull every backend's .lib into the AOT image. The init symbols referenced
+# by aot_register.cpp give the linker a strong reason to keep each backend TU.
+target_link_libraries(${PROJECT_NAME}
+    PUBLIC
+        jalium.native.core
+        jalium.native.software
+)
+
+if(WIN32 AND TARGET jalium.native.d3d12)
+    target_link_libraries(${PROJECT_NAME} PUBLIC jalium.native.d3d12)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE)
+elseif(NOT WIN32 AND NOT APPLE AND TARGET jalium.native.vulkan)
+    target_link_libraries(${PROJECT_NAME} PUBLIC jalium.native.vulkan)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE JALIUM_AOT_INCLUDE_VULKAN)
+elseif(APPLE AND TARGET jalium.native.metal)
+    target_link_libraries(${PROJECT_NAME} PUBLIC jalium.native.metal)
+endif()
+
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    OUTPUT_NAME "jalium.native.aot"
+    DEBUG_POSTFIX ""
+)

--- a/src/native/jalium.native.aot/aot_register.cpp
+++ b/src/native/jalium.native.aot/aot_register.cpp
@@ -1,0 +1,45 @@
+// jalium.native.aot — static aggregation entry point.
+//
+// In a NativeAOT single-exe build every native module is linked as .lib, so
+// there is no DllMain to auto-register backends with the core BackendRegistry.
+// This translation unit exposes one extern "C" aggregator function that the
+// managed entry point calls exactly once at startup; that call strongly
+// references each backend's *_init() function which in turn forces the
+// linker to pull the corresponding .obj (and therefore the backend factory)
+// into the final image.
+
+#include "jalium_api.h"
+
+extern "C" {
+
+// Forward declarations for the per-backend init symbols. In the static flavor
+// each one is provided by jalium_<backend>_init.cpp without dllexport.
+void jalium_d3d12_init(void);
+void jalium_software_init(void);
+#ifdef JALIUM_AOT_INCLUDE_VULKAN
+void jalium_vulkan_init(void);
+#endif
+#ifdef JALIUM_AOT_INCLUDE_BROWSER
+int  jalium_webview2_initialize(void);
+void jalium_webview2_shutdown(void);
+#endif
+
+// Sole AOT aggregation entry. Managed code P/Invokes this once before any
+// jalium_context_create. JALIUM_API collapses to nothing under JALIUM_STATIC,
+// so the symbol is just an extern "C" function in the .lib that NativeAOT
+// resolves through DirectPInvoke without any LoadLibrary.
+JALIUM_API void jalium_aot_register_all_backends(void) {
+#if defined(_WIN32)
+    // Primary GPU backend on Windows.
+    jalium_d3d12_init();
+#endif
+
+#ifdef JALIUM_AOT_INCLUDE_VULKAN
+    jalium_vulkan_init();
+#endif
+
+    // Software rasterizer is always registered as the universal fallback.
+    jalium_software_init();
+}
+
+} // extern "C"

--- a/src/native/jalium.native.aot/include/jalium_aot.h
+++ b/src/native/jalium.native.aot/include/jalium_aot.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "jalium_api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Static-only entry point that registers every backend compiled into this
+/// AOT image with the core BackendRegistry. Must be called once from managed
+/// code before the first jalium_context_create().
+///
+/// In dynamic-DLL builds backend registration is performed automatically by
+/// each backend's DllMain, so this function is irrelevant there. It is only
+/// emitted into the .lib produced by jalium.native.aot.static.vcxproj.
+JALIUM_API void jalium_aot_register_all_backends(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/native/jalium.native.aot/jalium.native.aot.static.vcxproj
+++ b/src/native/jalium.native.aot/jalium.native.aot.static.vcxproj
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{9C3D4E5F-AC1F-4153-BE0E-4F708192B3C3}</ProjectGuid>
+    <RootNamespace>jaliumnativeaotstatic</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>$(SolutionDir)bin\native-static\$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\static\</IntDir>
+    <TargetName>jalium.native.aot.static</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(SolutionDir)bin\native-static\$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\static\</IntDir>
+    <TargetName>jalium.native.aot.static</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>JALIUM_STATIC;WIN32_LEAN_AND_MEAN;NOMINMAX;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)include;$(ProjectDir)..\jalium.native.core\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>JALIUM_STATIC;WIN32_LEAN_AND_MEAN;NOMINMAX;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)include;$(ProjectDir)..\jalium.native.core\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="include\jalium_aot.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="aot_register.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\jalium.native.core\jalium.native.core.static.vcxproj">
+      <Project>{42D22534-5A36-41D5-A4D4-C7E2171C90C0}</Project>
+      <SetConfiguration>Configuration=$(Configuration)</SetConfiguration>
+      <SetPlatform>Platform=$(Platform)</SetPlatform>
+    </ProjectReference>
+    <ProjectReference Include="..\jalium.native.d3d12\jalium.native.d3d12.static.vcxproj">
+      <Project>{3FEFEAAB-211A-4E64-B314-7E5B4F3A1AA4}</Project>
+      <SetConfiguration>Configuration=$(Configuration)</SetConfiguration>
+      <SetPlatform>Platform=$(Platform)</SetPlatform>
+    </ProjectReference>
+    <ProjectReference Include="..\jalium.native.software\jalium.native.software.static.vcxproj">
+      <Project>{8B2C1D3E-9BAE-4042-AD9C-3E6F708192A2}</Project>
+      <SetConfiguration>Configuration=$(Configuration)</SetConfiguration>
+      <SetPlatform>Platform=$(Platform)</SetPlatform>
+    </ProjectReference>
+    <ProjectReference Include="..\jalium.native.platform\jalium.native.platform.static.vcxproj">
+      <Project>{2C3D4E5F-6071-4283-94A5-B6C7D8E9F0A1}</Project>
+      <SetConfiguration>Configuration=$(Configuration)</SetConfiguration>
+      <SetPlatform>Platform=$(Platform)</SetPlatform>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/src/native/jalium.native.browser/CMakeLists.txt
+++ b/src/native/jalium.native.browser/CMakeLists.txt
@@ -8,7 +8,7 @@ set(SOURCES
     src/browser.cpp
 )
 
-add_library(${PROJECT_NAME} SHARED ${HEADERS} ${SOURCES})
+add_library(${PROJECT_NAME} ${JALIUM_LIB_TYPE} ${HEADERS} ${SOURCES})
 
 target_include_directories(${PROJECT_NAME}
     PUBLIC
@@ -18,10 +18,12 @@ target_include_directories(${PROJECT_NAME}
         ${CMAKE_CURRENT_SOURCE_DIR}/third_party/webview2/include
 )
 
-target_compile_definitions(${PROJECT_NAME}
-    PRIVATE
-        JALIUM_BROWSER_EXPORTS
-)
+if(NOT JALIUM_BUILD_STATIC)
+    target_compile_definitions(${PROJECT_NAME}
+        PRIVATE
+            JALIUM_BROWSER_EXPORTS
+    )
+endif()
 
 if(WIN32)
     target_link_libraries(${PROJECT_NAME}

--- a/src/native/jalium.native.core/CMakeLists.txt
+++ b/src/native/jalium.native.core/CMakeLists.txt
@@ -17,7 +17,7 @@ set(SOURCES
     src/backend_registry.cpp
 )
 
-add_library(${PROJECT_NAME} SHARED ${HEADERS} ${SOURCES})
+add_library(${PROJECT_NAME} ${JALIUM_LIB_TYPE} ${HEADERS} ${SOURCES})
 
 target_include_directories(${PROJECT_NAME}
     PUBLIC
@@ -25,10 +25,12 @@ target_include_directories(${PROJECT_NAME}
         $<INSTALL_INTERFACE:include>
 )
 
-target_compile_definitions(${PROJECT_NAME}
-    PRIVATE
-        JALIUM_EXPORTS
-)
+if(NOT JALIUM_BUILD_STATIC)
+    target_compile_definitions(${PROJECT_NAME}
+        PRIVATE
+            JALIUM_EXPORTS
+    )
+endif()
 
 # Link Windows libraries
 if(WIN32)

--- a/src/native/jalium.native.d3d12/CMakeLists.txt
+++ b/src/native/jalium.native.d3d12/CMakeLists.txt
@@ -38,7 +38,7 @@ set(SOURCES
     src/transition_shader_effect.cpp
 )
 
-add_library(${PROJECT_NAME} SHARED ${HEADERS} ${SOURCES})
+add_library(${PROJECT_NAME} ${JALIUM_LIB_TYPE} ${HEADERS} ${SOURCES})
 
 target_include_directories(${PROJECT_NAME}
     PUBLIC
@@ -48,10 +48,12 @@ target_include_directories(${PROJECT_NAME}
         ${CMAKE_CURRENT_SOURCE_DIR}/../jalium.native.core/include
 )
 
-target_compile_definitions(${PROJECT_NAME}
-    PRIVATE
-        JALIUM_D3D12_EXPORTS
-)
+if(NOT JALIUM_BUILD_STATIC)
+    target_compile_definitions(${PROJECT_NAME}
+        PRIVATE
+            JALIUM_D3D12_EXPORTS
+    )
+endif()
 
 # Link against jalium.native.core and Windows libraries
 target_link_libraries(${PROJECT_NAME}

--- a/src/native/jalium.native.metal/CMakeLists.txt
+++ b/src/native/jalium.native.metal/CMakeLists.txt
@@ -18,7 +18,7 @@ if(APPLE)
     )
 endif()
 
-add_library(${PROJECT_NAME} SHARED ${HEADERS} ${SOURCES})
+add_library(${PROJECT_NAME} ${JALIUM_LIB_TYPE} ${HEADERS} ${SOURCES})
 
 target_include_directories(${PROJECT_NAME}
     PUBLIC

--- a/src/native/jalium.native.platform/CMakeLists.txt
+++ b/src/native/jalium.native.platform/CMakeLists.txt
@@ -8,6 +8,7 @@ set(HEADERS
 if(WIN32)
     set(PLATFORM_SOURCES
         src/platform_win32.cpp
+        src/platform_notification_stubs_win32.cpp
     )
 elseif(ANDROID)
     set(PLATFORM_SOURCES
@@ -28,9 +29,11 @@ set(SOURCES
     ${PLATFORM_SOURCES}
 )
 
-add_library(${PROJECT_NAME} SHARED ${HEADERS} ${SOURCES})
+add_library(${PROJECT_NAME} ${JALIUM_LIB_TYPE} ${HEADERS} ${SOURCES})
 
-target_compile_definitions(${PROJECT_NAME} PRIVATE JALIUM_PLATFORM_EXPORTS)
+if(NOT JALIUM_BUILD_STATIC)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE JALIUM_PLATFORM_EXPORTS)
+endif()
 
 target_include_directories(${PROJECT_NAME}
     PUBLIC

--- a/src/native/jalium.native.platform/include/jalium_platform.h
+++ b/src/native/jalium.native.platform/include/jalium_platform.h
@@ -2,9 +2,13 @@
 
 #include "jalium_types.h"
 
-// Platform-specific export macros
+// Platform-specific export macros.
+// JALIUM_STATIC (set globally for the NativeAOT static-link flavor) takes
+// precedence over the legacy JALIUM_PLATFORM_STATIC; either collapses the
+// macro so the same headers compile cleanly into a .lib without dllimport
+// stubs.
 #ifdef _WIN32
-    #if defined(JALIUM_PLATFORM_STATIC)
+    #if defined(JALIUM_STATIC) || defined(JALIUM_PLATFORM_STATIC)
         #define JALIUM_PLATFORM_API
     #elif defined(JALIUM_PLATFORM_EXPORTS)
         #define JALIUM_PLATFORM_API __declspec(dllexport)

--- a/src/native/jalium.native.platform/jalium.native.platform.static.vcxproj
+++ b/src/native/jalium.native.platform/jalium.native.platform.static.vcxproj
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{2C3D4E5F-6071-4283-94A5-B6C7D8E9F0A1}</ProjectGuid>
+    <RootNamespace>jaliumnativeplatformstatic</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>$(SolutionDir)bin\native-static\$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\static\</IntDir>
+    <TargetName>jalium.native.platform.static</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(SolutionDir)bin\native-static\$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\static\</IntDir>
+    <TargetName>jalium.native.platform.static</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>JALIUM_STATIC;WIN32_LEAN_AND_MEAN;NOMINMAX;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)include;$(ProjectDir)..\jalium.native.core\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>JALIUM_STATIC;WIN32_LEAN_AND_MEAN;NOMINMAX;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)include;$(ProjectDir)..\jalium.native.core\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="include\jalium_platform.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="src\platform_common.cpp" />
+    <ClCompile Include="src\platform_win32.cpp" />
+    <ClCompile Include="src\platform_notification_stubs_win32.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\jalium.native.core\jalium.native.core.static.vcxproj">
+      <Project>{42D22534-5A36-41D5-A4D4-C7E2171C90C0}</Project>
+      <SetConfiguration>Configuration=$(Configuration)</SetConfiguration>
+      <SetPlatform>Platform=$(Platform)</SetPlatform>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/src/native/jalium.native.platform/jalium.native.platform.vcxproj
+++ b/src/native/jalium.native.platform/jalium.native.platform.vcxproj
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{F1A2B3C4-D5E6-4071-8293-A4B5C6D7E8F9}</ProjectGuid>
+    <RootNamespace>jaliumnativeplatform</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>$(SolutionDir)bin\native\$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+    <TargetName>jalium.native.platform</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(SolutionDir)bin\native\$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+    <TargetName>jalium.native.platform</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>JALIUM_PLATFORM_EXPORTS;WIN32_LEAN_AND_MEAN;NOMINMAX;_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)include;$(ProjectDir)..\jalium.native.core\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ProgramDatabaseFile>$(ProjectDir)$(IntDir)$(TargetName).pdb</ProgramDatabaseFile>
+      <AdditionalDependencies>user32.lib;gdi32.lib;shcore.lib;dwmapi.lib;ole32.lib;imm32.lib;$(SolutionDir)bin\native\$(Configuration)\jalium.native.core.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>JALIUM_PLATFORM_EXPORTS;WIN32_LEAN_AND_MEAN;NOMINMAX;NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)include;$(ProjectDir)..\jalium.native.core\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ProgramDatabaseFile>$(ProjectDir)$(IntDir)$(TargetName).pdb</ProgramDatabaseFile>
+      <AdditionalDependencies>user32.lib;gdi32.lib;shcore.lib;dwmapi.lib;ole32.lib;imm32.lib;$(SolutionDir)bin\native\$(Configuration)\jalium.native.core.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="include\jalium_platform.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="src\platform_common.cpp" />
+    <ClCompile Include="src\platform_win32.cpp" />
+    <ClCompile Include="src\platform_notification_stubs_win32.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\jalium.native.core\jalium.native.core.vcxproj">
+      <Project>{A1B2C3D4-1234-5678-9ABC-DEF012345678}</Project>
+      <SetConfiguration>Configuration=$(Configuration)</SetConfiguration>
+      <SetPlatform>Platform=$(Platform)</SetPlatform>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/src/native/jalium.native.platform/src/platform_notification_stubs_win32.cpp
+++ b/src/native/jalium.native.platform/src/platform_notification_stubs_win32.cpp
@@ -1,0 +1,56 @@
+// Windows stubs for the Android notification API.
+//
+// jalium.native.platform's Android implementation (platform_android.cpp)
+// exports six jalium_notification_* C symbols that bridge to JNI / Java's
+// NotificationManager. The matching managed bindings live in
+// Notifications.Android.cs and are referenced — even if not invoked — from
+// SystemNotificationManager.CreateBackend's `if (PlatformFactory.IsAndroid)`
+// branch.
+//
+// Under NativeAOT static linking on Windows the trimmer keeps every
+// LibraryImport site that ILC can't prove unreachable, so link.exe insists
+// on resolving these symbols inside jalium.native.platform.static.lib.
+// Providing no-op Windows stubs satisfies the linker; the Windows runtime
+// always picks WindowsNotificationBackend (WinRT COM) so these stubs are
+// never actually invoked.
+
+#ifdef _WIN32
+
+#include <stdint.h>
+
+extern "C" {
+
+int jalium_notification_init(const char* /*appId*/, const char* /*appName*/, const char* /*channelId*/) {
+    return -1;
+}
+
+int jalium_notification_show(
+    int /*id*/,
+    const char* /*title*/,
+    const char* /*body*/,
+    const char* /*iconPath*/,
+    const char* /*imagePath*/,
+    const char* /*channelId*/,
+    int /*priority*/,
+    int /*silent*/,
+    const char* /*tag*/,
+    const char* /*group*/) {
+    return -1;
+}
+
+void jalium_notification_add_action(int /*id*/, const char* /*actionId*/, const char* /*label*/) {
+}
+
+void jalium_notification_cancel(int /*id*/, const char* /*tag*/) {
+}
+
+void jalium_notification_cancel_all(void) {
+}
+
+int jalium_notification_is_available(void) {
+    return 0;
+}
+
+} // extern "C"
+
+#endif // _WIN32

--- a/src/native/jalium.native.software/CMakeLists.txt
+++ b/src/native/jalium.native.software/CMakeLists.txt
@@ -9,7 +9,7 @@ set(SOURCES
     src/software_init.cpp
 )
 
-add_library(${PROJECT_NAME} SHARED ${HEADERS} ${SOURCES})
+add_library(${PROJECT_NAME} ${JALIUM_LIB_TYPE} ${HEADERS} ${SOURCES})
 
 target_include_directories(${PROJECT_NAME}
     PUBLIC

--- a/src/native/jalium.native.software/jalium.native.software.static.vcxproj
+++ b/src/native/jalium.native.software/jalium.native.software.static.vcxproj
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{8B2C1D3E-9BAE-4042-AD9C-3E6F708192A2}</ProjectGuid>
+    <RootNamespace>jaliumnativesoftwarestatic</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>$(SolutionDir)bin\native-static\$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\static\</IntDir>
+    <TargetName>jalium.native.software.static</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(SolutionDir)bin\native-static\$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\static\</IntDir>
+    <TargetName>jalium.native.software.static</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>JALIUM_STATIC;WIN32_LEAN_AND_MEAN;NOMINMAX;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)include;$(ProjectDir)..\jalium.native.core\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>JALIUM_STATIC;WIN32_LEAN_AND_MEAN;NOMINMAX;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)include;$(ProjectDir)..\jalium.native.core\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="include\software_backend.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="src\software_backend.cpp" />
+    <ClCompile Include="src\software_init.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\jalium.native.core\jalium.native.core.static.vcxproj">
+      <Project>{42D22534-5A36-41D5-A4D4-C7E2171C90C0}</Project>
+      <SetConfiguration>Configuration=$(Configuration)</SetConfiguration>
+      <SetPlatform>Platform=$(Platform)</SetPlatform>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/src/native/jalium.native.text/CMakeLists.txt
+++ b/src/native/jalium.native.text/CMakeLists.txt
@@ -32,9 +32,11 @@ elseif(UNIX AND NOT APPLE)
     list(APPEND SOURCES src/font_provider_fontconfig.cpp)
 endif()
 
-add_library(${PROJECT_NAME} SHARED ${HEADERS} ${SOURCES})
+add_library(${PROJECT_NAME} ${JALIUM_LIB_TYPE} ${HEADERS} ${SOURCES})
 
-target_compile_definitions(${PROJECT_NAME} PRIVATE JALIUM_TEXT_EXPORTS)
+if(NOT JALIUM_BUILD_STATIC)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE JALIUM_TEXT_EXPORTS)
+endif()
 
 target_include_directories(${PROJECT_NAME}
     PUBLIC

--- a/src/native/jalium.native.vulkan/CMakeLists.txt
+++ b/src/native/jalium.native.vulkan/CMakeLists.txt
@@ -33,7 +33,7 @@ set(SOURCES
     src/vulkan_vello_engine.cpp
 )
 
-add_library(${PROJECT_NAME} SHARED ${HEADERS} ${SOURCES})
+add_library(${PROJECT_NAME} ${JALIUM_LIB_TYPE} ${HEADERS} ${SOURCES})
 
 target_include_directories(${PROJECT_NAME}
     PUBLIC

--- a/src/native/jalium.native.vulkan/jalium.native.vulkan.static.vcxproj
+++ b/src/native/jalium.native.vulkan/jalium.native.vulkan.static.vcxproj
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{7A1B0C2D-8A9D-4F31-9C8B-2D5E6F7A8B91}</ProjectGuid>
+    <RootNamespace>jaliumnativevulkanstatic</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>$(SolutionDir)bin\native-static\$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\static\</IntDir>
+    <TargetName>jalium.native.vulkan.static</TargetName>
+    <JaliumSdkRoot Condition="'$(JALIUM_SDK_ROOT)' != ''">$(JALIUM_SDK_ROOT)</JaliumSdkRoot>
+    <JaliumSdkRoot Condition="'$(JaliumSdkRoot)' == ''">$(SolutionDir)..\..\..\Jalium.SDK</JaliumSdkRoot>
+    <VulkanSdkRoot Condition="'$(VULKAN_SDK)' != ''">$(VULKAN_SDK)</VulkanSdkRoot>
+    <VulkanSdkRoot Condition="'$(VulkanSdkRoot)' == ''">$(JaliumSdkRoot)\VulkanSDK\1.4.341.1</VulkanSdkRoot>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(SolutionDir)bin\native-static\$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\static\</IntDir>
+    <TargetName>jalium.native.vulkan.static</TargetName>
+    <JaliumSdkRoot Condition="'$(JALIUM_SDK_ROOT)' != ''">$(JALIUM_SDK_ROOT)</JaliumSdkRoot>
+    <JaliumSdkRoot Condition="'$(JaliumSdkRoot)' == ''">$(SolutionDir)..\..\..\Jalium.SDK</JaliumSdkRoot>
+    <VulkanSdkRoot Condition="'$(VULKAN_SDK)' != ''">$(VULKAN_SDK)</VulkanSdkRoot>
+    <VulkanSdkRoot Condition="'$(VulkanSdkRoot)' == ''">$(JaliumSdkRoot)\VulkanSDK\1.4.341.1</VulkanSdkRoot>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>JALIUM_STATIC;WIN32_LEAN_AND_MEAN;NOMINMAX;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)include;$(ProjectDir)..\jalium.native.core\include;$(VulkanSdkRoot)\Include;$(JaliumSdkRoot)\stb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>JALIUM_STATIC;WIN32_LEAN_AND_MEAN;NOMINMAX;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)include;$(ProjectDir)..\jalium.native.core\include;$(VulkanSdkRoot)\Include;$(JaliumSdkRoot)\stb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="include\vulkan_backend.h" />
+    <ClInclude Include="include\vulkan_embedded_shaders.h" />
+    <ClInclude Include="include\vulkan_render_target.h" />
+    <ClInclude Include="include\vulkan_resources.h" />
+    <ClInclude Include="include\vulkan_runtime.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="src\vulkan_backend.cpp" />
+    <ClCompile Include="src\vulkan_init.cpp" />
+    <ClCompile Include="src\vulkan_render_target.cpp" />
+    <ClCompile Include="src\vulkan_resources.cpp" />
+    <ClCompile Include="src\vulkan_runtime.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\jalium.native.core\jalium.native.core.static.vcxproj">
+      <Project>{42D22534-5A36-41D5-A4D4-C7E2171C90C0}</Project>
+      <SetConfiguration>Configuration=$(Configuration)</SetConfiguration>
+      <SetPlatform>Platform=$(Platform)</SetPlatform>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>


### PR DESCRIPTION
## Summary

Add a complete static-link / NativeAOT flavor so consumers can publish a single self-contained `.exe` with **zero `jalium.native.*.dll` alongside it**. The existing dynamic-DLL NuGet flow stays untouched; opt in with one property:

```xml
<PublishAot>true</PublishAot>
<UseJaliumNativeAot>true</UseJaliumNativeAot>
```

Verified end-to-end with `samples/Jalium.UI.AotWindowDemo` (single window) and in the downstream `Jalium.UI.Gallery.Desktop` (full UI module chain including the WebView demo). In both cases the publish folder contains exactly one `.exe` and no shared libraries.

## What changed

### Native (`src/native/`)

- **Five new `.static.vcxproj`** projects (vulkan / software / platform + a brand-new `platform.vcxproj` for Windows / aot aggregator). All output to `bin/native-static`, define `JALIUM_STATIC`, and are registered in `Jalium.Native.sln`.
- **`jalium.native.aot/aot_register.cpp`** exports `jalium_aot_register_all_backends()` — the AOT entry point that wires every backend into the core `BackendRegistry` without any `DllMain`.
- **`platform_notification_stubs_win32.cpp`** adds Windows no-op stubs for the six `jalium_notification_*` JNI symbols so `link.exe` resolves the `LibraryImport` sites that the trimmer keeps from `Notifications.Android.cs` (they are never invoked at runtime — `WindowsNotificationBackend` is selected via WinRT).
- **`jalium_platform.h`** lets the global `JALIUM_STATIC` collapse `JALIUM_PLATFORM_API` (used to require `JALIUM_PLATFORM_STATIC`).
- **Top-level CMakeLists** adds `option(JALIUM_BUILD_STATIC OFF)`. Every module switches from `add_library(... SHARED ...)` to `add_library(... \${JALIUM_LIB_TYPE} ...)` and gates the `*_EXPORTS` define on shared builds.

### Build SDK (`Jalium.UI.Build` NuGet package)

- **`ConfigureJaliumNativeAot`** wires `<DirectPInvoke>` + `<NativeLibrary>` for every Jalium native module, the aggregator, and 13 Win32/DirectX system imports. Resolves static archives from the package (`build/nativeaot/win-x64/`) with a source-tree fallback for in-repo consumers.
- **Browser AOT** (opt-in via `<JaliumIncludeBrowserAot>true</JaliumIncludeBrowserAot>`) statically links `jalium.native.browser.static.lib` plus `WebView2LoaderStatic.lib` so WebView works **without `WebView2Loader.dll`** alongside the exe (relies on the user-installed Edge WebView2 Runtime, which is an OS-level component).
- **`StripJaliumDuplicateNativeDllsAfterPublish`** removes the per-backend shared DLLs and `WebView2Loader.dll` that Interop's Content otherwise drops next to the published exe (dead weight under static linkage). Optional `<JaliumStripThirdPartyMediaNatives>true</JaliumStripThirdPartyMediaNatives>` also strips OpenCv / SoundFlow natives.
- **`BuildNativeProjects` / `BuildStaticNativeProjects`** targets gain a `MSBuildRuntimeType=='Full'` guard so `dotnet` CLI publish (which cannot import `VCTargetsPath`) doesn't try to nest-build `.vcxproj`.
- New `<Content>` entries pack software / platform / aot static archives plus the `WebView2LoaderStatic.lib` redistributable into the NuGet output.

### Managed (`src/managed/`)

- **`JaliumStaticInit.RegisterAllBackends`** — managed P/Invoke companion to the AOT aggregator entry; only used in static builds.
- **`Jalium.UI.Interop.csproj`** Content (per-backend dll drops) is suppressed when `PublishAot=true` so it doesn't fight the Build SDK's strip target.
- **Trim/AOT warnings** contained at their source:
  - `PropertyItem.ConvertValue` — `[DynamicallyAccessedMembers(All)]` annotation + `UnconditionalSuppressMessage` (PropertyGrid is documented as opt-in for AOT).
  - `Window.OpenDevTools` and the `IInputDispatcherHost` DevTools shims — `UnconditionalSuppressMessage` pinning DevTools as an explicit opt-in surface.

### Repo

- `.gitignore` exception so `WebView2LoaderStatic.lib` (10 MB redistributable from Microsoft.Web.WebView2 1.0.3179.45) lives at `src/native/jalium.native.browser/third_party/webview2/lib/x64/`.

## Why

NativeAOT publish previously failed at link time because (a) backend `.lib` archives didn't exist, (b) backend init wasn't called without `DllMain`, (c) Win32/DirectX system libs aren't auto-linked by `Microsoft.NETCore.Native.targets`, and (d) `Jalium.UI.Build`'s nested `BuildNativeProjects` tried to invoke `vcxproj` builds through the dotnet CLI's MSBuild, which can't import `VCTargetsPath`. This change closes every step of that chain so a single property opt-in produces a valid single-exe.

## Test plan

- [x] `samples/Jalium.UI.AotWindowDemo` opens a window and renders TextBlock + Button under static linkage (publish folder contains only the `.exe`).
- [x] `Jalium.UI.Gallery.Desktop` (full module chain + WebView page) opens with title `Jalium.UI Gallery`; publish folder contains only the `.exe`.
- [x] Dynamic-DLL NuGet flow (no `UseJaliumNativeAot` opt-in) unchanged — existing `Jalium.UI.DesktopDemo` consumers continue to copy `jalium.native.*.dll` as before.
- [ ] Manual: click Media → WebView page in Gallery to confirm WebView2 Runtime loads under the static loader (requires user-installed Edge WebView2 Runtime).