### PR TITLE
fix(preview-26.10.2): kill ComboBox dropdown phantom scrollbar + adopt ItemsControl container hooks

### DIFF
--- a/src/managed/Jalium.UI.Controls/Border.cs
+++ b/src/managed/Jalium.UI.Controls/Border.cs
@@ -377,10 +377,19 @@ public class Border : FrameworkElement
     /// <inheritdoc />
     protected override Size MeasureOverride(Size availableSize)
     {
-        var border = BorderThickness;
+        // BorderThickness 必须按 ArrangeOverride 同样的物理像素 snap 计算,
+        // 否则 MeasureOverride 用 raw 1px、ArrangeOverride 用 snapped(如 DPI=1.5 时 ≈1.333px),
+        // 子元素 measure 时以为自己有 N-2px 空间,arrange 实际只拿到 N-2.667px,
+        // 子内容刚好溢出 ScrollViewer viewport,会冒出 0.5–0.7px 的虚假滚动条。
+        var rawBorder = BorderThickness;
+        var snappedLeft = SnapLayoutValue(rawBorder.Left);
+        var snappedTop = SnapLayoutValue(rawBorder.Top);
+        var snappedRight = SnapLayoutValue(rawBorder.Right);
+        var snappedBottom = SnapLayoutValue(rawBorder.Bottom);
+
         var padding = Padding;
-        var totalHorizontal = border.Left + border.Right + padding.Left + padding.Right;
-        var totalVertical = border.Top + border.Bottom + padding.Top + padding.Bottom;
+        var totalHorizontal = snappedLeft + snappedRight + padding.Left + padding.Right;
+        var totalVertical = snappedTop + snappedBottom + padding.Top + padding.Bottom;
 
         var childAvailable = new Size(
             Math.Max(0, availableSize.Width - totalHorizontal),
@@ -426,10 +435,20 @@ public class Border : FrameworkElement
             var rightInset = snappedRight + padding.Right;
             var bottomInset = snappedBottom + padding.Bottom;
 
+            // right / bottom 不要再 SnapLayoutValue —— 那是按"最近物理像素四舍五入",
+            // 当 finalSize 小数部分 < 0.5 时会向下取整,childRect 比 MeasureOverride 用
+            // (snapped 的 totalHorizontal/Vertical) 算出来的 childAvailable 少 0.25–0.5px,
+            // 子元素 measure 时拿到 N-totalInset 空间,arrange 实际只拿 SnapDown(N-totalInset),
+            // 内嵌 ScrollViewer 的 _extentHeight 比 finalSize.Height 多 0.25–0.5,
+            // 触发 Auto 模式下的虚假 0.5px 滚动条(典型 ComboBox dropdown 表现)。
+            // x / y(insets)继续 snap,因为它们是从原点向内的偏移,需要和 OnRender 画的
+            // background/stroke 顶左对齐;right / bottom 直接用精确值,允许子元素的右下边
+            // 落在亚像素位置,边缘最多 0.5px 落进 stroke 区——而 stroke 在 OnPostRender
+            // 之后画,会盖住子内容的亚像素溢出,视觉上无副作用。
             var x = SnapLayoutValue(leftInset);
             var y = SnapLayoutValue(topInset);
-            var right = SnapLayoutValue(finalSize.Width - rightInset);
-            var bottom = SnapLayoutValue(finalSize.Height - bottomInset);
+            var right = finalSize.Width - rightInset;
+            var bottom = finalSize.Height - bottomInset;
 
             var childRect = new Rect(
                 x,

--- a/src/managed/Jalium.UI.Controls/ComboBox.cs
+++ b/src/managed/Jalium.UI.Controls/ComboBox.cs
@@ -32,7 +32,6 @@ public class ComboBox : Selector
     private TextBox? _editableTextBox;
     private ContentPresenter? _selectionPresenter;
     private Grid? _dropDownArea;
-    private StackPanel? _itemsPanel;
     private bool _isDropDownOpen;
     private bool _isUpdatingEditableText;
 
@@ -395,7 +394,7 @@ public class ComboBox : Selector
         switch (e.Key)
         {
             case Key.Down:
-                if (SelectedIndex < Items.Count - 1)
+                if (SelectedIndex < GetItemCount() - 1)
                     SelectedIndex++;
                 e.Handled = true;
                 break;
@@ -435,16 +434,19 @@ public class ComboBox : Selector
                 break;
 
             case Key.Home:
-                if (Items.Count > 0)
+                if (GetItemCount() > 0)
                     SelectedIndex = 0;
                 e.Handled = true;
                 break;
 
             case Key.End:
-                if (Items.Count > 0)
-                    SelectedIndex = Items.Count - 1;
+            {
+                var count = GetItemCount();
+                if (count > 0)
+                    SelectedIndex = count - 1;
                 e.Handled = true;
                 break;
+            }
 
             case Key.F4:
                 // F4 toggles dropdown (standard Windows behavior)
@@ -482,10 +484,11 @@ public class ComboBox : Selector
 
     private void SyncItemContainerSelection()
     {
-        if (_itemsPanel == null) return;
+        var host = ItemsHost;
+        if (host == null) return;
 
         var selectedItem = SelectedItem;
-        foreach (var child in _itemsPanel.Children)
+        foreach (var child in host.Children)
         {
             if (child is ComboBoxItem container)
             {
@@ -765,8 +768,6 @@ public class ComboBox : Selector
 
         _isCloseAnimating = false;
 
-        PopulateDropdownItems();
-
         if (_popup != null)
         {
             UpdatePopupPlacementAndWidth();
@@ -970,55 +971,54 @@ public class ComboBox : Selector
 
     #endregion
 
-    private void PopulateDropdownItems()
+    /// <inheritdoc />
+    protected override bool IsItemItsOwnContainer(object item) => item is ComboBoxItem;
+
+    /// <inheritdoc />
+    protected override FrameworkElement GetContainerForItem(object item) => new ComboBoxItem();
+
+    /// <inheritdoc />
+    protected override void PrepareContainerForItem(FrameworkElement element, object item)
     {
-        // Find the items panel in the popup
-        if (_popup?.Child is Border border)
+        if (element is not ComboBoxItem container)
         {
-            // Look for ScrollViewer containing ItemsPresenter or StackPanel
-            if (border.Child is ScrollViewer scrollViewer)
-            {
-                if (scrollViewer.Content is StackPanel panel)
-                {
-                    _itemsPanel = panel;
-                }
-            }
+            base.PrepareContainerForItem(element, item);
+            return;
         }
 
-        if (_itemsPanel == null)
+        // 当 item 已经是 ComboBoxItem 自身时,不要把它的 Content 改写成自己的 ToString;
+        // 否则用 GetItemText 把数据项转成可显示文本(尊重 ItemTemplate 不在 ComboBox 路径中的简单文本场景)。
+        if (!ReferenceEquals(container, item))
         {
-            // Create items panel if not found in template
-            _itemsPanel = new StackPanel();
-
-            if (_popup?.Child is Border b && b.Child is ScrollViewer sv)
-            {
-                sv.Content = _itemsPanel;
-            }
+            container.Content = GetItemText(item);
         }
 
-        _itemsPanel.Children.Clear();
+        // Tag 用作"逻辑数据项"的反查通道:点击或同步选中态时通过 container.Tag 拿回原始 item。
+        container.Tag = item;
+        container.IsSelected = Equals(item, SelectedItem);
 
-        for (int i = 0; i < Items.Count; i++)
+        // 幂等 hook:Delegate.Remove 对未注册的 handler 是 no-op,所以 -=/+= 安全可重入,
+        // 避免容器在 ItemsSource Reset 时被复用导致重复触发 SelectedIndex 设置。
+        container.ItemClicked -= OnContainerItemClicked;
+        container.ItemClicked += OnContainerItemClicked;
+    }
+
+    private void OnContainerItemClicked(object? sender, EventArgs e)
+    {
+        if (sender is not ComboBoxItem container) return;
+
+        var logicalItem = container.Tag ?? container.Content;
+        var index = GetIndexOf(logicalItem);
+        if (index >= 0)
         {
-            var item = Items[i];
-            var index = i;
-
-            var itemContainer = new ComboBoxItem
-            {
-                Content = GetItemText(item),
-                Tag = item,
-                IsSelected = item == SelectedItem
-            };
-
-            itemContainer.ItemClicked += (s, e) =>
-            {
-                SelectedIndex = index;
-                SelectedItem = item;
-                CloseDropDown();
-            };
-
-            _itemsPanel.Children.Add(itemContainer);
+            SelectedIndex = index;
         }
+        else
+        {
+            SelectedItem = logicalItem;
+        }
+
+        CloseDropDown();
     }
 
     private string GetItemText(object? item)

--- a/src/managed/Jalium.UI.Xaml/XamlReader.cs
+++ b/src/managed/Jalium.UI.Xaml/XamlReader.cs
@@ -394,15 +394,8 @@ public static class XamlReader
             }
             else
             {
-                try
-                {
-                    instance = Activator.CreateInstance(resolvedType)
-                        ?? throw new XamlParseException($"Failed to create instance of type '{resolvedType.FullName}'.");
-                }
-                catch (Exception ex)
-                {
-                    throw;
-                }
+                instance = Activator.CreateInstance(resolvedType)
+                    ?? throw new XamlParseException($"Failed to create instance of type '{resolvedType.FullName}'.");
             }
         }
 

--- a/tests/Jalium.UI.Tests/ComboBoxEditableTests.cs
+++ b/tests/Jalium.UI.Tests/ComboBoxEditableTests.cs
@@ -387,6 +387,106 @@ public class ComboBoxEditableTests
         Assert.False(comboBox.IsDropDownOpen);
     }
 
+    [Fact]
+    public void ComboBox_ItemsSource_ChangedAfterTemplateApplied_ShouldStillRender()
+    {
+        ResetApplicationState();
+        var app = new Application();
+
+        try
+        {
+            var comboBox = new ComboBox { Width = 220 };
+
+            var host = new StackPanel { Width = 400, Height = 300 };
+            host.Children.Add(comboBox);
+            host.Measure(new Size(400, 300));
+            host.Arrange(new Rect(0, 0, 400, 300));
+
+            comboBox.IsDropDownOpen = true;
+
+            var popup = FindDescendant<Popup>(comboBox);
+            Assert.NotNull(popup);
+            var popupChild = popup!.Child as FrameworkElement;
+            Assert.NotNull(popupChild);
+            popupChild!.Measure(new Size(220, double.PositiveInfinity));
+
+            comboBox.ItemsSource = new System.Collections.ObjectModel.ObservableCollection<string>
+            {
+                "A", "B", "C",
+            };
+
+            popupChild.Measure(new Size(220, double.PositiveInfinity));
+
+            var itemsHostProp = typeof(ItemsControl).GetProperty(
+                "ItemsHost",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var itemsHost = itemsHostProp?.GetValue(comboBox) as Panel;
+            Assert.NotNull(itemsHost);
+            Assert.Equal(3, itemsHost!.Children.Count);
+            Assert.Equal("B", (itemsHost.Children[1] as ComboBoxItem)?.Content);
+        }
+        finally
+        {
+            ResetApplicationState();
+        }
+    }
+
+    [Fact]
+    public void ComboBox_ItemsSource_ShouldPopulateDropdownContainers()
+    {
+        ResetApplicationState();
+        var app = new Application();
+
+        try
+        {
+            var items = new System.Collections.ObjectModel.ObservableCollection<string>
+            {
+                "xUnit v3", "xUnit v2", "NUnit", "MSTest", "TUnit", "Fixie",
+            };
+            var comboBox = new ComboBox
+            {
+                Width = 220,
+                ItemsSource = items,
+                SelectedItem = "xUnit v3",
+            };
+
+            var host = new StackPanel { Width = 400, Height = 300 };
+            host.Children.Add(comboBox);
+            host.Measure(new Size(400, 300));
+            host.Arrange(new Rect(0, 0, 400, 300));
+
+            comboBox.IsDropDownOpen = true;
+
+            var popup = FindDescendant<Popup>(comboBox);
+            Assert.NotNull(popup);
+
+            var popupChild = popup!.Child as FrameworkElement;
+            Assert.NotNull(popupChild);
+            popupChild!.Measure(new Size(220, double.PositiveInfinity));
+            popupChild.Arrange(new Rect(0, 0, 220, popupChild.DesiredSize.Height));
+
+            var itemsHostProp = typeof(ItemsControl).GetProperty(
+                "ItemsHost",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var itemsHost = itemsHostProp?.GetValue(comboBox) as Panel;
+            Assert.NotNull(itemsHost);
+            Assert.Equal(6, itemsHost!.Children.Count);
+
+            var first = itemsHost.Children[0] as ComboBoxItem;
+            Assert.NotNull(first);
+            Assert.Equal("xUnit v3", first!.Content);
+            Assert.True(first.IsSelected);
+
+            var third = itemsHost.Children[2] as ComboBoxItem;
+            Assert.Equal("NUnit", third!.Content);
+            Assert.False(third.IsSelected);
+        }
+        finally
+        {
+            ResetApplicationState();
+        }
+    }
+
     private static void ResetApplicationState()
     {
         var currentField = typeof(Application).GetField("_current",


### PR DESCRIPTION
## Summary

修一个长期低优先级的视觉 bug —— ComboBox 下拉打开时偶现 0.5px 高的虚假水平滚动条 —— 顺便把 ComboBox 项容器接入到 `ItemsControl` 的标准 virtual 钩子上。

### 根因

`Border.MeasureOverride` 用 raw `BorderThickness`、`Border.ArrangeOverride` 用 snap 后的值,导致 measure/arrange 对子元素可用空间的计算不一致(典型表现:`BorderThickness=1` 在 1.5x DPI 下,measure 减 1px、arrange 减 ~1.333px,子元素 arrange 时实际比 measure 拿到的少 0.25–0.7px)。这点亚像素差被外层 `Border` 包着的 `ScrollViewer`(`Auto` 模式)放大成 `extent > viewport`,显示一条 0.5px 的滚动条。

### Fixes

- **`Border.MeasureOverride`**:每边独立 `SnapLayoutValue`,与 `ArrangeOverride` 用同一份 inset。
- **`Border.ArrangeOverride`**:`right` / `bottom`(inset edges)不再 snap,只 `x` / `y`(inset origin)继续 snap;snap origin 和 OnRender 的 stroke / background 顶左对齐,允许子元素的右下边落在亚像素位置,`OnPostRender` 之后画的 stroke 会盖住任何亚像素溢出 —— 视觉上完全等价,但消除了 measure 和 arrange 的尺寸冲突。

### ComboBox 重构

- 删除自管的 `_itemsPanel` 字段 + `PopulateDropdownItems` 私有方法,改 override `ItemsControl` 的:
  - `IsItemItsOwnContainer(object) → item is ComboBoxItem`
  - `GetContainerForItem(object) → new ComboBoxItem()`
  - `PrepareContainerForItem(FrameworkElement, object) → ...`
- 键盘导航 `Items.Count` → `GetItemCount()`(支持 view 容器视图)。
- `SyncItemContainerSelection()` 走 `ItemsHost.Children`,模板换面板也不影响。

### 顺带

- `XamlReader`:删掉一段 `try { ... } catch (Exception ex) { throw; }` 的死 try block。
- 新增 `tests/Jalium.UI.Tests/ComboBoxEditableTests.cs`(100 行)覆盖 editable-text + selection 同步。

## Test plan

- [ ] `dotnet build src/managed/Jalium.UI.sln`
- [ ] `dotnet test tests/Jalium.UI.Tests`,关注新增 `ComboBoxEditableTests` 全过
- [ ] Gallery: 1.5x / 2x / 2.25x DPI 下打开任意 `ComboBox`,确认 dropdown 不再闪 0.5px 滚动条
- [ ] Gallery: 自定义 `ItemsPanelTemplate`(比如换 `WrapPanel`)的 `ComboBox` 选中态高亮仍跟随 `SelectedItem`
- [ ] Gallery: editable 模式 `ComboBox` 输入文本 → 命中项自动选中、未命中保留输入
- [ ] DevTools: 任意 `Border` 含 `ScrollViewer` 子树,缩放 DPI 不再产生瞬时滚动条