### PR TITLE
feat(preview-26.10.2): SG lowering + D3D12 path cache + hit-test memo

### DIFF
--- a/src/managed/Jalium.UI.Controls/Input/WindowInputDispatcher.cs
+++ b/src/managed/Jalium.UI.Controls/Input/WindowInputDispatcher.cs
@@ -15,7 +15,6 @@ internal sealed class WindowInputDispatcher
 
     // ── Mouse state ──
     private UIElement? _lastMouseOverElement;
-    private UIElement? _lastHitTestElement;
     private readonly List<UIElement> _mousePressedChain = [];
     private MouseButton? _suppressMouseUpButton;
     private TitleBarButton? _hoveredTitleBarButton;
@@ -49,7 +48,6 @@ internal sealed class WindowInputDispatcher
     // ── Public state accessors ──
 
     internal UIElement? LastMouseOverElement => _lastMouseOverElement;
-    internal UIElement? LastHitTestElement => _lastHitTestElement;
     internal TitleBarButton? HoveredTitleBarButton => _hoveredTitleBarButton;
     internal TitleBarButton? PressedTitleBarButton => _pressedTitleBarButton;
     internal TitleBarButton? PressedTitleBarButtonField { get => _pressedTitleBarButton; set => _pressedTitleBarButton = value; }
@@ -399,8 +397,6 @@ internal sealed class WindowInputDispatcher
             RaiseMouseLeaveChain(_lastMouseOverElement, null, Environment.TickCount);
             _lastMouseOverElement = null;
         }
-
-        _lastHitTestElement = null;
     }
 
     // ══════════════════════════════════════════════════════════════
@@ -673,7 +669,6 @@ internal sealed class WindowInputDispatcher
         UIElement.ForceReleaseMouseCapture();
         ClearPressedChains();
         _suppressMouseUpButton = null;
-        _lastHitTestElement = null;
 
         if (_host.TitleBarStyle == WindowTitleBarStyle.Custom)
             ClearTitleBarInteractionState();

--- a/src/managed/Jalium.UI.Controls/Window.cs
+++ b/src/managed/Jalium.UI.Controls/Window.cs
@@ -4840,8 +4840,7 @@ public partial class Window : ContentControl, IWindowHost, ILayoutManagerHost, I
         // Convert physical client pixels to DIPs
         Point clientPos = new(screenPt.X / _dpiScale, screenPt.Y / _dpiScale);
 
-        var hitResult = HitTestWithCache(clientPos);
-        var element = hitResult?.VisualHit as UIElement;
+        var element = HitTestElement(clientPos, "cursor");
 
         // Walk up the visual tree to find the first element with a non-null Cursor
         var cursor = ResolveCursor(element);
@@ -6355,7 +6354,16 @@ public partial class Window : ContentControl, IWindowHost, ILayoutManagerHost, I
 
     private RenderTargetDrawingContext? _drawingContext;
     private UIElement? _lastMouseOverElement;
-    private UIElement? _lastHitTestElement;
+    // Per-frame hit-test memoize. `_hitMemoLayoutGeneration` snapshots
+    // LayoutManager.Generation at the time of the cached hit; any later
+    // measure/arrange (including ScrollViewer scrolling, animation, theme
+    // changes, etc.) bumps Generation and invalidates the memo automatically.
+    // Cache only hits for the exact same (point, generation) pair — same frame,
+    // same layout, same coordinate — so it removes redundant traversals from
+    // mouse-down/up/wheel at the same position without any manual invalidation.
+    private Point _hitMemoPoint;
+    private UIElement? _hitMemoElement;
+    private long _hitMemoLayoutGeneration = -1;
     private readonly List<UIElement> _mousePressedChain = [];
     private readonly List<UIElement> _keyboardPressedChain = [];
     private nint _detachedImeContext;
@@ -7525,7 +7533,6 @@ public partial class Window : ContentControl, IWindowHost, ILayoutManagerHost, I
     {
         UIElement.ForceReleaseMouseCapture();
         ClearPressedChains();
-        _lastHitTestElement = null;
 
         if (TitleBarStyle == WindowTitleBarStyle.Custom)
         {
@@ -8050,170 +8057,41 @@ public partial class Window : ContentControl, IWindowHost, ILayoutManagerHost, I
 
     private UIElement? HitTestElement(Point windowPosition, string source = "hit-test")
     {
-        var hitElement = HitTestWithCache(windowPosition)?.VisualHit as UIElement;
-        _lastHitTestElement = hitElement;
+        // Bring layout up to date before reading any element's _visualBounds /
+        // _cachedScreenOffset. Mirrors WPF's MouseDevice.Synchronize →
+        // ContextLayoutManager.UpdateLayout pattern: an input event that arrives
+        // between an InvalidateArrange call and the next render frame would
+        // otherwise hit-test against stale geometry (the bug that forced the
+        // previous TryHitTestCachedSubtree fast path to be disabled).
+        EnsureLayoutValidForInput();
+
+        long generation = _layoutManager.Generation;
+        if (generation == _hitMemoLayoutGeneration && _hitMemoPoint == windowPosition)
+        {
+            return _hitMemoElement;
+        }
+
+        var hitElement = HitTest(windowPosition)?.VisualHit as UIElement;
+
+        _hitMemoLayoutGeneration = generation;
+        _hitMemoPoint = windowPosition;
+        _hitMemoElement = hitElement;
+
         return hitElement;
     }
 
-    private HitTestResult? HitTestWithCache(Point windowPosition)
+    // Flush any queued measure/arrange so input handlers see the same layout
+    // the next render will. No-op when the window is closing or the queue is
+    // empty — the common steady-state path stays free of layout work.
+    private void EnsureLayoutValidForInput()
     {
-        if (ActiveContentDialog != null || ActiveInPlaceDialogs.Count > 0 || OverlayLayer.HasModalRoots || OverlayLayer.HasLightDismissPopups || OverlayLayer.HasPopupRoots)
-        {
-            return HitTest(windowPosition);
-        }
+        if (_isClosing || Handle == nint.Zero)
+            return;
 
-        var cachedHit = TryHitTestCachedSubtree(windowPosition);
-        if (cachedHit != null)
-        {
-            return cachedHit;
-        }
+        if (!_layoutManager.HasPendingLayout && !_isFirstLayout)
+            return;
 
-        return HitTest(windowPosition);
-    }
-
-    private HitTestResult? TryHitTestCachedSubtree(Point windowPosition)
-    {
-        var current = _lastHitTestElement;
-        if (current == null)
-            return null;
-
-        if (!IsElementAttachedToThisWindow(current))
-        {
-            _lastHitTestElement = null;
-            return null;
-        }
-
-        // The fast path is only safe when the point is inside *every* ancestor's
-        // bounds and layout clip, AND no higher-z sibling of the cached element or
-        // any ancestor could intercept the click. Without either guard, clicks leak
-        // through to scrolled-off or visually clipped content that the user cannot
-        // see — e.g. clicking a title bar above a ScrollViewer should hit the title
-        // bar button, not whichever ScrollViewer child was hit most recently, and
-        // clicking a ScrollBar overlaying the content should hit the ScrollBar, not
-        // the content behind it.
-        if (current is not FrameworkElement fe
-            || !fe.IsHitTestVisible
-            || fe.Visibility != Visibility.Visible)
-        {
-            return null;
-        }
-
-        if (!IsCachedSubtreeSafeForPoint(fe, windowPosition))
-        {
-            return null;
-        }
-
-        var parent = fe.VisualParent as UIElement;
-        var pointInParent = parent == null
-            ? windowPosition
-            : new Point(
-                windowPosition.X - parent.GetScreenBounds().X,
-                windowPosition.Y - parent.GetScreenBounds().Y);
-
-        var subtreeHit = fe.HitTest(pointInParent);
-        if (subtreeHit != null)
-        {
-            return subtreeHit;
-        }
-
-        return null;
-    }
-
-    // Walks from the cached element up to the window, confirming at each level that
-    // the point is inside the element and its layout clip. At the cached element's
-    // immediate parent we also verify no higher-z sibling shadows the cached branch
-    // (the scrollbar-over-content case). Checking only the direct parent avoids
-    // false positives from transparent overlays that always span the window (e.g.
-    // OverlayLayer), while still catching the most common occlusion pattern where
-    // a sibling widget renders on top of the cached subtree.
-    private static bool IsCachedSubtreeSafeForPoint(UIElement cached, Point windowPosition)
-    {
-        var parent = cached.VisualParent;
-        if (parent != null && TryFindHigherZSiblingThatContains(parent, cached, windowPosition))
-        {
-            return false;
-        }
-
-        Visual? node = cached;
-        while (node != null && node is not IWindowHost)
-        {
-            if (node is not UIElement ui)
-            {
-                node = node.VisualParent;
-                continue;
-            }
-
-            var screenBounds = ui.GetScreenBounds();
-            if (!screenBounds.Contains(windowPosition))
-            {
-                return false;
-            }
-
-            var localPoint = new Point(
-                windowPosition.X - screenBounds.X,
-                windowPosition.Y - screenBounds.Y);
-            if (!ui.IsPointInsideLayoutClip(localPoint))
-            {
-                return false;
-            }
-
-            node = ui.VisualParent;
-        }
-
-        return true;
-    }
-
-    private static bool TryFindHigherZSiblingThatContains(Visual parent, Visual child, Point windowPosition)
-    {
-        int count = parent.VisualChildrenCount;
-
-        // Find the child's index.
-        int childIndex = -1;
-        for (int i = 0; i < count; i++)
-        {
-            if (ReferenceEquals(parent.GetVisualChild(i), child))
-            {
-                childIndex = i;
-                break;
-            }
-        }
-
-        if (childIndex < 0)
-        {
-            return false;
-        }
-
-        // Siblings at higher indices render on top of the cached branch; if one of
-        // them contains the point, it would win in a full hit test, so the cache
-        // cannot be trusted to produce the same answer.
-        for (int i = childIndex + 1; i < count; i++)
-        {
-            if (parent.GetVisualChild(i) is UIElement sibling
-                && sibling.IsHitTestVisible
-                && sibling.Visibility == Visibility.Visible
-                && sibling.GetScreenBounds().Contains(windowPosition))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private bool IsElementAttachedToThisWindow(UIElement element)
-    {
-        Visual? current = element;
-        while (current != null)
-        {
-            if (ReferenceEquals(current, this))
-            {
-                return true;
-            }
-
-            current = current.VisualParent;
-        }
-
-        return false;
+        UpdateLayout();
     }
 
     private static MenuItem? FindTopLevelMenuItemAncestor(UIElement? element)

--- a/src/managed/Jalium.UI.Core/LayoutManager.cs
+++ b/src/managed/Jalium.UI.Core/LayoutManager.cs
@@ -64,6 +64,14 @@ internal sealed class LayoutManager
     public bool HasPendingLayout => _measureQueue.Count > 0 || _arrangeQueue.Count > 0;
 
     /// <summary>
+    /// Monotonically increasing token bumped each time UpdateLayout completes.
+    /// Consumers (e.g. Window's per-frame hit-test memoize) compare this against
+    /// a captured value to detect "is layout the same as when I last looked?".
+    /// Wraps naturally on overflow; equality is the only operation used.
+    /// </summary>
+    public long Generation { get; private set; }
+
+    /// <summary>
     /// Processes all pending measure and arrange operations.
     /// Called by Window before rendering.
     /// </summary>
@@ -146,6 +154,7 @@ internal sealed class LayoutManager
         {
             _isUpdating = false;
             _depthCache.Clear();
+            Generation++;
         }
     }
 

--- a/src/managed/Jalium.UI.Core/Markup/XamlBuilder.cs
+++ b/src/managed/Jalium.UI.Core/Markup/XamlBuilder.cs
@@ -265,6 +265,12 @@ public static class XamlBuilder
     /// <summary>Registered by Jalium.UI.Xaml: lower SG-detected Razor expression onto the element's content property (Text / Content).</summary>
     public static Action<object, string, string[], XamlBuildContext>? SetContentRazorBindingImpl { get; set; }
 
+    /// <summary>Registered by Jalium.UI.Xaml: bind a lifted <c>@if</c> child's Visibility to the (combined) condition.</summary>
+    public static Action<object, string, string[], XamlBuildContext>? SetRazorIfVisibilityImpl { get; set; }
+
+    /// <summary>Registered by Jalium.UI.Xaml: register a compiled <c>@section</c> body factory under a name.</summary>
+    public static Action<string, Func<object?>>? RegisterRazorSectionImpl { get; set; }
+
     /// <summary>
     /// Bind <paramref name="propertyName"/> on <paramref name="target"/> to a Razor value-expression
     /// (<c>@(expr)</c>, <c>@identifier</c>, <c>$.path</c>, <c>#.path</c>, or interpolated mix).
@@ -282,6 +288,30 @@ public static class XamlBuilder
     /// </summary>
     public static void SetContentRazorBinding(object target, string expression, string[] dependencies, XamlBuildContext ctx)
         => Required(SetContentRazorBindingImpl, nameof(SetContentRazorBindingImpl))(target, expression, dependencies, ctx);
+
+    /// <summary>
+    /// Bind <paramref name="child"/>'s <c>Visibility</c> to a Razor <c>@if</c>
+    /// <paramref name="condition"/> (already combined across nesting levels, matching the
+    /// runtime <c>BuildCombinedIfConditionExpression</c> shape). The SG calls this once per
+    /// element that sat inside a lifted <c>@if(...) { ... }</c> block, immediately after the
+    /// child is added to its parent. Behaviour is identical to the streaming parser's
+    /// <c>ShouldIncludeConditionalChild</c> path — the same
+    /// <c>RazorBindingEngine.TryApplyIfVisibility</c> binding — but with no document
+    /// re-parse. <paramref name="dependencies"/> are pre-computed by the SG so the runtime
+    /// analyzer skips its reflection walk.
+    /// </summary>
+    public static void SetRazorIfVisibility(object child, string condition, string[] dependencies, XamlBuildContext ctx)
+        => Required(SetRazorIfVisibilityImpl, nameof(SetRazorIfVisibilityImpl))(child, condition, dependencies, ctx);
+
+    /// <summary>
+    /// Register a compiled <c>@section <paramref name="name"/> { ... }</c> body factory.
+    /// The SG emits this into the defining component's <c>InitializeComponent</c> instead
+    /// of registering the section's raw XAML string; <see cref="RazorSectionHost"/> then
+    /// invokes <paramref name="factory"/> directly (no <c>XamlReader.Parse</c>). Each call
+    /// produces a fresh visual tree, matching the runtime's per-host re-parse semantics.
+    /// </summary>
+    public static void RegisterRazorSection(string name, Func<object?> factory)
+        => Required(RegisterRazorSectionImpl, nameof(RegisterRazorSectionImpl))(name, factory);
 
     // Strongly-typed attached fast paths.
     /// <summary>Strongly-typed setter for <c>Grid.Row</c>.</summary>

--- a/src/managed/Jalium.UI.Core/Markup/XamlBuilder.cs
+++ b/src/managed/Jalium.UI.Core/Markup/XamlBuilder.cs
@@ -271,6 +271,9 @@ public static class XamlBuilder
     /// <summary>Registered by Jalium.UI.Xaml: register a compiled <c>@section</c> body factory under a name.</summary>
     public static Action<string, Func<object?>>? RegisterRazorSectionImpl { get; set; }
 
+    /// <summary>Registered by Jalium.UI.Xaml: apply an SG-pre-split <c>{Binding ...}</c> to a property.</summary>
+    public static Action<object, string, string?, string[], string[], XamlBuildContext>? SetCompiledBindingImpl { get; set; }
+
     /// <summary>
     /// Bind <paramref name="propertyName"/> on <paramref name="target"/> to a Razor value-expression
     /// (<c>@(expr)</c>, <c>@identifier</c>, <c>$.path</c>, <c>#.path</c>, or interpolated mix).
@@ -312,6 +315,19 @@ public static class XamlBuilder
     /// </summary>
     public static void RegisterRazorSection(string name, Func<object?> factory)
         => Required(RegisterRazorSectionImpl, nameof(RegisterRazorSectionImpl))(name, factory);
+
+    /// <summary>
+    /// Apply a <c>{Binding ...}</c> the SourceGenerator already split at compile time:
+    /// <paramref name="positionalPath"/> is the leading path segment (or null) and
+    /// <paramref name="names"/>/<paramref name="values"/> are the <c>name=value</c> pairs.
+    /// The runtime rebuilds the binding via the verbatim
+    /// <c>MarkupExtensionParser.BuildBindingExtension</c> + the same apply path a
+    /// runtime-parsed binding uses, so behaviour is identical — only the
+    /// <c>{Binding}</c> string parse moved off the construction hot path (AOT-safe,
+    /// no per-element markup re-parse).
+    /// </summary>
+    public static void SetCompiledBinding(object target, string propertyName, string? positionalPath, string[] names, string[] values, XamlBuildContext ctx)
+        => Required(SetCompiledBindingImpl, nameof(SetCompiledBindingImpl))(target, propertyName, positionalPath, names, values, ctx);
 
     // Strongly-typed attached fast paths.
     /// <summary>Strongly-typed setter for <c>Grid.Row</c>.</summary>

--- a/src/managed/Jalium.UI.Xaml.SourceGenerator/BindingMarkupLowering.cs
+++ b/src/managed/Jalium.UI.Xaml.SourceGenerator/BindingMarkupLowering.cs
@@ -1,0 +1,139 @@
+using System.Collections.Generic;
+
+namespace Jalium.UI.Xaml.SourceGenerator;
+
+/// <summary>
+/// Compile-time split of a <c>{Binding ...}</c> markup-extension string into its
+/// positional path + <c>name=value</c> pairs. This is the build-time half of binding
+/// lowering: it does exactly the string work the runtime
+/// <c>MarkupExtensionParser.TryParse</c> envelope + <c>SplitParameters</c> +
+/// <c>CreateBindingExtension</c> positional rule would do, and nothing more — the runtime
+/// trampoline (<c>XamlBuilder.SetCompiledBinding</c> →
+/// <c>MarkupExtensionParser.BuildBindingExtension</c>) reconstructs the
+/// <c>BindingExtension</c> through the verbatim <c>SetBindingParameter</c> and applies it
+/// via the same path a runtime-parsed binding uses. So every <c>{Binding}</c> — including
+/// Converter / Source / RelativeSource / ConverterParameter / nested markup — is lowered
+/// with byte-identical behaviour; only the per-element string parse moves to build time.
+/// <para>
+/// The split algorithm here is a deliberate line-for-line mirror of the runtime
+/// <c>SplitParameters</c> (brace-depth + quote aware, comma at depth 0). Keeping the two
+/// in lockstep is a hard correctness requirement — divergence would mean an SG-compiled
+/// binding parses differently from a runtime-parsed one.
+/// </para>
+/// </summary>
+internal static class BindingMarkupLowering
+{
+    /// <summary>
+    /// Returns true and the structured split when <paramref name="rawValue"/> is a
+    /// <c>{Binding ...}</c> / <c>{Binding}</c> markup extension. False for anything that is
+    /// not a binding (the caller then keeps its existing handling — literal / other markup
+    /// extension / runtime <c>SetProperty</c>).
+    /// </summary>
+    public static bool TryLower(
+        string? rawValue,
+        out string? positionalPath,
+        out string[] names,
+        out string[] values)
+    {
+        positionalPath = null;
+        names = System.Array.Empty<string>();
+        values = System.Array.Empty<string>();
+
+        if (string.IsNullOrEmpty(rawValue))
+            return false;
+
+        // Mirror MarkupExtensionParser.TryParse envelope.
+        var trimmed = rawValue!.Trim();
+        if (trimmed.Length < 2 || trimmed[0] != '{' || trimmed[trimmed.Length - 1] != '}')
+            return false;
+
+        var content = trimmed.Substring(1, trimmed.Length - 2).Trim();
+        if (content.Length == 0)
+            return false;
+
+        var spaceIndex = content.IndexOf(' ');
+        var extensionName = spaceIndex >= 0 ? content.Substring(0, spaceIndex) : content;
+        var parameters = spaceIndex >= 0 ? content.Substring(spaceIndex + 1).Trim() : string.Empty;
+
+        // CreateMarkupExtension strips a leading "x:" then switches on the lowercased name.
+        if (extensionName.StartsWith("x:", System.StringComparison.Ordinal))
+            extensionName = extensionName.Substring(2);
+        if (!string.Equals(extensionName.ToLowerInvariant(), "binding", System.StringComparison.Ordinal))
+            return false;
+
+        // {Binding} with no parameters — CreateBindingExtension early-returns an empty
+        // BindingExtension; nothing to split.
+        if (parameters.Length == 0)
+            return true;
+
+        var nameList = new List<string>();
+        var valueList = new List<string>();
+        foreach (var part in SplitParameters(parameters))
+        {
+            var equalsIndex = part.IndexOf('=');
+            if (equalsIndex < 0)
+            {
+                // Positional parameter — first/only is Path (runtime: last assignment wins).
+                positionalPath = part.Trim();
+            }
+            else
+            {
+                nameList.Add(part.Substring(0, equalsIndex).Trim());
+                valueList.Add(part.Substring(equalsIndex + 1).Trim());
+            }
+        }
+
+        names = nameList.ToArray();
+        values = valueList.ToArray();
+        return true;
+    }
+
+    /// <summary>
+    /// Byte-for-byte mirror of <c>MarkupExtensionParser.SplitParameters</c>: split on
+    /// commas at brace-depth 0 and outside quotes, so a nested
+    /// <c>Converter={StaticResource X}</c> or <c>RelativeSource={RelativeSource ...}</c>
+    /// stays a single part. MUST stay identical to the runtime implementation.
+    /// </summary>
+    private static List<string> SplitParameters(string parameters)
+    {
+        var result = new List<string>();
+        var current = new System.Text.StringBuilder();
+        var braceDepth = 0;
+        var inQuote = false;
+
+        foreach (var c in parameters)
+        {
+            if (c == '\'' || c == '"')
+            {
+                inQuote = !inQuote;
+                current.Append(c);
+            }
+            else if (!inQuote && c == '{')
+            {
+                braceDepth++;
+                current.Append(c);
+            }
+            else if (!inQuote && c == '}')
+            {
+                braceDepth--;
+                current.Append(c);
+            }
+            else if (!inQuote && braceDepth == 0 && c == ',')
+            {
+                result.Add(current.ToString().Trim());
+                current.Clear();
+            }
+            else
+            {
+                current.Append(c);
+            }
+        }
+
+        if (current.Length > 0)
+        {
+            result.Add(current.ToString().Trim());
+        }
+
+        return result;
+    }
+}

--- a/src/managed/Jalium.UI.Xaml.SourceGenerator/JalxamlAst.cs
+++ b/src/managed/Jalium.UI.Xaml.SourceGenerator/JalxamlAst.cs
@@ -61,6 +61,19 @@ public sealed class JalxamlAstNode
     /// generic <c>FrameworkElement</c> field is too weak even for the fallback.
     /// </summary>
     public string FallbackClrTypeName { get; set; } = "Jalium.UI.FrameworkElement";
+
+    /// <summary>
+    /// Combined Razor <c>@if</c> condition guarding this child, set when the element sat
+    /// inside one or more <c>@if(...) { ... }</c> blocks that the parser lifted into the
+    /// synthetic <c>__RazorIf</c> wrapper and then flattened away. Null for unconditional
+    /// elements. The string mirrors the runtime
+    /// <c>XamlReader.BuildCombinedIfConditionExpression</c> shape — each nesting level wrapped
+    /// in parentheses, outermost first, joined by <c> &amp;&amp; </c> (e.g. <c>(A) &amp;&amp; (B)</c>).
+    /// The generator emits one <c>XamlBuilder.SetRazorIfVisibility</c> call per conditional
+    /// child so the runtime applies the exact same visibility binding the streaming parser
+    /// would, with no document re-parse.
+    /// </summary>
+    public string? RazorIfCondition { get; set; }
 }
 
 /// <summary>

--- a/src/managed/Jalium.UI.Xaml.SourceGenerator/JalxamlCodeGenerator.cs
+++ b/src/managed/Jalium.UI.Xaml.SourceGenerator/JalxamlCodeGenerator.cs
@@ -386,7 +386,7 @@ internal static class JalxamlCodeGenerator
                 continue;
             if (attr.LocalName == "Name" && string.IsNullOrEmpty(attr.Prefix))
                 continue;
-            EmitValueAttribute(sb, varName, attr, elementSymbol, ctx, pad);
+            EmitValueAttribute(sb, varName, attr, elementSymbol, ctx, pad, node.ResolvedClrTypeName);
         }
 
         // Attached properties — use strongly-typed fast paths for known framework owners,
@@ -623,7 +623,8 @@ internal static class JalxamlCodeGenerator
         JalxamlAstAttribute attr,
         INamedTypeSymbol? elementSymbol,
         EmitContext ctx,
-        string pad)
+        string pad,
+        string? elementClrTypeName = null)
     {
         // Razor value-expression fast path. Detected forms (in attribute values):
         //   PropName="@Identifier"         — bind to DataContext path "Identifier"
@@ -660,10 +661,17 @@ internal static class JalxamlCodeGenerator
         // So we route Setter.Value through the runtime SetProperty(string) path
         // unconditionally, which invokes the same deferred-resolution machinery the
         // streaming parser used.
+        // Recognise <Setter Value="..."> symbol-independently: the deferred-resolution
+        // exclusion is behaviour-critical, so it must hold even when no SymbolTypeHelper
+        // resolved the element symbol (the parser always resolves <Setter> to the CLR
+        // type name via the curated table). Relying on the symbol alone would wrongly
+        // eager-resolve a Setter.Value markup extension at construction time whenever
+        // the symbol is unavailable.
         bool isSetterValueAttribute =
             string.Equals(attr.LocalName, "Value", StringComparison.Ordinal) &&
-            string.Equals(elementSymbol?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
-                          "global::Jalium.UI.Setter", StringComparison.Ordinal);
+            (string.Equals(elementSymbol?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                           "global::Jalium.UI.Setter", StringComparison.Ordinal) ||
+             string.Equals(elementClrTypeName, "Jalium.UI.Setter", StringComparison.Ordinal));
 
         if (!isSetterValueAttribute && TryMatchSimpleMarkupExtension(attr.Value, out var extKind, out var extKey))
         {
@@ -683,6 +691,22 @@ internal static class JalxamlCodeGenerator
                     sb.AppendLine($"{pad}{varName}.{attr.LocalName} = null!;");
                     return;
             }
+        }
+
+        // {Binding ...} — split the envelope at compile time and hand the structured
+        // parts to the runtime trampoline, which rebuilds the BindingExtension through
+        // the verbatim SetBindingParameter and applies it via the same path a
+        // runtime-parsed binding uses (Converter / Source / RelativeSource / nested
+        // markup all handled identically). Setter.Value stays on the runtime
+        // SetProperty path — its markup-extension resolution is intentionally deferred
+        // to setter-apply time, so it must NOT be evaluated here during construction.
+        if (!isSetterValueAttribute &&
+            BindingMarkupLowering.TryLower(attr.Value, out var bindPath, out var bindNames, out var bindValues))
+        {
+            var pathExpr = bindPath == null ? "null" : EscapeStringLiteral(bindPath);
+            sb.AppendLine(
+                $"{pad}global::Jalium.UI.Markup.XamlBuilder.SetCompiledBinding({varName}, \"{attr.LocalName}\", {pathExpr}, {EmitStringArray(bindNames)}, {EmitStringArray(bindValues)}, __ctx);");
+            return;
         }
 
         if (elementSymbol != null && ctx.Symbols != null)
@@ -1225,6 +1249,26 @@ internal static class JalxamlCodeGenerator
             }
         }
         sb.Append('"');
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Emit a C# <c>string[]</c> literal (each element via <see cref="EscapeStringLiteral"/>),
+    /// or <c>global::System.Array.Empty&lt;string&gt;()</c> for an empty array to avoid an
+    /// allocation. Used for the SG-split <c>{Binding}</c> name/value pairs.
+    /// </summary>
+    private static string EmitStringArray(string[] items)
+    {
+        if (items.Length == 0)
+            return "global::System.Array.Empty<string>()";
+        var sb = new StringBuilder();
+        sb.Append("new string[] { ");
+        for (var i = 0; i < items.Length; i++)
+        {
+            if (i > 0) sb.Append(", ");
+            sb.Append(EscapeStringLiteral(items[i]));
+        }
+        sb.Append(" }");
         return sb.ToString();
     }
 

--- a/src/managed/Jalium.UI.Xaml.SourceGenerator/JalxamlCodeGenerator.cs
+++ b/src/managed/Jalium.UI.Xaml.SourceGenerator/JalxamlCodeGenerator.cs
@@ -490,6 +490,83 @@ internal static class JalxamlCodeGenerator
     }
 
     /// <summary>
+    /// Emit a compiled <c>@section Name { body }</c> registration. The body is built by a
+    /// captured factory delegate (same lambda + ambient-resource priming as
+    /// <see cref="EmitTemplateVisualTree"/>) and registered via
+    /// <c>XamlBuilder.RegisterRazorSection</c>. <see cref="Jalium.UI.Markup.RazorSectionHost"/>
+    /// invokes the factory per render — no XAML string is stored or re-parsed. The body is
+    /// a single element (enforced by <c>JalxamlParser.ValidateLiftedSections</c>); a lifted
+    /// <c>@if</c> directly wrapping it carries its condition through, applied before return.
+    /// </summary>
+    private static void EmitRazorSectionRegistration(
+        StringBuilder sb,
+        JalxamlAstNode sectionNode,
+        IndexCounter counter,
+        int indent,
+        EmitContext ctx)
+    {
+        if (sectionNode.Children.Count == 0)
+            return; // empty @section — nothing to register (matches an empty runtime body).
+
+        string sectionName = "";
+        foreach (var a in sectionNode.Attributes)
+        {
+            if (a.Kind == JalxamlAttributeKind.Value &&
+                string.Equals(a.LocalName, "__SectionName", StringComparison.Ordinal))
+            {
+                sectionName = a.Value;
+                break;
+            }
+        }
+        if (sectionName.Length == 0)
+            return;
+
+        var pad = new string(' ', indent);
+        var rootChild = sectionNode.Children[0];
+
+        sb.AppendLine($"{pad}global::Jalium.UI.Markup.XamlBuilder.RegisterRazorSection({EscapeStringLiteral(sectionName)}, () =>");
+        sb.AppendLine($"{pad}{{");
+
+        var inner = indent + 4;
+        var innerPad = new string(' ', inner);
+        var rootIndex = counter.Next();
+        var rootVar = $"__sec{rootIndex}";
+
+        // Prime the ambient resource stack with the defining component so
+        // {StaticResource} inside the section body resolves against its Resources —
+        // same rationale as EmitTemplateVisualTree.
+        sb.AppendLine($"{innerPad}global::Jalium.UI.Markup.XamlBuilder.PushParent({ctx.OwnerExpression}, __ctx);");
+        sb.AppendLine($"{innerPad}try");
+        sb.AppendLine($"{innerPad}{{");
+
+        var bodyInner = inner + 4;
+        var bodyPad = new string(' ', bodyInner);
+
+        sb.AppendLine($"{bodyPad}var {rootVar} = new global::{rootChild.ResolvedClrTypeName!}();");
+        EmitElementBody(sb, rootChild, rootVar, counter, new HashSet<string>(StringComparer.Ordinal), bodyInner, ctx);
+
+        // A lifted @if wrapping the whole section body stamped the root with a combined
+        // condition — bind its Visibility exactly as elsewhere so the section content
+        // honours the conditional.
+        if (!string.IsNullOrEmpty(rootChild.RazorIfCondition))
+        {
+            var ifDeps = RazorExpressionLowering.ExtractConditionDependencies(rootChild.RazorIfCondition);
+            sb.AppendLine(
+                $"{bodyPad}global::Jalium.UI.Markup.XamlBuilder.SetRazorIfVisibility({rootVar}, {EscapeStringLiteral(rootChild.RazorIfCondition!)}, {RazorExpressionLowering.EmitDependencyArray(ifDeps)}, __ctx);");
+        }
+
+        sb.AppendLine($"{bodyPad}return ({rootVar} as object);");
+
+        sb.AppendLine($"{innerPad}}}");
+        sb.AppendLine($"{innerPad}finally");
+        sb.AppendLine($"{innerPad}{{");
+        sb.AppendLine($"{bodyPad}global::Jalium.UI.Markup.XamlBuilder.PopParent(__ctx);");
+        sb.AppendLine($"{innerPad}}}");
+
+        sb.AppendLine($"{pad}}});");
+    }
+
+    /// <summary>
     /// Emit one value attribute (<c>PropName="value"</c>). Tries to lower the assignment
     /// to a strongly-typed setter call (<c>__c.Prop = literal;</c>) when:
     /// <list type="bullet">
@@ -861,6 +938,15 @@ internal static class JalxamlCodeGenerator
         PropertyElementTarget? asPropertyElementChild,
         JalxamlAstNode? parentNode = null)
     {
+        // @section Name { body } — a definition, not in-place content. Emit a compiled
+        // body-factory registration and no visual child (the runtime's
+        // RazorSectionHost invokes the factory; no XAML string is re-parsed).
+        if (child.LocalName == JalxamlParser.RazorSectionElementName)
+        {
+            EmitRazorSectionRegistration(sb, child, counter, indent, ctx);
+            return;
+        }
+
         var pad = new string(' ', indent);
         var childIndex = counter.Next();
         var childVar = $"__c{childIndex}";
@@ -896,6 +982,18 @@ internal static class JalxamlCodeGenerator
         else
         {
             EmitAddChildToParent(sb, parentVar, childVar, parentNode, child, ctx, innerPad);
+        }
+
+        // Lifted @if(cond) { ... }: the parser flattened the synthetic wrapper and stamped
+        // this child with the combined condition. Bind its Visibility exactly as the
+        // streaming parser's ShouldIncludeConditionalChild would have — same runtime
+        // binding, no document re-parse. Emitted after the add so the element is parented
+        // before the binding attaches (matching XamlReader's order).
+        if (!string.IsNullOrEmpty(child.RazorIfCondition))
+        {
+            var ifDeps = RazorExpressionLowering.ExtractConditionDependencies(child.RazorIfCondition);
+            sb.AppendLine(
+                $"{innerPad}global::Jalium.UI.Markup.XamlBuilder.SetRazorIfVisibility({childVar}, {EscapeStringLiteral(child.RazorIfCondition!)}, {RazorExpressionLowering.EmitDependencyArray(ifDeps)}, __ctx);");
         }
 
         sb.AppendLine($"{pad}}}");

--- a/src/managed/Jalium.UI.Xaml.SourceGenerator/JalxamlCodeGenerator.cs
+++ b/src/managed/Jalium.UI.Xaml.SourceGenerator/JalxamlCodeGenerator.cs
@@ -27,6 +27,7 @@ internal static class JalxamlCodeGenerator
         {
             return null;
         }
+        AugmentUnresolvedTypes(result.Root!, xmlnsResolver);
         if (string.IsNullOrEmpty(result.Root!.ResolvedClrTypeName))
         {
             return null;
@@ -189,6 +190,7 @@ internal static class JalxamlCodeGenerator
     {
         if (result.Root == null || result.HasStructuralRazor)
             return null;
+        AugmentUnresolvedTypes(result.Root!, xmlnsResolver);
         if (string.IsNullOrEmpty(result.Root!.ResolvedClrTypeName))
             return null;
         if (HasUnresolvedNode(result.Root!))
@@ -208,6 +210,44 @@ internal static class JalxamlCodeGenerator
         EmitElementBody(sb, result.Root, "__target", counter, namedAlready, indent: 8, ctx);
 
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Fill in element types the parser's curated table could not resolve, using the
+    /// compilation-backed <see cref="XmlnsTypeResolver"/> (clr-namespace + assembly-declared
+    /// <c>XmlnsDefinition</c> + every referenced assembly). Without this, an element whose
+    /// XML namespace is a custom URI mapped via <c>[assembly: XmlnsDefinition]</c>
+    /// (third-party / library controls) is left unresolved and the WHOLE document falls
+    /// back to the runtime parser (<c>XamlReader.LoadComponentFromString</c>). Only fills
+    /// when the parser left the type empty — the curated fast path and the parser's
+    /// <c>clr-namespace:</c> concatenation stay authoritative where they apply. A null
+    /// resolver (e.g. white-box unit tests) makes this a no-op so prior behaviour is
+    /// preserved. Genuinely unknown types stay empty and still bail via
+    /// <see cref="HasUnresolvedNode"/> — this never forces a wrong type.
+    /// </summary>
+    private static void AugmentUnresolvedTypes(JalxamlAstNode node, XmlnsTypeResolver? resolver)
+    {
+        if (resolver == null)
+            return;
+
+        if (string.IsNullOrEmpty(node.ResolvedClrTypeName))
+        {
+            var g = resolver.ResolveToGlobalQualifiedName(node.LocalName, node.NamespaceUri);
+            if (!string.IsNullOrEmpty(g))
+            {
+                // ResolveToGlobalQualifiedName yields a `global::`-prefixed name; the
+                // codegen re-prefixes `global::` itself, so store the bare FQN.
+                var bare = g!.StartsWith("global::", StringComparison.Ordinal) ? g!.Substring(8) : g!;
+                node.ResolvedClrTypeName = bare;
+                node.FallbackClrTypeName = bare;
+            }
+        }
+
+        foreach (var child in node.Children)
+            AugmentUnresolvedTypes(child, resolver);
+        foreach (var pe in node.PropertyElements)
+            foreach (var child in pe.Children)
+                AugmentUnresolvedTypes(child, resolver);
     }
 
     private static bool HasUnresolvedNode(JalxamlAstNode node)

--- a/src/managed/Jalium.UI.Xaml.SourceGenerator/JalxamlParser.cs
+++ b/src/managed/Jalium.UI.Xaml.SourceGenerator/JalxamlParser.cs
@@ -25,6 +25,31 @@ public static class JalxamlParser
     private const string JaliumLegacyNamespace = "http://schemas.jalium.ui/2024";
     private const string PresentationNamespace = "http://schemas.microsoft.com/winfx/2006/xaml/presentation";
 
+    /// <summary>
+    /// Synthetic element name a simple <c>@if(...) { ... }</c> block is lifted into so the
+    /// XML reader can parse the conditional region. It never resolves to a CLR type and is
+    /// flattened out of the AST (its children inherit a combined
+    /// <see cref="JalxamlAstNode.RazorIfCondition"/>) before codegen runs, so it never
+    /// reaches type resolution or AOT pinning.
+    /// </summary>
+    internal const string RazorIfElementName = "__RazorIf";
+
+    /// <summary>
+    /// Synthetic element a <c>@section Name { ... }</c> definition is lifted into. Codegen
+    /// turns it into a <c>XamlBuilder.RegisterRazorSection</c> factory registration and
+    /// emits NO visual child (a section is a definition, not in-place content). Never
+    /// resolves to a CLR type; never AOT-pinned.
+    /// </summary>
+    internal const string RazorSectionElementName = "__RazorSection";
+
+    /// <summary>
+    /// Synthetic element a <c>@RenderSection("Name")</c> call is lifted into. Codegen
+    /// constructs a <see cref="Jalium.UI.Markup.RazorSectionHost"/> with
+    /// <c>SectionName</c> set and adds it as a normal child (this is exactly what the
+    /// runtime preprocessor emits for a not-yet-registered section).
+    /// </summary>
+    internal const string RazorRenderSectionElementName = "__RazorRenderSection";
+
     // Mapping from XML element names to C# fully-qualified type names. Covers framework
     // types whose simple name maps to a single CLR type at compile time. Anything not in
     // this table (e.g. user-defined controls, third-party controls) is resolved through
@@ -205,6 +230,38 @@ public static class JalxamlParser
 
     public static JalxamlParseResult? Parse(string content, string filePath)
     {
+        // Lift lowerable structural Razor (simple @if / @section / @RenderSection) into
+        // synthetic XML so the SG can emit straight-line C# — the runtime then applies
+        // the exact same visibility binding / section host the streaming parser would,
+        // with NO document re-parse (no XamlReader.LoadComponentFromString /
+        // XamlReader.Parse). The lift is purely additive in risk: if it produces XML the
+        // streaming pass cannot consume, or any block turns out non-pure, we drop it
+        // entirely and reparse the ORIGINAL content via the legacy strip path, so the
+        // worst case is identical to the pre-lift behaviour.
+        if (TryLowerStructuralRazor(content, out var lifted))
+        {
+            var liftedResult = new JalxamlParseResult();
+            var liftedStripped = StripRazorCodeBlocks(lifted, out var liftedStructural, out var liftedExpr);
+            if (TryStreamingParse(liftedStripped, liftedResult) && liftedResult.Root != null)
+            {
+                // @if purity is flagged during the parse (FlattenRazorIf). @section nodes
+                // survive the tree, so validate their single-root-element shape here.
+                ValidateLiftedSections(liftedResult.Root!, liftedResult);
+            }
+            if (liftedResult.Root != null && !liftedResult.RazorLiftUnfaithful)
+            {
+                liftedResult.HasLoweredStructuralRazor = true;
+                // No @if/@section survives the lift, so the strip pass sees no structural
+                // Razor — the SG codegen path proceeds and lowers each construct.
+                liftedResult.HasStructuralRazor = liftedStructural;
+                liftedResult.HasRazorExpressions = liftedExpr;
+                return liftedResult;
+            }
+            // Lift unusable for this document (unparseable, rooted on a synthetic
+            // wrapper, or a non-pure @if/@section body) — fall through to the legacy
+            // path on the ORIGINAL content so behaviour is identical to before.
+        }
+
         var result = new JalxamlParseResult();
 
         // Strip Razor directives that would break the XML reader (text-content @if/@section/
@@ -216,6 +273,25 @@ public static class JalxamlParser
         result.HasStructuralRazor = hasStructural;
         result.HasRazorExpressions = hasExpressions;
 
+        if (!TryStreamingParse(stripped, result))
+        {
+            // The streaming pass blew up (typical trigger: Razor @{ ... } code blocks
+            // containing XML fragments). Fall back to a regex-based metadata sweep over
+            // the ORIGINAL content. TryStreamingParse already cleared partial state.
+            ParseWithRegexFallback(content, result);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Streaming XML pass that builds <see cref="JalxamlParseResult.Root"/> and the
+    /// AOT-pinning metadata from <paramref name="strippedXml"/> (Razor already
+    /// stripped/lifted). Returns <c>false</c> and resets partial state if the reader
+    /// throws, so the caller can choose a fallback without inheriting a half-built tree.
+    /// </summary>
+    private static bool TryStreamingParse(string strippedXml, JalxamlParseResult result)
+    {
         try
         {
             var settings = new XmlReaderSettings
@@ -227,7 +303,7 @@ public static class JalxamlParser
                 IgnoreWhitespace = false,
             };
 
-            using var stringReader = new StringReader(stripped);
+            using var stringReader = new StringReader(strippedXml);
             using var reader = XmlReader.Create(stringReader, settings);
 
             while (reader.Read())
@@ -266,26 +342,42 @@ public static class JalxamlParser
 
                     // Build the AST root — this descends into the entire document.
                     result.Root = ParseElementTree(reader, result);
+
+                    // Defensive: a component has a single x:Class root. An @if wrapper or
+                    // a bare @section definition must never be that root (the former is
+                    // not a real element; the latter produces no visual tree). A
+                    // @RenderSection root IS valid — it resolves to a real RazorSectionHost.
+                    // If a non-renderable synthetic bubbled up, the lift was malformed for
+                    // this document — fail so the caller falls back to the legacy path.
+                    if (result.Root != null &&
+                        (result.Root.LocalName == RazorIfElementName ||
+                         result.Root.LocalName == RazorSectionElementName))
+                    {
+                        ResetStreamingState(result);
+                        return false;
+                    }
                     break;
                 }
             }
+
+            return true;
         }
         catch
         {
-            // The streaming pass blew up (typical trigger: Razor @{ ... } code blocks
-            // containing XML fragments). Fall back to a regex-based metadata sweep over
-            // the ORIGINAL content. Clear partial state so the codegen path sees a clean
-            // "fallback only" result.
-            result.NamedElements.Clear();
-            result.ReferencedElements.Clear();
-            result.DataTypeReferences.Clear();
-            result.ClassName = null;
-            result.RootElementType = null;
-            result.Root = null;
-            ParseWithRegexFallback(content, result);
+            ResetStreamingState(result);
+            return false;
         }
+    }
 
-        return result;
+    private static void ResetStreamingState(JalxamlParseResult result)
+    {
+        result.NamedElements.Clear();
+        result.ReferencedElements.Clear();
+        result.DataTypeReferences.Clear();
+        result.RootPrefixMappings.Clear();
+        result.ClassName = null;
+        result.RootElementType = null;
+        result.Root = null;
     }
 
     // ============================================================
@@ -293,15 +385,49 @@ public static class JalxamlParser
     // children and property-element bodies so the generator has everything to emit C#.
     // ============================================================
 
-    private static JalxamlAstNode ParseElementTree(XmlReader reader, JalxamlParseResult result)
+    private static JalxamlAstNode ParseElementTree(XmlReader reader, JalxamlParseResult result, bool suppressNames = false)
     {
+        var localName = reader.LocalName;
+        var isSynthetic = localName == RazorIfElementName ||
+                          localName == RazorSectionElementName ||
+                          localName == RazorRenderSectionElementName;
+
+        // Synthetic type resolution:
+        //  - __RazorRenderSection  → a real RazorSectionHost (flows through normal codegen
+        //    as a typed child with SectionName set).
+        //  - __RazorSection        → sentinel (non-empty so FindFirstUnresolved doesn't
+        //    flag it; codegen special-cases by LocalName and never news the sentinel).
+        //  - __RazorIf             → left null; flattened out before codegen.
+        string? resolved;
+        string fallback;
+        if (localName == RazorRenderSectionElementName)
+        {
+            resolved = "Jalium.UI.Markup.RazorSectionHost";
+            fallback = "Jalium.UI.Markup.RazorSectionHost";
+        }
+        else if (localName == RazorSectionElementName)
+        {
+            resolved = RazorSectionElementName;
+            fallback = "Jalium.UI.FrameworkElement";
+        }
+        else if (localName == RazorIfElementName)
+        {
+            resolved = null;
+            fallback = "Jalium.UI.FrameworkElement";
+        }
+        else
+        {
+            resolved = GetTypeName(localName, reader.NamespaceURI);
+            fallback = GetTypeNameWithFallback(localName, reader.NamespaceURI);
+        }
+
         var node = new JalxamlAstNode
         {
-            LocalName = reader.LocalName,
+            LocalName = localName,
             NamespaceUri = reader.NamespaceURI,
             Prefix = string.IsNullOrEmpty(reader.Prefix) ? null : reader.Prefix,
-            ResolvedClrTypeName = GetTypeName(reader.LocalName, reader.NamespaceURI),
-            FallbackClrTypeName = GetTypeNameWithFallback(reader.LocalName, reader.NamespaceURI),
+            ResolvedClrTypeName = resolved,
+            FallbackClrTypeName = fallback,
         };
 
         if (reader is IXmlLineInfo lineInfo && lineInfo.HasLineInfo())
@@ -311,15 +437,24 @@ public static class JalxamlParser
         }
 
         // Track every element type for AOT pinning (legacy metadata path used by the SG to
-        // emit `RegisterType<T>()` calls in the ModuleInitializer).
-        AddReferencedElement(result, reader.LocalName, reader.NamespaceURI);
+        // emit `RegisterType<T>()` calls in the ModuleInitializer). The synthetic Razor
+        // wrappers have no element-named CLR type (RazorSectionHost is referenced directly
+        // by the emitted `new` instead), so they must never enter the referenced-type set.
+        if (!isSynthetic)
+            AddReferencedElement(result, reader.LocalName, reader.NamespaceURI);
 
         // Capture attributes. We also have to feed the legacy metadata structures because
         // the existing AOT-pinning emit reads them.
         if (reader.HasAttributes)
         {
-            CaptureAttributes(reader, node, result);
+            CaptureAttributes(reader, node, result, suppressNames);
         }
+
+        // A @section body is registered as a compiled factory invoked by RazorSectionHost
+        // — its x:Names are scoped to that subtree (like a template), NOT codebehind
+        // fields on the defining component, matching the runtime which parses the section
+        // separately. Suppress name capture for everything inside a __RazorSection.
+        var childSuppressNames = suppressNames || localName == RazorSectionElementName;
 
         if (reader.IsEmptyElement)
         {
@@ -343,13 +478,20 @@ public static class JalxamlParser
                     if (reader.LocalName.Contains('.'))
                     {
                         // Property element: <Foo.Bar>...</Foo.Bar>
-                        var pe = ParsePropertyElementBody(reader, result);
+                        var pe = ParsePropertyElementBody(reader, result, childSuppressNames);
                         node.PropertyElements.Add(pe);
                     }
                     else
                     {
-                        var child = ParseElementTree(reader, result);
-                        node.Children.Add(child);
+                        var child = ParseElementTree(reader, result, childSuppressNames);
+                        // Flatten a lifted @if wrapper into this parent, stamping each
+                        // conditional child with the combined condition. While building a
+                        // <__RazorIf> subtree itself, keep nested wrappers intact so
+                        // FlattenRazorIf can layer the conditions in the correct order.
+                        if (child.LocalName == RazorIfElementName && node.LocalName != RazorIfElementName)
+                            FlattenRazorIf(child, null, node.Children, result);
+                        else
+                            node.Children.Add(child);
                     }
                     break;
                 }
@@ -374,7 +516,7 @@ public static class JalxamlParser
         return node;
     }
 
-    private static JalxamlAstPropertyElement ParsePropertyElementBody(XmlReader reader, JalxamlParseResult result)
+    private static JalxamlAstPropertyElement ParsePropertyElementBody(XmlReader reader, JalxamlParseResult result, bool suppressNames = false)
     {
         var parts = reader.LocalName.Split('.');
         var ownerName = parts.Length > 0 ? parts[0] : reader.LocalName;
@@ -413,8 +555,11 @@ public static class JalxamlParser
                 }
                 else
                 {
-                    var child = ParseElementTree(reader, result);
-                    pe.Children.Add(child);
+                    var child = ParseElementTree(reader, result, suppressNames);
+                    if (child.LocalName == RazorIfElementName)
+                        FlattenRazorIf(child, null, pe.Children, result);
+                    else
+                        pe.Children.Add(child);
                 }
             }
         }
@@ -454,7 +599,7 @@ public static class JalxamlParser
         }
     }
 
-    private static void CaptureAttributes(XmlReader reader, JalxamlAstNode node, JalxamlParseResult result)
+    private static void CaptureAttributes(XmlReader reader, JalxamlAstNode node, JalxamlParseResult result, bool suppressNames = false)
     {
         for (var i = 0; i < reader.AttributeCount; i++)
         {
@@ -483,7 +628,7 @@ public static class JalxamlParser
             // tag for the codegen to invoke ApplyXDirective.
             if (IsXamlMarkupNamespace(ns))
             {
-                if (string.Equals(local, "Name", StringComparison.Ordinal))
+                if (!suppressNames && string.Equals(local, "Name", StringComparison.Ordinal))
                 {
                     result.NamedElements.Add(new NamedElement
                     {
@@ -529,7 +674,7 @@ public static class JalxamlParser
             }
 
             // Compatibility: an unprefixed `Name="Foo"` is treated as x:Name by the runtime.
-            if (string.Equals(local, "Name", StringComparison.Ordinal) && string.IsNullOrEmpty(prefix))
+            if (!suppressNames && string.Equals(local, "Name", StringComparison.Ordinal) && string.IsNullOrEmpty(prefix))
             {
                 result.NamedElements.Add(new NamedElement
                 {
@@ -1026,4 +1171,455 @@ public static class JalxamlParser
         // Stray flow-control that escaped the build task. Same treatment.
         "for", "foreach", "while", "switch", "do", "try", "using", "lock"
     };
+
+    /// <summary>
+    /// Rewrite structural Razor the SG can lower into synthetic XML so the reader can
+    /// parse it and codegen can emit straight-line C# (no document re-parse):
+    /// <list type="bullet">
+    ///   <item><c>@if(cond) { ... }</c> → <c>&lt;__RazorIf Condition="cond"&gt;...&lt;/__RazorIf&gt;</c>
+    ///   — each conditional child later gets a <c>SetRazorIfVisibility</c> binding
+    ///   (same as the streaming parser's <c>ShouldIncludeConditionalChild</c>).</item>
+    ///   <item><c>@section Name { ... }</c> → <c>&lt;__RazorSection Name="Name"&gt;...&lt;/__RazorSection&gt;</c>
+    ///   — codegen registers a compiled body factory (<c>RegisterRazorSection</c>),
+    ///   replacing the runtime's "store XAML string, re-parse per host".</item>
+    ///   <item><c>@RenderSection("Name")</c> → <c>&lt;__RazorRenderSection Name="Name"/&gt;</c>
+    ///   — codegen builds a <see cref="Jalium.UI.Markup.RazorSectionHost"/> (exactly what
+    ///   the runtime preprocessor emits for a not-yet-registered section).</item>
+    /// </list>
+    /// <para>
+    /// Returns <c>false</c> — leaving <paramref name="rewritten"/> equal to
+    /// <paramref name="content"/> — for any document this cannot faithfully lower so the
+    /// caller keeps the legacy strip + runtime-fallback path: <c>else</c> / <c>else if</c>
+    /// chains; stray <c>@{ ... }</c> or leaked loop/flow keywords
+    /// (<c>@for</c>/<c>@foreach</c>/<c>@while</c>/<c>@switch</c>/<c>@do</c>/<c>@try</c>/
+    /// <c>@using</c>/<c>@lock</c>); a <c>@RenderSection</c> whose name is not a string
+    /// literal; unbalanced braces; or no structural Razor at all.
+    /// </para>
+    /// <para>
+    /// Purity (an <c>@if</c> / <c>@section</c> body holding only child elements — no
+    /// block-level text, no property element) is enforced after parsing in
+    /// <see cref="FlattenRazorIf"/> / the section-node check, where the real tree
+    /// distinguishes block-level text from text inside a child element. A non-pure block
+    /// sets <see cref="JalxamlParseResult.RazorLiftUnfaithful"/> so <see cref="Parse"/>
+    /// discards the lift and falls back to the legacy path — behaviour identical to before.
+    /// </para>
+    /// </summary>
+    private static bool TryLowerStructuralRazor(string content, out string rewritten)
+    {
+        rewritten = content;
+        if (content.IndexOf("@if", StringComparison.Ordinal) < 0 &&
+            content.IndexOf("@section", StringComparison.Ordinal) < 0 &&
+            content.IndexOf("@RenderSection", StringComparison.Ordinal) < 0)
+        {
+            return false;
+        }
+
+        var sb = new System.Text.StringBuilder(content.Length + 64);
+        var i = 0;
+        var inTag = false;
+        var inAttr = false;
+        char attrQuote = '\0';
+        // Open block stack — 'I' = @if, 'S' = @section. A text-level '}' closes the
+        // innermost block and emits the matching close tag. @if condition layering for
+        // nesting is rebuilt later from the XML nesting of <__RazorIf> (FlattenRazorIf),
+        // not from this scan; the stack only needs the block kind.
+        var blocks = new System.Collections.Generic.Stack<char>();
+        var liftedAny = false;
+
+        while (i < content.Length)
+        {
+            char c = content[i];
+
+            if (inAttr)
+            {
+                sb.Append(c);
+                if (c == attrQuote) { inAttr = false; attrQuote = '\0'; }
+                i++;
+                continue;
+            }
+
+            if (inTag)
+            {
+                sb.Append(c);
+                if (c == '"' || c == '\'') { inAttr = true; attrQuote = c; }
+                else if (c == '>') inTag = false;
+                i++;
+                continue;
+            }
+
+            // XML comment / CDATA — copy verbatim, never interpret Razor inside.
+            if (c == '<' && StartsWith(content, i, "<!--"))
+            {
+                var end = content.IndexOf("-->", i + 4, StringComparison.Ordinal);
+                if (end < 0) return false;
+                end += 3;
+                sb.Append(content, i, end - i);
+                i = end;
+                continue;
+            }
+            if (c == '<' && StartsWith(content, i, "<![CDATA["))
+            {
+                var end = content.IndexOf("]]>", i + 9, StringComparison.Ordinal);
+                if (end < 0) return false;
+                end += 3;
+                sb.Append(content, i, end - i);
+                i = end;
+                continue;
+            }
+
+            if (c == '<' && i + 1 < content.Length &&
+                (char.IsLetter(content[i + 1]) || content[i + 1] == '/' ||
+                 content[i + 1] == '!' || content[i + 1] == '?'))
+            {
+                inTag = true;
+                sb.Append(c);
+                i++;
+                continue;
+            }
+
+            if (c == '@' && i + 1 < content.Length)
+            {
+                // @@ → literal '@'.
+                if (content[i + 1] == '@') { sb.Append("@@"); i += 2; continue; }
+
+                // @if ( cond ) {  → open a conditional block.
+                if (IsWordAt(content, i + 1, "if", out var afterIf))
+                {
+                    var openParen = SkipWhitespace(content, afterIf);
+                    if (openParen < content.Length && content[openParen] == '(')
+                    {
+                        if (!TryReadBalancedParens(content, openParen, out var condition, out var afterParen))
+                            return false;
+                        var brace = SkipWhitespace(content, afterParen);
+                        if (brace >= content.Length || content[brace] != '{')
+                            return false;
+
+                        sb.Append('<').Append(RazorIfElementName)
+                          .Append(" Condition=\"").Append(EscapeXmlAttribute(condition.Trim()))
+                          .Append("\">");
+                        blocks.Push('I');
+                        liftedAny = true;
+                        i = brace + 1;
+                        continue;
+                    }
+                    return false; // `@if` without `(...)` body — not a form we lower.
+                }
+
+                // @section Name { ... }  → open a section-definition block.
+                if (IsWordAt(content, i + 1, "section", out var afterSec))
+                {
+                    var nameStart = SkipWhitespace(content, afterSec);
+                    var p = nameStart;
+                    while (p < content.Length &&
+                           (char.IsLetterOrDigit(content[p]) || content[p] == '_'))
+                    {
+                        p++;
+                    }
+                    if (p == nameStart) return false; // no name — cannot lower.
+                    var sectionName = content.Substring(nameStart, p - nameStart);
+                    var brace = SkipWhitespace(content, p);
+                    if (brace >= content.Length || content[brace] != '{')
+                        return false;
+
+                    // Use a non-reserved attribute name: an unprefixed `Name=` would be
+                    // captured as an x:Name and emit a bogus codebehind field.
+                    sb.Append('<').Append(RazorSectionElementName)
+                      .Append(" __SectionName=\"").Append(EscapeXmlAttribute(sectionName))
+                      .Append("\">");
+                    blocks.Push('S');
+                    liftedAny = true;
+                    i = brace + 1;
+                    continue;
+                }
+
+                // @RenderSection ( "Name" [, ...] )  → a section host placeholder.
+                if (IsWordAt(content, i + 1, "RenderSection", out var afterRs))
+                {
+                    var op = SkipWhitespace(content, afterRs);
+                    if (op >= content.Length || content[op] != '(')
+                        return false;
+                    if (!TryReadBalancedParens(content, op, out var args, out var afterArgs))
+                        return false;
+                    var renderName = ExtractRenderSectionName(args);
+                    if (renderName == null) return false; // non-literal name — cannot lower.
+
+                    // Emit the real RazorSectionHost property name so the normal codegen
+                    // path sets it directly (no RenderSection-specific codegen needed).
+                    sb.Append('<').Append(RazorRenderSectionElementName)
+                      .Append(" SectionName=\"").Append(EscapeXmlAttribute(renderName))
+                      .Append("\" />");
+                    liftedAny = true;
+                    i = afterArgs;
+                    continue;
+                }
+
+                // Stray @{ ... } or a leaked loop/flow keyword — cannot lower.
+                if (content[i + 1] == '{' || IsLeakedFlowKeywordAt(content, i + 1))
+                    return false;
+
+                // Value-expression Razor (@id, @(expr)) — copy verbatim; SG lowers it.
+                sb.Append(c);
+                i++;
+                continue;
+            }
+
+            // Text-level '}' closes the innermost open block. Mirrors the runtime parser,
+            // which also treats a '}' in text content as the block terminator.
+            if (c == '}' && blocks.Count > 0)
+            {
+                var kind = blocks.Pop();
+                i++;
+                if (kind == 'I')
+                {
+                    sb.Append("</").Append(RazorIfElementName).Append('>');
+                    // `} else` / `} else if` — an else-chain is not lowerable.
+                    var afterBrace = SkipWhitespace(content, i);
+                    if (IsWordAt(content, afterBrace, "else", out _))
+                        return false;
+                }
+                else
+                {
+                    sb.Append("</").Append(RazorSectionElementName).Append('>');
+                }
+                continue;
+            }
+
+            sb.Append(c);
+            i++;
+        }
+
+        if (blocks.Count != 0 || !liftedAny)
+            return false;
+
+        rewritten = sb.ToString();
+        return true;
+    }
+
+    /// <summary>
+    /// Extract the section name from <c>@RenderSection</c> arguments. Mirrors the runtime
+    /// <c>RazorCodeBlockPreprocessor.ExtractSectionNameFromArgs</c>: the name is the first
+    /// string literal (<c>"Name"</c>, optionally followed by <c>, required: false</c> /
+    /// <c>, false</c>). Returns null when the first argument is not a string literal — a
+    /// dynamic name can't be resolved at compile time, so the document defers to runtime.
+    /// </summary>
+    private static string? ExtractRenderSectionName(string args)
+    {
+        var t = args.Trim();
+        if (t.Length < 2) return null;
+        var q = t[0];
+        if (q != '"' && q != '\'') return null;
+        var end = t.IndexOf(q, 1);
+        if (end <= 0) return null;
+        return t.Substring(1, end - 1);
+    }
+
+    private static bool StartsWith(string s, int pos, string token)
+        => pos + token.Length <= s.Length && string.CompareOrdinal(s, pos, token, 0, token.Length) == 0;
+
+    /// <summary>
+    /// True if <paramref name="word"/> sits at <paramref name="pos"/> as a whole token
+    /// (not a longer identifier — <c>@iffy</c> must not match <c>if</c>). On match
+    /// <paramref name="after"/> is the index just past the word.
+    /// </summary>
+    private static bool IsWordAt(string s, int pos, string word, out int after)
+    {
+        after = pos;
+        if (!StartsWith(s, pos, word))
+            return false;
+        var next = pos + word.Length;
+        if (next < s.Length)
+        {
+            var n = s[next];
+            if (n == '_' || char.IsLetterOrDigit(n))
+                return false;
+        }
+        after = next;
+        return true;
+    }
+
+    private static int SkipWhitespace(string s, int pos)
+    {
+        while (pos < s.Length && char.IsWhiteSpace(s[pos])) pos++;
+        return pos;
+    }
+
+    private static readonly string[] s_leakedFlowKeywords =
+    {
+        // @if / @section / @RenderSection are lowered, not bailed. These are the
+        // loop/flow keywords TransformJalxamlRazorTask should have build-time expanded;
+        // if one leaks, the doc can't be faithfully lowered.
+        "for", "foreach", "while", "switch", "do", "try", "using", "lock"
+    };
+
+    private static bool IsLeakedFlowKeywordAt(string content, int position)
+    {
+        foreach (var kw in s_leakedFlowKeywords)
+        {
+            if (IsWordAt(content, position, kw, out _))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Read a balanced <c>( ... )</c> starting at <paramref name="openParen"/> (which must
+    /// index the '('). String / char literals inside are skipped so a ')' or '"' in the
+    /// condition text doesn't end the scan early. <paramref name="inner"/> is the text
+    /// between the outer parens; <paramref name="afterClose"/> is the index past ')'.
+    /// </summary>
+    private static bool TryReadBalancedParens(string s, int openParen, out string inner, out int afterClose)
+    {
+        inner = string.Empty;
+        afterClose = openParen;
+        var depth = 0;
+        var start = openParen + 1;
+        var i = openParen;
+        while (i < s.Length)
+        {
+            var c = s[i];
+            if (c == '"' || c == '\'')
+            {
+                var q = c;
+                i++;
+                while (i < s.Length && s[i] != q)
+                {
+                    if (s[i] == '\\' && i + 1 < s.Length) i++;
+                    i++;
+                }
+                if (i >= s.Length) return false; // unterminated literal
+                i++;
+                continue;
+            }
+            if (c == '(') depth++;
+            else if (c == ')')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    inner = s.Substring(start, i - start);
+                    afterClose = i + 1;
+                    return true;
+                }
+            }
+            i++;
+        }
+        return false;
+    }
+
+    private static string EscapeXmlAttribute(string value)
+    {
+        var sb = new System.Text.StringBuilder(value.Length + 8);
+        foreach (var c in value)
+        {
+            switch (c)
+            {
+                case '&': sb.Append("&amp;"); break;
+                case '<': sb.Append("&lt;"); break;
+                case '>': sb.Append("&gt;"); break;
+                case '"': sb.Append("&quot;"); break;
+                case '\'': sb.Append("&apos;"); break;
+                default: sb.Append(c); break;
+            }
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Combine an inherited (outer) <c>@if</c> condition with this level's condition,
+    /// matching the runtime <c>XamlReader.BuildCombinedIfConditionExpression</c> shape:
+    /// each level parenthesised, outermost first, joined by <c> &amp;&amp; </c>.
+    /// </summary>
+    private static string CombineRazorIfCondition(string? inherited, string own)
+    {
+        var wrapped = "(" + own.Trim() + ")";
+        return string.IsNullOrEmpty(inherited) ? wrapped : inherited + " && " + wrapped;
+    }
+
+    private static string? GetRazorIfConditionAttribute(JalxamlAstNode node)
+    {
+        foreach (var attr in node.Attributes)
+        {
+            if (attr.Kind == JalxamlAttributeKind.Value &&
+                string.Equals(attr.LocalName, "Condition", StringComparison.Ordinal))
+            {
+                return attr.Value;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Flatten a synthetic <see cref="RazorIfElementName"/> subtree into
+    /// <paramref name="target"/>: each real descendant element is appended directly and
+    /// stamped with the combined condition; nested <see cref="RazorIfElementName"/> nodes
+    /// recurse with the condition extended. The wrapper itself never reaches codegen.
+    /// <para>
+    /// Purity gate: a faithful per-child visibility binding requires the block to hold
+    /// only child elements. If the wrapper captured block-level text or a property
+    /// element, <see cref="JalxamlParseResult.RazorLiftUnfaithful"/> is set so
+    /// <see cref="Parse"/> abandons the lift and reparses via the legacy path (identical
+    /// to the pre-lift behaviour). Text/expressions <em>inside</em> a child element are
+    /// that child's own content and are unaffected.
+    /// </para>
+    /// </summary>
+    private static void FlattenRazorIf(JalxamlAstNode razorIf, string? inherited, List<JalxamlAstNode> target, JalxamlParseResult result)
+    {
+        if (!string.IsNullOrWhiteSpace(razorIf.TextContent) || razorIf.PropertyElements.Count > 0)
+            result.RazorLiftUnfaithful = true;
+
+        var combined = CombineRazorIfCondition(inherited, GetRazorIfConditionAttribute(razorIf) ?? "true");
+        foreach (var child in razorIf.Children)
+        {
+            if (child.LocalName == RazorIfElementName)
+            {
+                FlattenRazorIf(child, combined, target, result);
+            }
+            else
+            {
+                // An element can only ever sit on one @if path so a straight assign is
+                // correct (FlattenRazorIf is the single writer of RazorIfCondition).
+                child.RazorIfCondition = combined;
+                target.Add(child);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Walk the lifted tree and validate every <see cref="RazorSectionElementName"/>
+    /// node: a compiled section factory feeds a single-Content
+    /// <see cref="Jalium.UI.Markup.RazorSectionHost"/> (mirroring the runtime's
+    /// <c>&lt;Border&gt;{body}&lt;/Border&gt;</c> single child), so the body must be
+    /// exactly one element — no block-level text, no property element, and not itself a
+    /// bare section. A violation sets <see cref="JalxamlParseResult.RazorLiftUnfaithful"/>
+    /// so <see cref="Parse"/> drops the lift and the document renders via the legacy
+    /// runtime path exactly as before.
+    /// </summary>
+    private static void ValidateLiftedSections(JalxamlAstNode node, JalxamlParseResult result)
+    {
+        if (node.LocalName == RazorSectionElementName)
+        {
+            var bodyRoots = 0;
+            foreach (var c in node.Children)
+            {
+                if (c.LocalName == RazorSectionElementName)
+                {
+                    result.RazorLiftUnfaithful = true; // nested bare section — no visual root
+                    break;
+                }
+                bodyRoots++;
+            }
+            if (bodyRoots != 1 ||
+                !string.IsNullOrWhiteSpace(node.TextContent) ||
+                node.PropertyElements.Count > 0)
+            {
+                result.RazorLiftUnfaithful = true;
+            }
+        }
+
+        foreach (var child in node.Children)
+            ValidateLiftedSections(child, result);
+        foreach (var pe in node.PropertyElements)
+            foreach (var child in pe.Children)
+                ValidateLiftedSections(child, result);
+    }
 }

--- a/src/managed/Jalium.UI.Xaml.SourceGenerator/JalxamlParser.cs
+++ b/src/managed/Jalium.UI.Xaml.SourceGenerator/JalxamlParser.cs
@@ -1220,10 +1220,12 @@ public static class JalxamlParser
         var inAttr = false;
         char attrQuote = '\0';
         // Open block stack — 'I' = @if, 'S' = @section. A text-level '}' closes the
-        // innermost block and emits the matching close tag. @if condition layering for
-        // nesting is rebuilt later from the XML nesting of <__RazorIf> (FlattenRazorIf),
-        // not from this scan; the stack only needs the block kind.
-        var blocks = new System.Collections.Generic.Stack<char>();
+        // innermost block and emits the matching close tag. For @if, the frame also
+        // carries the chain conditions seen so far so a following `else if` / `else`
+        // can compute its mutually-exclusive effective condition exactly as the runtime
+        // (XamlReader RazorIfBlockEntry.ChainBranchConditions). Nesting is rebuilt later
+        // from the XML nesting of <__RazorIf> by FlattenRazorIf.
+        var blocks = new System.Collections.Generic.Stack<RazorBlock>();
         var liftedAny = false;
 
         while (i < content.Length)
@@ -1294,10 +1296,11 @@ public static class JalxamlParser
                         if (brace >= content.Length || content[brace] != '{')
                             return false;
 
+                        var c1 = condition.Trim();
                         sb.Append('<').Append(RazorIfElementName)
-                          .Append(" Condition=\"").Append(EscapeXmlAttribute(condition.Trim()))
+                          .Append(" Condition=\"").Append(EscapeXmlAttribute(c1))
                           .Append("\">");
-                        blocks.Push('I');
+                        blocks.Push(new RazorBlock { Kind = 'I', Chain = new System.Collections.Generic.List<string> { c1 } });
                         liftedAny = true;
                         i = brace + 1;
                         continue;
@@ -1326,7 +1329,7 @@ public static class JalxamlParser
                     sb.Append('<').Append(RazorSectionElementName)
                       .Append(" __SectionName=\"").Append(EscapeXmlAttribute(sectionName))
                       .Append("\">");
-                    blocks.Push('S');
+                    blocks.Push(new RazorBlock { Kind = 'S' });
                     liftedAny = true;
                     i = brace + 1;
                     continue;
@@ -1367,21 +1370,65 @@ public static class JalxamlParser
             // which also treats a '}' in text content as the block terminator.
             if (c == '}' && blocks.Count > 0)
             {
-                var kind = blocks.Pop();
+                var frame = blocks.Pop();
                 i++;
-                if (kind == 'I')
-                {
-                    sb.Append("</").Append(RazorIfElementName).Append('>');
-                    // `} else` / `} else if` — an else-chain is not lowerable.
-                    var afterBrace = SkipWhitespace(content, i);
-                    if (IsWordAt(content, afterBrace, "else", out _))
-                        return false;
-                }
-                else
+                if (frame.Kind != 'I')
                 {
                     sb.Append("</").Append(RazorSectionElementName).Append('>');
+                    continue;
                 }
-                continue;
+
+                sb.Append("</").Append(RazorIfElementName).Append('>');
+
+                // `} else` / `} else if(c) {` — open the next mutually-exclusive branch
+                // as a sibling <__RazorIf> whose Condition is the effective expression
+                // computed exactly as the runtime (negate every prior chain condition,
+                // AND the new one for else-if). FlattenRazorIf later wraps + combines
+                // these with ancestors, reproducing BuildCombinedIfConditionExpression.
+                var afterBrace = SkipWhitespace(content, i);
+                if (!IsWordAt(content, afterBrace, "else", out var afterElse))
+                    continue; // chain ends here.
+
+                var p = SkipWhitespace(content, afterElse);
+                if (IsWordAt(content, p, "if", out var afterElseIf))
+                {
+                    var ep = SkipWhitespace(content, afterElseIf);
+                    if (ep >= content.Length || content[ep] != '(')
+                        return false;
+                    if (!TryReadBalancedParens(content, ep, out var elseIfCond, out var afterEp))
+                        return false;
+                    var eb = SkipWhitespace(content, afterEp);
+                    if (eb >= content.Length || content[eb] != '{')
+                        return false;
+
+                    var ck = elseIfCond.Trim();
+                    sb.Append('<').Append(RazorIfElementName)
+                      .Append(" Condition=\"")
+                      .Append(EscapeXmlAttribute(BuildElseIfEffectiveCondition(frame.Chain!, ck)))
+                      .Append("\">");
+                    var newChain = new System.Collections.Generic.List<string>(frame.Chain!) { ck };
+                    blocks.Push(new RazorBlock { Kind = 'I', Chain = newChain });
+                    liftedAny = true;
+                    i = eb + 1;
+                    continue;
+                }
+
+                if (p < content.Length && content[p] == '{')
+                {
+                    sb.Append('<').Append(RazorIfElementName)
+                      .Append(" Condition=\"")
+                      .Append(EscapeXmlAttribute(BuildElseEffectiveCondition(frame.Chain!)))
+                      .Append("\">");
+                    // `else` adds no new condition; a later (illegal) else would simply
+                    // re-negate the same chain — harmless, mirrors the runtime.
+                    blocks.Push(new RazorBlock { Kind = 'I', Chain = frame.Chain });
+                    liftedAny = true;
+                    i = p + 1;
+                    continue;
+                }
+
+                // `else` not followed by `if(` or `{` — malformed; defer to runtime.
+                return false;
             }
 
             sb.Append(c);
@@ -1411,6 +1458,56 @@ public static class JalxamlParser
         var end = t.IndexOf(q, 1);
         if (end <= 0) return null;
         return t.Substring(1, end - 1);
+    }
+
+    /// <summary>One open structural block in the lift scanner.</summary>
+    private sealed class RazorBlock
+    {
+        /// <summary>'I' = @if branch, 'S' = @section.</summary>
+        public char Kind;
+
+        /// <summary>
+        /// For an @if branch: every branch condition seen so far in this if/else-if chain
+        /// (c1 .. c_k for the currently-open k-th branch), mirroring the runtime
+        /// <c>RazorIfBlockEntry.ChainBranchConditions</c>. Null for @section.
+        /// </summary>
+        public System.Collections.Generic.List<string>? Chain;
+    }
+
+    /// <summary>
+    /// Effective condition for an <c>else if(ck)</c> branch following branches whose
+    /// conditions are <paramref name="priorChain"/> (c1..c_{k-1} ... actually the popped
+    /// branch's full chain). Byte-identical to the runtime
+    /// (<c>XamlReader</c>: <c>!(c1) &amp;&amp; !(c2) &amp;&amp; ... &amp;&amp; (ck)</c>, always joined).
+    /// </summary>
+    private static string BuildElseIfEffectiveCondition(System.Collections.Generic.List<string> priorChain, string ck)
+    {
+        var sb = new System.Text.StringBuilder();
+        foreach (var cond in priorChain)
+        {
+            sb.Append("!(").Append(cond).Append(") && ");
+        }
+        sb.Append('(').Append(ck).Append(')');
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Effective condition for a plain <c>else</c> following branches
+    /// <paramref name="priorChain"/>. Byte-identical to the runtime: a single prior
+    /// condition is emitted as <c>!(c1)</c> (NOT joined); multiple as
+    /// <c>!(c1) &amp;&amp; !(c2) &amp;&amp; ...</c>.
+    /// </summary>
+    private static string BuildElseEffectiveCondition(System.Collections.Generic.List<string> priorChain)
+    {
+        if (priorChain.Count == 1)
+            return "!(" + priorChain[0] + ")";
+        var sb = new System.Text.StringBuilder();
+        for (var k = 0; k < priorChain.Count; k++)
+        {
+            if (k > 0) sb.Append(" && ");
+            sb.Append("!(").Append(priorChain[k]).Append(')');
+        }
+        return sb.ToString();
     }
 
     private static bool StartsWith(string s, int pos, string token)

--- a/src/managed/Jalium.UI.Xaml.SourceGenerator/JalxamlSourceGenerator.cs
+++ b/src/managed/Jalium.UI.Xaml.SourceGenerator/JalxamlSourceGenerator.cs
@@ -800,6 +800,29 @@ public sealed class JalxamlParseResult
     /// </summary>
     public bool HasRazorExpressions { get; set; }
 
+    /// <summary>
+    /// True if the document contained lowerable structural Razor (simple <c>@if</c> /
+    /// <c>@section</c> / <c>@RenderSection</c>) that the parser lifted into synthetic
+    /// wrappers and codegen turned into straight-line C#
+    /// (<c>SetRazorIfVisibility</c> / <c>RegisterRazorSection</c> /
+    /// <see cref="Jalium.UI.Markup.RazorSectionHost"/>). Purely informational — unlike
+    /// <see cref="HasStructuralRazor"/> it does NOT force the runtime fallback (the
+    /// whole point is that these no longer hit
+    /// <see cref="Jalium.UI.Markup.XamlReader.LoadComponentFromString(object, string, Uri?, System.Reflection.Assembly?)"/>
+    /// or <c>XamlReader.Parse</c>).
+    /// </summary>
+    public bool HasLoweredStructuralRazor { get; set; }
+
+    /// <summary>
+    /// Set during the lifted parse when an <c>@if</c> or <c>@section</c> block turned out
+    /// to contain block-level text or a property element (not purely child elements),
+    /// which the per-child visibility binding / single-root section factory can't
+    /// represent faithfully. <see cref="JalxamlParser.Parse"/> then discards the lifted
+    /// result and reparses the original document via the legacy strip + runtime-fallback
+    /// path. Never observed by codegen — it only gates the parse-time fallback decision.
+    /// </summary>
+    public bool RazorLiftUnfaithful { get; set; }
+
     public List<NamedElement> NamedElements { get; } = new();
 
     /// <summary>

--- a/src/managed/Jalium.UI.Xaml.SourceGenerator/RazorExpressionLowering.cs
+++ b/src/managed/Jalium.UI.Xaml.SourceGenerator/RazorExpressionLowering.cs
@@ -49,6 +49,26 @@ internal static class RazorExpressionLowering
     }
 
     /// <summary>
+    /// Extract the dependency paths a Razor <c>@if</c> condition must observe. Unlike
+    /// <see cref="TryLowerAttributeValue"/> the condition is a bare C# boolean expression
+    /// (no <c>@</c> sigil) — e.g. <c>Count &gt; 0</c>, <c>IsBusy &amp;&amp; $.Ready</c> — so we
+    /// run the same identifier walker used inside <c>@(...)</c>. The result is handed to
+    /// the runtime via <c>XamlBuilder.SetRazorIfVisibility</c> so
+    /// <see cref="Jalium.UI.Markup.RazorExpressionAnalyzer"/> can skip its reflection walk
+    /// (it consults the pre-registered metadata first).
+    /// </summary>
+    public static string[] ExtractConditionDependencies(string? condition)
+    {
+        if (string.IsNullOrWhiteSpace(condition))
+            return System.Array.Empty<string>();
+        var deps = new HashSet<string>(System.StringComparer.Ordinal);
+        ExtractIdentifiersFromExpression(condition!, 0, condition!.Length, deps);
+        return deps.Count == 0
+            ? System.Array.Empty<string>()
+            : new List<string>(deps).ToArray();
+    }
+
+    /// <summary>
     /// Emit a C# array-literal expression for the dependency list. Empty list emits
     /// <c>global::System.Array.Empty&lt;string&gt;()</c> to avoid one allocation per call.
     /// </summary>

--- a/src/managed/Jalium.UI.Xaml/MarkupExtension.cs
+++ b/src/managed/Jalium.UI.Xaml/MarkupExtension.cs
@@ -951,20 +951,38 @@ internal static class MarkupExtensionParser
         if (extension == null)
             return false;
 
-        // Provide the value
+        result = ProvideExtensionValue(extension, targetObject, targetProperty?.Name, ambientProvider);
+        return true;
+    }
+
+    /// <summary>
+    /// Builds the markup-extension service provider, resolves the target
+    /// <see cref="DependencyProperty"/> from <paramref name="targetPropertyName"/>, and
+    /// invokes <see cref="MarkupExtension.ProvideValue"/> — the exact tail
+    /// <see cref="TryParse(string, object, PropertyInfo?, IAmbientResourceProvider?, out object?)"/>
+    /// uses. Factored out so the SG-lowered compiled-binding path
+    /// (<see cref="BuildBindingExtension"/>) applies a binding through byte-identical
+    /// runtime machinery — no behavioural divergence from a runtime-parsed
+    /// <c>{Binding ...}</c>.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("MarkupExtension.ProvideValue may reflect on resolved types.")]
+    internal static object? ProvideExtensionValue(
+        MarkupExtension extension,
+        object targetObject,
+        string? targetPropertyName,
+        IAmbientResourceProvider? ambientProvider)
+    {
         var serviceProvider = new MarkupExtensionServiceProvider();
 
-        // Add ambient resource provider if available
         if (ambientProvider != null)
         {
             serviceProvider.AddService(typeof(IAmbientResourceProvider), ambientProvider);
         }
 
-        // Find the DependencyProperty if the target is a DependencyObject
         DependencyProperty? dp = null;
-        if (targetObject is DependencyObject && targetProperty != null)
+        if (targetObject is DependencyObject && !string.IsNullOrEmpty(targetPropertyName))
         {
-            dp = FindDependencyProperty(targetObject.GetType(), targetProperty.Name);
+            dp = FindDependencyProperty(targetObject.GetType(), targetPropertyName!);
         }
 
         var provideValueTarget = new ProvideValueTarget
@@ -974,8 +992,39 @@ internal static class MarkupExtensionParser
         };
         serviceProvider.AddService(typeof(IProvideValueTarget), provideValueTarget);
 
-        result = extension.ProvideValue(serviceProvider);
-        return true;
+        return extension.ProvideValue(serviceProvider);
+    }
+
+    /// <summary>
+    /// Reconstructs a <see cref="BindingExtension"/> from the SG-pre-split
+    /// <c>{Binding ...}</c> parameter list. This is <see cref="CreateBindingExtension"/>
+    /// minus the <see cref="SplitParameters"/> string work (which the SourceGenerator did
+    /// at compile time): the positional segment becomes <see cref="BindingExtension.Path"/>
+    /// and every <c>name=value</c> pair flows through the <b>verbatim</b>
+    /// <see cref="SetBindingParameter"/> — so Converter / Source / RelativeSource /
+    /// ConverterParameter / FallbackValue / TargetNullValue and any nested markup
+    /// extension resolve exactly as a runtime-parsed binding (incl. the deferred
+    /// <c>Converter={StaticResource X}</c> → <see cref="BindingExtension.PendingConverterKey"/>
+    /// path).
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Forwards to SetBindingParameter which may invoke nested markup extensions that reflect on user types.")]
+    internal static BindingExtension BuildBindingExtension(
+        string? positionalPath,
+        IReadOnlyList<string> names,
+        IReadOnlyList<string> values,
+        IAmbientResourceProvider? ambientProvider)
+    {
+        var extension = new BindingExtension();
+        if (!string.IsNullOrEmpty(positionalPath))
+            extension.Path = positionalPath!.Trim();
+
+        var count = names.Count < values.Count ? names.Count : values.Count;
+        for (var i = 0; i < count; i++)
+        {
+            SetBindingParameter(extension, names[i].Trim(), values[i].Trim(), ambientProvider);
+        }
+
+        return extension;
     }
 
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Some markup extensions (e.g. x:Static) reflect on the resolved Type to read fields/properties.")]

--- a/src/managed/Jalium.UI.Xaml/RazorBinding.cs
+++ b/src/managed/Jalium.UI.Xaml/RazorBinding.cs
@@ -437,6 +437,40 @@ internal static class RazorBindingEngine
     }
 
     /// <summary>
+    /// SourceGenerator-lowered Razor <c>@if</c>. The parser lifted a simple
+    /// <c>@if(cond) { ... }</c> block into a synthetic wrapper, flattened it away, and the
+    /// SG emitted one call here per conditional child immediately after adding it to its
+    /// parent. This is the exact <see cref="TryApplyIfVisibility"/> binding the streaming
+    /// parser's <c>ShouldIncludeConditionalChild</c> applies — same
+    /// <c>RazorConditionalVisibilityConverter</c>, same DataContext trigger — but reached
+    /// from straight-line generated C# instead of a runtime document re-parse
+    /// (<c>XamlReader.LoadComponentFromString</c> is no longer involved for these blocks).
+    /// <para>
+    /// <paramref name="dependencies"/> is the SG-computed identifier set for
+    /// <paramref name="condition"/>; pre-registering it lets
+    /// <see cref="RazorExpressionAnalyzer.GetPlan"/> skip its reflection/Roslyn walk (the
+    /// documented SG fast path). The set is a superset of the precise dependencies so the
+    /// binding never misses an update.
+    /// </para>
+    /// </summary>
+    internal static void ApplySgLoweredIfVisibility(
+        object child,
+        string condition,
+        string[] dependencies,
+        XamlParserContext context)
+    {
+        if (dependencies is { Length: > 0 })
+            RazorExpressionRegistry.RegisterMetadata(condition, condition, dependencies);
+
+        // For a lifted simple @if the child is always a UIElement and the condition is
+        // never blank (the parser refuses to lift text-only / bodyless @if), so this
+        // applies the visibility binding exactly as the streaming parser would. The
+        // non-UIElement branch ShouldIncludeConditionalChild has (EvaluateConditionOnce)
+        // is unreachable here by construction, so it is intentionally not duplicated.
+        TryApplyIfVisibility(child, condition, context);
+    }
+
+    /// <summary>
     /// SourceGenerator-lowered Razor value-expression on a named property. The SG
     /// pre-computed <paramref name="dependencies"/> from the expression text at codegen
     /// time so we skip the reflection walk in <see cref="RazorExpressionAnalyzer"/>.
@@ -997,6 +1031,41 @@ public static class RazorExpressionRegistry
     internal static bool TryGetGlobalSection(string name, out string content)
     {
         return GlobalSections.TryGetValue(name, out content!);
+    }
+
+    // ── Compiled section factories (SourceGenerator-lowered @section) ──
+    //
+    // The runtime preprocessor path registers a section's raw XAML *string*
+    // (RegisterSection above); RazorSectionHost then re-parses it via
+    // XamlReader.Parse on render. The SG instead compiles the @section body to a
+    // straight-line element factory and registers the delegate here, so the host
+    // can invoke it directly with no document re-parse. Both stores share the
+    // SectionRegistered/SectionUnregistered events and the same name space; the
+    // host prefers a factory and falls back to the string store, so SG-compiled
+    // and runtime-parsed documents interoperate.
+
+    private static readonly ConcurrentDictionary<string, Func<object?>> SectionFactories = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Registers a compiled <c>@section</c> body factory. Emitted by the
+    /// SourceGenerator into the defining component's <c>InitializeComponent</c>.
+    /// Each invocation produces a fresh visual tree (factory semantics, matching
+    /// the runtime which re-parses the section XAML per host). Fires
+    /// <see cref="SectionRegistered"/> so any already-loaded
+    /// <see cref="RazorSectionHost"/> for this name re-renders.
+    /// </summary>
+    public static void RegisterSectionFactory(string name, Func<object?> factory)
+    {
+        if (!string.IsNullOrWhiteSpace(name) && factory != null)
+        {
+            SectionFactories[name] = factory;
+            SectionRegistered?.Invoke(name);
+        }
+    }
+
+    internal static bool TryGetSectionFactory(string name, out Func<object?> factory)
+    {
+        return SectionFactories.TryGetValue(name, out factory!);
     }
 
     // ── AOT-safe property accessor registry ──

--- a/src/managed/Jalium.UI.Xaml/RazorSectionHost.cs
+++ b/src/managed/Jalium.UI.Xaml/RazorSectionHost.cs
@@ -48,7 +48,28 @@ public sealed class RazorSectionHost : ContentControl
         var name = SectionName;
         if (string.IsNullOrWhiteSpace(name)) return;
 
-        if (!RazorExpressionRegistry.TryGetGlobalSection(name, out var xaml))
+        // SG-compiled @section: invoke the registered factory directly — the section
+        // body was lowered to straight-line C# at build time, so there is no XAML
+        // string to re-parse here. This is the path that removes XamlReader.Parse
+        // from section rendering entirely.
+        if (RazorExpressionRegistry.TryGetSectionFactory(name!, out var factory))
+        {
+            try
+            {
+                Content = factory();
+                InvalidateMeasure();
+            }
+            catch
+            {
+                // Compiled section factory threw — leave Content unchanged.
+            }
+            return;
+        }
+
+        // Runtime-preprocessor @section: only the raw XAML string was registered
+        // (the defining document was loaded via the runtime parser, not the SG), so
+        // fall back to parsing it. Kept for interop with non-SG-compiled documents.
+        if (!RazorExpressionRegistry.TryGetGlobalSection(name!, out var xaml))
             return;
 
         try

--- a/src/managed/Jalium.UI.Xaml/XamlBuilder.cs
+++ b/src/managed/Jalium.UI.Xaml/XamlBuilder.cs
@@ -129,6 +129,11 @@ internal static class XamlBuilderInitializer
         {
             RazorExpressionRegistry.RegisterSectionFactory(name, factory);
         };
+
+        XamlBuilder.SetCompiledBindingImpl = static (target, propertyName, positionalPath, names, values, ctx) =>
+        {
+            XamlReader.BuilderApplyCompiledBinding(target, propertyName, positionalPath, names, values, CtxOf(ctx));
+        };
     }
 
     /// <summary>

--- a/src/managed/Jalium.UI.Xaml/XamlBuilder.cs
+++ b/src/managed/Jalium.UI.Xaml/XamlBuilder.cs
@@ -119,6 +119,16 @@ internal static class XamlBuilderInitializer
         {
             RazorBindingEngine.ApplySgLoweredContentExpression(target, expression, dependencies, CtxOf(ctx));
         };
+
+        XamlBuilder.SetRazorIfVisibilityImpl = static (child, condition, dependencies, ctx) =>
+        {
+            RazorBindingEngine.ApplySgLoweredIfVisibility(child, condition, dependencies, CtxOf(ctx));
+        };
+
+        XamlBuilder.RegisterRazorSectionImpl = static (name, factory) =>
+        {
+            RazorExpressionRegistry.RegisterSectionFactory(name, factory);
+        };
     }
 
     /// <summary>

--- a/src/managed/Jalium.UI.Xaml/XamlReader.cs
+++ b/src/managed/Jalium.UI.Xaml/XamlReader.cs
@@ -3055,6 +3055,41 @@ public static class XamlReader
         return SetProperty(instance, propertyName, value, context, null);
     }
 
+    /// <summary>
+    /// Apply a SourceGenerator-lowered <c>{Binding ...}</c>. The SG already did the
+    /// envelope + <c>SplitParameters</c> string work at compile time and hands us the
+    /// positional path and the <c>name=value</c> pairs. We rebuild the
+    /// <see cref="BindingExtension"/> via the verbatim <see cref="MarkupExtensionParser.BuildBindingExtension"/>
+    /// (so Converter / Source / RelativeSource / nested markup resolve identically) and
+    /// then run the <b>exact</b> apply/assign path the streaming parser uses for a
+    /// runtime-parsed binding (mirrors <c>SetProperty</c>'s markup-extension branch):
+    /// a produced <see cref="BindingExpressionBase"/> means
+    /// <see cref="DependencyObject.SetBinding(DependencyProperty, BindingBase)"/> already
+    /// bound it; otherwise the produced value is assigned through the same
+    /// <see cref="BuilderSetProperty"/> path. Behaviour is byte-identical to
+    /// <c>{Binding ...}</c> parsed at runtime — only the string parse moved to build time.
+    /// </summary>
+    [RequiresUnreferencedCode("Forwards to MarkupExtensionParser.BuildBindingExtension / ProvideExtensionValue which resolve nested markup extensions via reflection.")]
+    internal static void BuilderApplyCompiledBinding(
+        object target,
+        string propertyName,
+        string? positionalPath,
+        string[] names,
+        string[] values,
+        XamlParserContext context)
+    {
+        var extension = MarkupExtensionParser.BuildBindingExtension(positionalPath, names, values, context);
+        var result = MarkupExtensionParser.ProvideExtensionValue(extension, target, propertyName, context);
+
+        // Mirror SetProperty's markup-extension branch exactly: SetBinding already
+        // applied the binding when ProvideValue returned a BindingExpressionBase;
+        // anything else is a value to assign through the normal property path.
+        if (result is BindingExpressionBase)
+            return;
+        if (result != null)
+            BuilderSetProperty(target, propertyName, result, context);
+    }
+
     [RequiresUnreferencedCode("XamlBuilder.SetAttachedProperty resolves the static SetXxx method via reflection on the owner type.")]
     internal static void BuilderSetAttachedProperty(
         object instance,

--- a/src/native/jalium.native.core/include/jalium_path_cache.h
+++ b/src/native/jalium.native.core/include/jalium_path_cache.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "jalium_api.h"
+#include "jalium_triangulate.h"  // Contour (cached boundary for edge-AA feather)
 
 namespace jalium {
 
@@ -45,6 +46,14 @@ struct CachedPathGeometry {
     // intersecting glyph outline, multi-subpath SVG icon) — the caller must
     // fall back to CPU rasterization in that case.
     std::vector<float> localTriangles;
+
+    // Local-space boundary contours (post-bezier-flatten, pre-transform).
+    // Populated by the D3D12 Impeller engine so the per-frame emit step can
+    // build a constant-width edge-AA feather ring around the fill on its
+    // non-MSAA target without re-flattening. Vulkan leaves this empty (its
+    // pipeline AAs differently). Cached here, like localTriangles, so a
+    // moving / scaled / rotated path never re-flattens.
+    std::vector<Contour> contours;
 
     bool triangulationSucceeded = false;
 };

--- a/src/native/jalium.native.d3d12/include/d3d12_direct_renderer.h
+++ b/src/native/jalium.native.d3d12/include/d3d12_direct_renderer.h
@@ -204,7 +204,8 @@ public:
     // --- Draw commands (called between BeginFrame/EndFrame) ---
     void AddSdfRect(const SdfRectInstance& inst);
     void AddText(IDWriteTextLayout* layout, float x, float y,
-                 float r, float g, float b, float a);
+                 float r, float g, float b, float a,
+                 uint64_t layoutKey = 0);
     void AddBitmap(float x, float y, float w, float h, float opacity,
                    ID3D12Resource* textureResource, DXGI_FORMAT format,
                    float uvMaxX = 1.0f, float uvMaxY = 1.0f,

--- a/src/native/jalium.native.d3d12/include/d3d12_glyph_atlas.h
+++ b/src/native/jalium.native.d3d12/include/d3d12_glyph_atlas.h
@@ -4,6 +4,8 @@
 #include <dwrite_3.h>
 #include <unordered_map>
 #include <vector>
+#include <list>
+#include <cstdint>
 
 namespace jalium {
 
@@ -90,12 +92,20 @@ public:
     /// Generates glyph instances for a text layout.
     /// Returns the number of glyph instances added to `outInstances`.
     /// Optionally outputs text decoration rects (underline/strikethrough).
+    /// `layoutKey` (0 = uncacheable) is a stable content hash of the source
+    /// text + format + constraints (from D3D12TextFormat::CreateLayout). When
+    /// non-zero the resolved glyph quads + decorations are memoized per
+    /// (layoutKey, origin) so repeat frames skip layout->Draw + the per-glyph
+    /// atlas walk — the dominant DrawText cost once the layout itself is
+    /// cached. Entries are tagged with the atlas generation and ignored after
+    /// any Reset()/GrowAtlas() so stale atlas UVs are never served.
     uint32_t GenerateGlyphs(
         IDWriteTextLayout* layout,
         float originX, float originY,
         float colorR, float colorG, float colorB, float colorA,
         std::vector<GlyphQuadInstance>& outInstances,
-        std::vector<TextDecorationRect>* outDecorations = nullptr);
+        std::vector<TextDecorationRect>* outDecorations = nullptr,
+        uint64_t layoutKey = 0);
 
     /// Uploads any pending glyph data to the GPU atlas texture.
     /// Must be called before rendering text in a frame.
@@ -196,6 +206,31 @@ private:
 
     // Glyph cache (GlyphCacheValue holds a ComPtr to prevent dangling fontFace pointers)
     std::unordered_map<GlyphKey, GlyphCacheValue, GlyphKeyHash> cache_;
+
+    // Atlas generation: bumped on every Reset()/GrowAtlas() (anything that
+    // moves slots or changes atlas dimensions, invalidating cached UVs).
+    // The resolved-glyph cache tags entries with the generation they were
+    // built under and treats a mismatch as a miss — content-addressed key
+    // (no raw pointers) + generation guard makes stale-UV garbled text
+    // impossible by construction.
+    uint32_t atlasGeneration_ = 0;
+
+    // Resolved-glyph memo: color-neutral quads + decorations for a shaped
+    // run at a given (layoutKey, origin). Caller applies its premultiplied
+    // colour at emit, so different-coloured draws of the same text still hit.
+    struct CachedGlyphRun {
+        std::vector<GlyphQuadInstance> instances;  // colour left unset (filled at emit)
+        std::vector<TextDecorationRect> decos;     // colour left unset (filled at emit)
+        uint32_t gen = 0;
+    };
+    struct InstNode { uint64_t key; CachedGlyphRun run; };
+    std::list<InstNode> instLru_;
+    std::unordered_map<uint64_t, std::list<InstNode>::iterator> instMap_;
+    static constexpr size_t kInstCacheCap = 4096;
+
+    static uint64_t HashInstanceKey(uint64_t layoutKey,
+                                    float originX, float originY,
+                                    float dpiScale) noexcept;
 
     // Simple row-based atlas packer
     uint16_t packX_ = 0;

--- a/src/native/jalium.native.d3d12/include/d3d12_impeller_engine.h
+++ b/src/native/jalium.native.d3d12/include/d3d12_impeller_engine.h
@@ -269,6 +269,49 @@ public:
         uint32_t viewportW, uint32_t viewportH);
 
 private:
+    // --- Fill: transform-independent geometry cache + legacy fallback ---
+
+    /// Legacy pixel-space scanline fill. Preserved verbatim from the old
+    /// EncodeFillPath; EncodeFillPath now delegates here for gradient brushes
+    /// and for outlines its local-space triangulator can't handle.
+    bool EncodeFillPathScanline(
+        float startX, float startY,
+        const float* commands, uint32_t commandLength,
+        const EngineBrushData& brush,
+        FillRule fillRule,
+        const EngineTransform& transform,
+        int32_t edgeMode);
+
+    /// Legacy per-call pixel-space scanline polygon fill. EncodeFillPolygon
+    /// delegates here for gradient brushes and polygons its local-space
+    /// triangulator rejects.
+    bool EncodeFillPolygonScanline(
+        const float* points, uint32_t pointCount,
+        const EngineBrushData& brush,
+        FillRule fillRule,
+        const EngineTransform& transform);
+
+    /// Legacy pixel-space, transform-keyed stroke pipeline (analytic scanline
+    /// or binary mesh). EncodeStrokePath delegates here for dashed strokes,
+    /// explicit Antialiased mode, gradient brushes and the empty-command case.
+    bool EncodeStrokePathPixelCached(
+        float startX, float startY,
+        const float* commands, uint32_t commandLength,
+        const EngineBrushData& brush,
+        float strokeWidth, bool closed,
+        int32_t lineJoin, float miterLimit,
+        int32_t lineCap,
+        const float* dashPattern, uint32_t dashCount, float dashOffset,
+        const EngineTransform& transform,
+        int32_t edgeMode);
+
+    /// Per-frame constant-width edge-AA feather ring built from the cached
+    /// local-space boundary contours (our solid-fill target has no MSAA).
+    void EmitContourFeather(
+        const std::vector<Contour>& contours,
+        const EngineTransform& transform,
+        float r, float g, float b, float a);
+
     // --- Gradient Fill ---
 
     /// Encode a gradient-filled path (linear or radial).
@@ -351,14 +394,14 @@ private:
 
     float flattenTolerance_ = 0.25f;
 
-    // Source-space PathGeometryCache. Hoisted from jalium.native.vulkan to
-    // jalium.native.core; D3D12 holds it but does NOT use it yet — the
-    // pixel-space flatten that EncodeFillPath does today bakes transform
-    // into the cached vertices, so naively caching by source-only key would
-    // re-introduce the under-subdivision bug that pixel-space flatten was
-    // supposed to fix (see d3d12_impeller_engine.cpp:1737-1755). Wired up in
-    // the tolerance-scale-aware commit once scaleBucket lands in the cache
-    // key — only then is source-space caching safe across scales.
+    // Source-space PathGeometryCache (hoisted from jalium.native.vulkan to
+    // jalium.native.core). EncodeFillPath caches the local-space flatten +
+    // triangulation + boundary contours here, keyed by path data + fillRule +
+    // scaleBucket (NOT the full transform). scaleBucket gives each scale
+    // octave its own entry so source-space caching is safe across scales (the
+    // under-subdivision concern that previously kept this unused). A moving /
+    // scaled / rotated path now reuses the cached geometry and only pays an
+    // O(N) per-frame vertex transform instead of re-rasterizing every frame.
     std::unique_ptr<PathGeometryCache> pathGeometryCache_;
 
     // Precomputed trig cache (shared across frames)

--- a/src/native/jalium.native.d3d12/include/d3d12_resources.h
+++ b/src/native/jalium.native.d3d12/include/d3d12_resources.h
@@ -3,6 +3,9 @@
 #include "jalium_backend.h"
 #include "d3d12_backend.h"
 #include <vector>
+#include <list>
+#include <unordered_map>
+#include <cstdint>
 
 namespace jalium {
 
@@ -150,17 +153,43 @@ public:
     IDWriteTextFormat* GetFormat() const { return format_.Get(); }
     IDWriteFactory* GetFactory() const { return factory_; }
 
-    /// Creates an IDWriteTextLayout with the current format settings (including maxLines).
+    /// Creates an IDWriteTextLayout with the current format settings (including
+    /// maxLines). Cached: DirectWrite shaping/itemization/line-breaking is
+    /// ~10-15µs and a data-heavy frame issues hundreds of identical calls
+    /// (profiled: DrawText 344 calls / 5.46 ms). The shaped layout depends
+    /// only on (text, maxWidth, maxHeight, maxLines) for THIS format object —
+    /// the format (font/size/weight/style/alignment/wrap/trim/spacing) is the
+    /// natural cache partition, so a format mutation clears the whole cache.
+    /// AddText consumes the layout read-only, so sharing one instance across
+    /// draws and frames is safe.
+    /// `outKey` (optional) receives a globally-unique content hash of this
+    /// shaped layout (text + this format object + constraints). The glyph
+    /// atlas uses it to memoize resolved glyph quads across frames.
     HRESULT CreateLayout(const wchar_t* text, uint32_t textLength,
                          float maxWidth, float maxHeight,
-                         IDWriteTextLayout** layout);
+                         IDWriteTextLayout** layout,
+                         uint64_t* outKey = nullptr);
 
 private:
+    uint64_t HashLayoutKey(const wchar_t* text, uint32_t textLength,
+                           float maxWidth, float maxHeight) const noexcept;
+    /// Drop all cached layouts. Called by every setter that mutates a
+    /// layout-affecting format property so stale layouts are never served.
+    void InvalidateLayoutCache() noexcept;
 
     ComPtr<IDWriteTextFormat> format_;
     IDWriteFactory* factory_ = nullptr;
     float fontSize_ = 0.0f;
     uint32_t maxLines_ = 0;  // 0 = unlimited
+
+    // Bounded LRU of shaped layouts. Cap covers a data-heavy frame's full
+    // visible text set (hundreds of unique strings) so it reuses across
+    // frames instead of thrashing. Layouts are small (DirectWrite internal
+    // buffers, a few KB each).
+    struct LayoutCacheEntry { uint64_t key; ComPtr<IDWriteTextLayout> layout; };
+    std::list<LayoutCacheEntry> layoutLru_;
+    std::unordered_map<uint64_t, std::list<LayoutCacheEntry>::iterator> layoutMap_;
+    static constexpr size_t kLayoutCacheCap = 2048;
 };
 
 } // namespace jalium

--- a/src/native/jalium.native.d3d12/src/d3d12_direct_renderer.cpp
+++ b/src/native/jalium.native.d3d12/src/d3d12_direct_renderer.cpp
@@ -1150,7 +1150,8 @@ void D3D12DirectRenderer::AddSdfRect(const SdfRectInstance& inst)
 }
 
 void D3D12DirectRenderer::AddText(IDWriteTextLayout* layout, float x, float y,
-                                   float r, float g, float b, float a)
+                                   float r, float g, float b, float a,
+                                   uint64_t layoutKey)
 {
     if (!glyphAtlas_ || !layout) return;
 
@@ -1171,7 +1172,8 @@ void D3D12DirectRenderer::AddText(IDWriteTextLayout* layout, float x, float y,
     // Collect glyph instances and text decorations
     std::vector<D3D12GlyphAtlas::TextDecorationRect> decorations;
     uint32_t count = glyphAtlas_->GenerateGlyphs(layout, tx, ty, r, g, b, effectiveA,
-                                                  textInstances_, &decorations);
+                                                  textInstances_, &decorations,
+                                                  layoutKey);
 
     // Apply transform scaling to each glyph instance.
     // GenerateGlyphs places glyphs at absolute screen positions using the

--- a/src/native/jalium.native.d3d12/src/d3d12_glyph_atlas.cpp
+++ b/src/native/jalium.native.d3d12/src/d3d12_glyph_atlas.cpp
@@ -213,6 +213,10 @@ D3D12GlyphAtlas::~D3D12GlyphAtlas() = default;
 
 void D3D12GlyphAtlas::Reset()
 {
+    // Every cached glyph slot is about to be invalidated — bump the
+    // generation so the resolved-glyph memo treats all its entries (which
+    // hold now-stale atlas UVs) as misses.
+    ++atlasGeneration_;
     cache_.clear();
     std::fill(atlasBitmap_.begin(), atlasBitmap_.end(), (uint8_t)0);
     packX_ = 0;
@@ -403,6 +407,9 @@ bool D3D12GlyphAtlas::GrowAtlas(uint32_t reqW, uint32_t reqH)
     atlasW_ = newW;
     atlasH_ = newH;
     atlasState_ = D3D12_RESOURCE_STATE_COMMON;
+    // Atlas dimensions changed → every cached UV (entry.x*invW etc.) is now
+    // wrong. Bump generation so the resolved-glyph memo rebuilds.
+    ++atlasGeneration_;
 
     // The full atlas needs reupload — old rows preserved data is on the CPU
     // shadow, but the new GPU texture is freshly created and empty.
@@ -639,14 +646,69 @@ bool D3D12GlyphAtlas::RasterizeGlyph(const GlyphKey& key, GlyphEntry& entry)
 // Generate Glyph Instances
 // ============================================================================
 
+uint64_t D3D12GlyphAtlas::HashInstanceKey(uint64_t layoutKey,
+                                          float originX, float originY,
+                                          float dpiScale) noexcept
+{
+    uint64_t h = 0xCBF29CE484222325ull;  // FNV-1a 64-bit
+    auto mix = [&h](const void* p, size_t n) {
+        const uint8_t* b = static_cast<const uint8_t*>(p);
+        for (size_t i = 0; i < n; ++i) { h ^= b[i]; h *= 0x100000001B3ull; }
+    };
+    mix(&layoutKey, sizeof(layoutKey));
+    mix(&originX, sizeof(originX));
+    mix(&originY, sizeof(originY));
+    mix(&dpiScale, sizeof(dpiScale));
+    return h;
+}
+
 uint32_t D3D12GlyphAtlas::GenerateGlyphs(
     IDWriteTextLayout* layout,
     float originX, float originY,
     float colorR, float colorG, float colorB, float colorA,
     std::vector<GlyphQuadInstance>& outInstances,
-    std::vector<TextDecorationRect>* outDecorations)
+    std::vector<TextDecorationRect>* outDecorations,
+    uint64_t layoutKey)
 {
     if (!layout || !initialized_) return 0;
+
+    // Apply this call's premultiplied colour to a colour-neutral run (cached
+    // or freshly built) and append it to the caller's buffers. Decorations
+    // are always built so the memo is correct even if outDecorations varies
+    // between calls; they're only emitted when the caller asked for them.
+    auto emitRun = [&](const CachedGlyphRun& run) -> uint32_t {
+        const float pr = colorR * colorA, pg = colorG * colorA,
+                    pb = colorB * colorA, pa = colorA;
+        outInstances.reserve(outInstances.size() + run.instances.size());
+        for (GlyphQuadInstance gi : run.instances) {
+            gi.colorR = pr; gi.colorG = pg; gi.colorB = pb; gi.colorA = pa;
+            outInstances.push_back(gi);
+        }
+        if (outDecorations) {
+            for (TextDecorationRect dr : run.decos) {
+                dr.colorR = pr; dr.colorG = pg; dr.colorB = pb; dr.colorA = pa;
+                outDecorations->push_back(dr);
+            }
+        }
+        return (uint32_t)run.instances.size();
+    };
+
+    // Cache hit: skip layout->Draw + the entire per-glyph atlas walk. The
+    // generation guard rejects any entry built before a Reset()/GrowAtlas()
+    // (its cached UVs would now point at the wrong atlas slots) so stale-UV
+    // garbled text is impossible.
+    if (layoutKey != 0) {
+        const uint64_t ck = HashInstanceKey(layoutKey, originX, originY, dpiScale_);
+        auto mit = instMap_.find(ck);
+        if (mit != instMap_.end()) {
+            if (mit->second->run.gen == atlasGeneration_) {
+                instLru_.splice(instLru_.begin(), instLru_, mit->second);
+                return emitRun(mit->second->run);
+            }
+            instLru_.erase(mit->second);   // stale generation → rebuild
+            instMap_.erase(mit);
+        }
+    }
 
     // Atlas overflow recycling happens at the real frame boundary inside
     // D3D12DirectRenderer::BeginFrame (see NeedsReset/ClearResetFlag pair).
@@ -664,7 +726,7 @@ uint32_t D3D12GlyphAtlas::GenerateGlyphs(
     GlyphRunCollector collector;
     layout->Draw(nullptr, &collector, originX, originY);
 
-    uint32_t count = 0;
+    CachedGlyphRun built;
     float invW = 1.0f / static_cast<float>(atlasW_);
     float invH = 1.0f / static_cast<float>(atlasH_);
 
@@ -725,12 +787,9 @@ uint32_t D3D12GlyphAtlas::GenerateGlyphs(
                 inst.uvMinY = entry.y * invH;
                 inst.uvMaxX = (entry.x + entry.w) * invW;
                 inst.uvMaxY = (entry.y + entry.h) * invH;
-                inst.colorR = colorR * colorA; // premultiply
-                inst.colorG = colorG * colorA;
-                inst.colorB = colorB * colorA;
-                inst.colorA = colorA;
-                outInstances.push_back(inst);
-                count++;
+                // Colour applied at emit so one cached run serves any colour.
+                inst.colorR = inst.colorG = inst.colorB = inst.colorA = 0.0f;
+                built.instances.push_back(inst);
             }
 
             if (i < run.glyphAdvances.size())
@@ -738,23 +797,34 @@ uint32_t D3D12GlyphAtlas::GenerateGlyphs(
         }
     }
 
-    // Output text decorations (underline/strikethrough) as rect primitives
-    if (outDecorations && !collector.decorations.empty()) {
-        for (auto& dec : collector.decorations) {
-            TextDecorationRect rect;
-            rect.x = dec.x;
-            rect.y = dec.y;
-            rect.width = dec.width;
-            rect.thickness = std::max(dec.thickness, 1.0f);
-            // Premultiply color
-            rect.colorR = colorR * colorA;
-            rect.colorG = colorG * colorA;
-            rect.colorB = colorB * colorA;
-            rect.colorA = colorA;
-            outDecorations->push_back(rect);
-        }
+    // Build decorations unconditionally so the memo stays correct even if a
+    // later same-key call passes outDecorations; emit gates on the pointer.
+    for (auto& dec : collector.decorations) {
+        TextDecorationRect rect;
+        rect.x = dec.x;
+        rect.y = dec.y;
+        rect.width = dec.width;
+        rect.thickness = std::max(dec.thickness, 1.0f);
+        rect.colorR = rect.colorG = rect.colorB = rect.colorA = 0.0f;
+        built.decos.push_back(rect);
     }
 
+    const uint32_t count = emitRun(built);
+
+    if (layoutKey != 0) {
+        built.gen = atlasGeneration_;
+        const uint64_t ck = HashInstanceKey(layoutKey, originX, originY, dpiScale_);
+        if (auto ex = instMap_.find(ck); ex != instMap_.end()) {
+            instLru_.erase(ex->second);
+            instMap_.erase(ex);
+        }
+        if (instLru_.size() >= kInstCacheCap) {
+            instMap_.erase(instLru_.back().key);
+            instLru_.pop_back();
+        }
+        instLru_.push_front(InstNode{ ck, std::move(built) });
+        instMap_[ck] = instLru_.begin();
+    }
     return count;
 }
 

--- a/src/native/jalium.native.d3d12/src/d3d12_impeller_engine.cpp
+++ b/src/native/jalium.native.d3d12/src/d3d12_impeller_engine.cpp
@@ -2,6 +2,7 @@
 #include "jalium_scanline_rasterizer.h"   // PixelRect / RasterizePathToRects
 #include "jalium_api.h"                   // JALIUM_API export macro
 #include "jalium_path_stats.h"            // unified path telemetry (core dll)
+#include "jalium_flatten.h"               // MaxScaleFromTransform / ScaleBucketFromMaxScale
 #include <atomic>
 #include <cstring>
 #include <cmath>
@@ -460,6 +461,12 @@ float4 main(PSInput input) : SV_TARGET {
 ImpellerD3D12Engine::ImpellerD3D12Engine(ID3D12Device* device, DXGI_FORMAT rtvFormat)
     : device_(device), rtvFormat_(rtvFormat)
 {
+    // Transform-independent geometry cache (flatten + triangulate result keyed
+    // by path data + fill rule + scale octave, NOT by the full transform). A
+    // moving / scaled / rotated path hits this and only pays an O(N) per-frame
+    // vertex transform instead of re-rasterizing every frame. Same type and
+    // capacity Vulkan uses (vulkan_render_target.cpp kMaxPathCacheEntries).
+    pathGeometryCache_ = std::make_unique<PathGeometryCache>(512);
 }
 
 ImpellerD3D12Engine::~ImpellerD3D12Engine() = default;
@@ -1562,7 +1569,223 @@ inline void RasterizePathToRects(
 // Path Encoding Entry Points
 // ============================================================================
 
+// ============================================================================
+// EncodeFillPath — transform-independent local-space geometry cache.
+//
+// THE fix for "Geometry drawing is laggy under animation/scroll/zoom". The
+// legacy pipeline (now EncodeFillPathScanline, kept verbatim as the fallback)
+// transforms commands to PIXEL space, flattens + scanline-rasterizes, and
+// caches the resulting PixelRect list keyed by the FULL transform matrix. Any
+// scale/rotation change ⇒ cache miss ⇒ the whole O(W·H·edges) rasterizer
+// re-runs every frame for every visible path. WPF/WinUI3 (Direct2D) instead
+// tessellate ONCE in geometry-local space and let the GPU apply the transform.
+//
+// This mirrors VulkanRenderTarget::FillPath (vulkan_render_target.cpp:8059):
+// flatten + triangulate once in LOCAL space, cache keyed by (startX, startY,
+// commands, fillRule, scaleBucket) — translation & rotation are NOT in the
+// key — then each frame only transform the cached vertices (O(N)). Edge AA on
+// our non-MSAA solid-fill target is a constant-width feather ring built per
+// frame from the cached boundary contours (the same vertex-feather technique
+// the binary-mesh stroke path documents).
+//
+// Self-intersecting / multi-subpath outlines that TriangulateCompoundPath
+// can't handle fall through to EncodeFillPathScanline unchanged — those are
+// rare and usually static, so correctness wins there over transform-free
+// caching (exactly Vulkan's triangulationSucceeded ? fast : fallback split).
+// ============================================================================
 bool ImpellerD3D12Engine::EncodeFillPath(
+    float startX, float startY,
+    const float* commands, uint32_t commandLength,
+    const EngineBrushData& brush,
+    FillRule fillRule,
+    const EngineTransform& transformIn,
+    int32_t edgeMode)
+{
+    // Gradient brushes keep the legacy source-space sampler path (the gradient
+    // is sampled in path-local coords before the pixel transform). Solid-fill
+    // colour only here; everything else defers to the scanline implementation.
+    if (brush.type == 1 || brush.type == 2 || !pathGeometryCache_ ||
+        !commands || commandLength == 0) {
+        return EncodeFillPathScanline(startX, startY, commands, commandLength,
+                                      brush, fillRule, transformIn, edgeMode);
+    }
+
+    const float maxScale     = MaxScaleFromTransform(transformIn);
+    const uint32_t scaleBkt  = ScaleBucketFromMaxScale(maxScale);
+    const uint64_t key = HashPathInput(startX, startY, commands, commandLength,
+                                       (int32_t)fillRule, scaleBkt);
+
+    std::shared_ptr<const CachedPathGeometry> geom;
+    if (auto hit = pathGeometryCache_->FindAndTouch(key)) {
+        geom = std::move(hit->entry);
+        path_stats::AddGeometryHit();
+    } else {
+        auto fresh = std::make_shared<CachedPathGeometry>();
+        // Local-space flatten. Source-space tolerance = pixel tolerance /
+        // maxScale so the on-screen flattening error stays ≈flattenTolerance_
+        // px at this scale bucket (same contract the gradient branch in the
+        // scanline path relies on; scaleBucket gives each octave its own
+        // entry so density tracks on-screen size).
+        const float srcTol = (maxScale > 0.001f)
+            ? flattenTolerance_ / maxScale : flattenTolerance_;
+        {
+            path_stats::ScopedFlattenTimer flattenTimer(commandLength);
+            fresh->contours = FlattenPathToContours(
+                startX, startY, commands, commandLength, srcTol);
+            uint64_t ov = 0;
+            for (const auto& c : fresh->contours) ov += c.VertexCount();
+            flattenTimer.RecordOutputVerts(ov);
+        }
+        fresh->contours.erase(
+            std::remove_if(fresh->contours.begin(), fresh->contours.end(),
+                [](const Contour& c) { return c.VertexCount() < 3; }),
+            fresh->contours.end());
+        if (!fresh->contours.empty()) {
+            const int32_t fr = (fillRule == FillRule::NonZero) ? 1 : 0;
+            std::vector<float> tri;
+            {
+                path_stats::ScopedTriangulateTimer triTimer;
+                bool ok = TriangulateCompoundPath(fresh->contours, fr, tri)
+                          && tri.size() >= 6;
+                if (ok) {
+                    triTimer.MarkOk();
+                    fresh->localTriangles = std::move(tri);
+                    fresh->triangulationSucceeded = true;
+                }
+            }
+        }
+        pathGeometryCache_->Insert(key, fresh);
+        geom = std::move(fresh);
+        path_stats::AddGeometryMiss();
+    }
+
+    if (!geom->triangulationSucceeded || geom->localTriangles.empty()) {
+        // Not triangulable here — preserve the proven analytic-AA slow path.
+        return EncodeFillPathScanline(startX, startY, commands, commandLength,
+                                      brush, fillRule, transformIn, edgeMode);
+    }
+
+    const float r = brush.r * brush.a;
+    const float g = brush.g * brush.a;
+    const float b = brush.b * brush.a;
+    const float a = brush.a;
+    if (a <= 0.0f) return true;
+
+    // Interior: transform the cached local-space triangle soup to pixel space.
+    // This O(N) loop is the ONLY per-frame CPU cost for an animated fill now
+    // (was: full bezier flatten + AET scanline rasterization every frame).
+    {
+        const auto& lt = geom->localTriangles;       // x,y pairs, 3 per tri
+        const uint32_t vc = (uint32_t)(lt.size() / 2);
+        ImpellerDrawBatch batch;
+        batch.vertices.resize(vc);
+        batch.indices.resize(vc);
+        for (uint32_t i = 0; i < vc; ++i) {
+            float x = lt[i * 2], y = lt[i * 2 + 1];
+            TransformPoint(x, y, transformIn);
+            batch.vertices[i] = { x, y, r, g, b, a };
+            batch.indices[i]  = i;
+        }
+        batch.pipelineType = 0;
+        PushBatch(std::move(batch));
+    }
+
+    // Edge AA: constant-width feather ring around every boundary contour,
+    // built in pixel space from the cached local contours so the soft edge
+    // stays ~0.6 px on screen at any transform.
+    EmitContourFeather(geom->contours, transformIn, r, g, b, a);
+
+    encodedPathCount_++;
+    return true;
+}
+
+// ----------------------------------------------------------------------------
+// EmitContourFeather — 1 px-ish alpha-fade ring along each boundary contour.
+//
+// Our solid-fill PSO renders to a single-sample target (no MSAA), so raw
+// triangle edges would stair-step. For every contour we emit a centred ring:
+// each boundary vertex contributes an inner vertex (full fill alpha, ~0.3 px
+// inside) and an outer vertex (alpha 0, ~0.3 px outside) along the averaged
+// edge normal; consecutive pairs form a triangle strip. GPU bilinear blend of
+// the per-vertex alpha gives a clean ~0.6 px feather. The ring is centred so
+// it always overlaps the interior mesh — no seam, and the inner-side normal
+// sign is irrelevant to quality.
+// ----------------------------------------------------------------------------
+void ImpellerD3D12Engine::EmitContourFeather(
+    const std::vector<Contour>& contours,
+    const EngineTransform& transform,
+    float r, float g, float b, float a)
+{
+    if (a <= 0.0f) return;
+    constexpr float kHalfFeatherPx = 0.3f;  // ⇒ ~0.6 px total soft edge
+
+    ImpellerDrawBatch batch;
+    batch.pipelineType = 0;
+
+    for (const auto& c : contours) {
+        const uint32_t n = c.VertexCount();
+        if (n < 3) continue;
+
+        // Transform this contour's points to pixel space once.
+        std::vector<float> p(n * 2);
+        for (uint32_t i = 0; i < n; ++i) {
+            float x = c.X(i), y = c.Y(i);
+            TransformPoint(x, y, transform);
+            p[i * 2] = x;
+            p[i * 2 + 1] = y;
+        }
+
+        const uint32_t base = (uint32_t)batch.vertices.size();
+        batch.vertices.reserve(batch.vertices.size() + (size_t)n * 2 + 2);
+        batch.indices.reserve(batch.indices.size() + (size_t)n * 6 + 6);
+
+        for (uint32_t i = 0; i < n; ++i) {
+            const uint32_t prev = (i + n - 1) % n;
+            const uint32_t next = (i + 1) % n;
+            // Averaged adjacent-edge direction → outward normal (perp).
+            float dx = p[next * 2]     - p[prev * 2];
+            float dy = p[next * 2 + 1] - p[prev * 2 + 1];
+            float len = std::sqrt(dx * dx + dy * dy);
+            float nx, ny;
+            if (len > 1e-6f) { nx = -dy / len; ny = dx / len; }
+            else             { nx = 0.0f;      ny = 0.0f; }
+            const float px = p[i * 2], py = p[i * 2 + 1];
+            // Inner (solid) then outer (transparent).
+            batch.vertices.push_back(
+                { px - nx * kHalfFeatherPx, py - ny * kHalfFeatherPx, r, g, b, a });
+            batch.vertices.push_back(
+                { px + nx * kHalfFeatherPx, py + ny * kHalfFeatherPx, 0, 0, 0, 0 });
+        }
+
+        // Strip around the closed loop: (in_i,out_i,in_i+1)+(out_i,out_i+1,in_i+1)
+        for (uint32_t i = 0; i < n; ++i) {
+            const uint32_t j = (i + 1) % n;
+            const uint32_t in_i  = base + i * 2;
+            const uint32_t out_i = in_i + 1;
+            const uint32_t in_j  = base + j * 2;
+            const uint32_t out_j = in_j + 1;
+            batch.indices.push_back(in_i);
+            batch.indices.push_back(out_i);
+            batch.indices.push_back(in_j);
+            batch.indices.push_back(out_i);
+            batch.indices.push_back(out_j);
+            batch.indices.push_back(in_j);
+        }
+    }
+
+    if (!batch.vertices.empty())
+        PushBatch(std::move(batch));
+}
+
+// ============================================================================
+// EncodeFillPathScanline — legacy pixel-space scanline fill (UNCHANGED).
+//
+// Preserved verbatim as the fallback for paths EncodeFillPath's triangulator
+// can't handle (self-intersecting / multi-subpath glyph outlines) and for
+// gradient brushes. Its transform-coupled PixelRect cache is fine here: the
+// inputs that reach it are rare and typically static.
+// ============================================================================
+bool ImpellerD3D12Engine::EncodeFillPathScanline(
     float startX, float startY,
     const float* commands, uint32_t commandLength,
     const EngineBrushData& brush,
@@ -2184,7 +2407,164 @@ void ImpellerD3D12Engine::FillCacheInsert(
     fillCacheMap_[key] = fillCacheList_.begin();
 }
 
+// ============================================================================
+// EncodeStrokePath — transform-independent local-space cache for the common
+// case (solid, non-dashed, binary-mesh+feather — i.e. animated spinners /
+// progress rings / stroked Paths under a RenderTransform). Same root-cause fix
+// as EncodeFillPath/EncodeFillPolygon: the legacy body (now
+// EncodeStrokePathPixelCached) keys its cache on the FULL transform and runs
+// the whole flatten → ExpandStroke → (analytic) rasterize pipeline in pixel
+// space, so any scale/rotation/animation misses every frame.
+//
+// Here we flatten + expand ONCE in source space (source-unit strokeWidth →
+// thickness scales with the transform, exactly WPF Pen semantics), cache the
+// local-space feathered triangle mesh keyed by path + stroke params +
+// scaleBucket (NOT transform), then each frame only transform the cached
+// vertices (O(N)). Dashed strokes, explicit Antialiased (analytic, the
+// static-icon quality mode), gradient brushes and the no-command case defer
+// to EncodeStrokePathPixelCached unchanged.
+// ============================================================================
 bool ImpellerD3D12Engine::EncodeStrokePath(
+    float startX, float startY,
+    const float* commands, uint32_t commandLength,
+    const EngineBrushData& brush,
+    float strokeWidth, bool closed,
+    int32_t lineJoin, float miterLimit,
+    int32_t lineCap,
+    const float* dashPattern, uint32_t dashCount, float dashOffset,
+    const EngineTransform& transformIn,
+    int32_t edgeMode)
+{
+    int em = edgeMode;
+    if (em < 0) em = 1;                       // default = binary mesh + feather
+    const bool analytic = (em == 2);          // explicit Antialiased (static)
+
+    // Anything outside the cacheable common case keeps the proven legacy path.
+    if (analytic || dashCount > 0 || dashPattern ||
+        brush.type == 1 || brush.type == 2 ||
+        !commands || commandLength == 0 || strokeWidth <= 0.0f) {
+        return EncodeStrokePathPixelCached(
+            startX, startY, commands, commandLength, brush,
+            strokeWidth, closed, lineJoin, miterLimit, lineCap,
+            dashPattern, dashCount, dashOffset, transformIn, edgeMode);
+    }
+
+    const float maxScale    = MaxScaleFromTransform(transformIn);
+    const uint32_t scaleBkt = ScaleBucketFromMaxScale(maxScale);
+
+    // Key: geometry + scaleBucket (HashPathInput, same as fill) then the
+    // stroke-shape parameters mixed in. Transform is NOT in the key — it is
+    // applied per frame at emit. StrokeCache is a distinct map from the fill
+    // cache so there is no cross-pollution.
+    uint64_t key = HashPathInput(startX, startY, commands, commandLength,
+                                 /*fillRule*/ 0, scaleBkt);
+    FnvMix64(key, &strokeWidth, sizeof(strokeWidth));
+    uint8_t closedByte = closed ? 1 : 0;
+    FnvMix64(key, &closedByte, sizeof(closedByte));
+    FnvMix64(key, &lineJoin, sizeof(lineJoin));
+    FnvMix64(key, &miterLimit, sizeof(miterLimit));
+    FnvMix64(key, &lineCap, sizeof(lineCap));
+
+    const float br = brush.r * brush.a;
+    const float bg = brush.g * brush.a;
+    const float bb = brush.b * brush.a;
+    const float ba = brush.a;
+
+    // Emit a cached local-space mesh: transform every vertex by the current
+    // transform (O(N)) and reapply the per-vertex feather coverage. This is
+    // the ONLY per-frame CPU cost now for an animated stroke (was: full
+    // flatten + ExpandStroke + scanline rasterize every frame).
+    auto emitLocalMesh = [&](const CachedStrokeRects& m) {
+        const size_t vc = m.positions.size() / 2;
+        if (vc == 0 || m.indices.empty()) return;
+        ImpellerDrawBatch batch;
+        batch.vertices.resize(vc);
+        batch.indices = m.indices;
+        const float kInv255 = 1.0f / 255.0f;
+        for (size_t i = 0; i < vc; ++i) {
+            float x = m.positions[i * 2], y = m.positions[i * 2 + 1];
+            TransformPoint(x, y, transformIn);
+            float cov = m.coverage.empty() ? 1.0f : (float)m.coverage[i] * kInv255;
+            batch.vertices[i] = { x, y, br * cov, bg * cov, bb * cov, ba * cov };
+        }
+        batch.pipelineType = 0;
+        PushBatch(std::move(batch));
+        encodedPathCount_++;
+    };
+
+    if (auto cached = StrokeCacheFind(key)) {
+        path_stats::AddStrokeHit(cached->positions.size() / 2);
+        if (cached->positions.empty()) return false;
+        emitLocalMesh(*cached);
+        return true;
+    }
+    path_stats::AddStrokeMiss();
+
+    // Miss: flatten the raw commands in SOURCE space (tolerance scaled by
+    // 1/maxScale so on-screen smoothness matches this scale bucket — same
+    // contract EncodeFillPath uses) and expand the stroke at source-unit
+    // width into a binary feathered mesh.
+    const float srcTol = (maxScale > 0.001f)
+        ? flattenTolerance_ / maxScale : flattenTolerance_;
+    std::vector<Contour> contours;
+    {
+        path_stats::ScopedFlattenTimer flattenTimer(commandLength);
+        contours = FlattenPathToContours(startX, startY, commands,
+                                         commandLength, srcTol);
+        uint64_t ov = 0;
+        for (const auto& c : contours) ov += c.VertexCount();
+        flattenTimer.RecordOutputVerts(ov);
+    }
+
+    auto join = static_cast<ImpellerJoin>(lineJoin);
+    auto cap  = static_cast<ImpellerCap>(lineCap);
+    std::vector<ImpellerVertex> meshVerts;
+    std::vector<uint32_t>       meshIndices;
+    meshVerts.reserve(contours.size() * 64);
+    meshIndices.reserve(contours.size() * 96);
+    for (auto& c : contours) {
+        if (c.VertexCount() < 2) continue;
+        jalium::ExpandStrokePath<ImpellerVertex>(
+            meshVerts, meshIndices,
+            c.points.data(), c.VertexCount(),
+            strokeWidth, join, miterLimit, cap, closed,
+            brush.r, brush.g, brush.b, brush.a,
+            /*collectContours*/ nullptr);
+    }
+
+    auto entry = std::make_shared<CachedStrokeRects>();
+    if (meshVerts.empty() || meshIndices.empty()) {
+        StrokeCacheInsert(key, entry);   // negative cache: empty result
+        return false;
+    }
+    entry->positions.resize(meshVerts.size() * 2);
+    entry->coverage.resize(meshVerts.size());
+    float minX =  std::numeric_limits<float>::infinity();
+    float minY =  std::numeric_limits<float>::infinity();
+    float maxX = -std::numeric_limits<float>::infinity();
+    float maxY = -std::numeric_limits<float>::infinity();
+    const float invBrushA = (brush.a > 0.0f) ? (1.0f / brush.a) : 0.0f;
+    for (size_t i = 0; i < meshVerts.size(); ++i) {
+        const auto& v = meshVerts[i];
+        entry->positions[i * 2]     = v.x;
+        entry->positions[i * 2 + 1] = v.y;
+        float cov = v.a * invBrushA;
+        if (cov < 0.0f) cov = 0.0f; else if (cov > 1.0f) cov = 1.0f;
+        entry->coverage[i] = (uint8_t)std::lround(cov * 255.0f);
+        if (v.x < minX) minX = v.x;
+        if (v.y < minY) minY = v.y;
+        if (v.x > maxX) maxX = v.x;
+        if (v.y > maxY) maxY = v.y;
+    }
+    entry->indices = std::move(meshIndices);
+    entry->bboxL = minX; entry->bboxT = minY;
+    entry->bboxR = maxX; entry->bboxB = maxY;
+    StrokeCacheInsert(key, entry);
+    emitLocalMesh(*entry);
+    return true;
+}
+
+bool ImpellerD3D12Engine::EncodeStrokePathPixelCached(
     float startX, float startY,
     const float* commands, uint32_t commandLength,
     const EngineBrushData& brush,
@@ -2760,7 +3140,107 @@ bool ImpellerD3D12Engine::EncodeStrokePath(
     return true;
 }
 
+// ============================================================================
+// EncodeFillPolygon — transform-independent local-space cache (same fix as
+// EncodeFillPath). This is THE hot path for straight-line filled figures
+// (Path/Shape Data without curves, ScrollBar/RepeatButton glyphs): managed
+// DrawPathFigurePolygon → RenderTarget.FillPolygon → here. The legacy body
+// (now EncodeFillPolygonScanline) re-ran the full AET scanline rasterizer for
+// EVERY polygon EVERY frame with NO cache at all — profiled at ~3.3 ms × 38
+// polygons = 127 ms/frame, the dominant "Geometry drawing is laggy" cost.
+//
+// The incoming points carry the element's stable layout Offset (baked managed-
+// side) but NOT scroll/animation — those live in `transform`, applied per
+// frame at emit. So hashing the raw points + fillRule + scaleBucket gives a
+// frame-stable key: triangulate once, then only an O(N) vertex transform per
+// frame. Mirrors VulkanRenderTarget::FillPath / our EncodeFillPath exactly.
+// ============================================================================
 bool ImpellerD3D12Engine::EncodeFillPolygon(
+    const float* points, uint32_t pointCount,
+    const EngineBrushData& brush,
+    FillRule fillRule,
+    const EngineTransform& transform)
+{
+    if (pointCount < 3 || !points) return false;
+
+    // Gradient brushes (sampled in path-local space) and the no-cache safety
+    // case defer to the legacy per-call scanline rasterizer unchanged.
+    if (brush.type == 1 || brush.type == 2 || !pathGeometryCache_) {
+        return EncodeFillPolygonScanline(points, pointCount, brush, fillRule,
+                                         transform);
+    }
+
+    const float maxScale    = MaxScaleFromTransform(transform);
+    const uint32_t scaleBkt = ScaleBucketFromMaxScale(maxScale);
+    // Hash the raw (pre-transform) point array as the geometry payload.
+    const uint64_t key = HashPathInput(points[0], points[1],
+                                       points, pointCount * 2u,
+                                       (int32_t)fillRule, scaleBkt);
+
+    std::shared_ptr<const CachedPathGeometry> geom;
+    if (auto hit = pathGeometryCache_->FindAndTouch(key)) {
+        geom = std::move(hit->entry);
+        path_stats::AddGeometryHit();
+    } else {
+        auto fresh = std::make_shared<CachedPathGeometry>();
+        fresh->contours.resize(1);
+        fresh->contours[0].points.assign(points, points + (size_t)pointCount * 2);
+        const int32_t fr = (fillRule == FillRule::NonZero) ? 1 : 0;
+        std::vector<float> tri;
+        {
+            path_stats::ScopedTriangulateTimer triTimer;
+            bool ok = TriangulateCompoundPath(fresh->contours, fr, tri)
+                      && tri.size() >= 6;
+            if (ok) {
+                triTimer.MarkOk();
+                fresh->localTriangles = std::move(tri);
+                fresh->triangulationSucceeded = true;
+            }
+        }
+        pathGeometryCache_->Insert(key, fresh);
+        geom = std::move(fresh);
+        path_stats::AddGeometryMiss();
+    }
+
+    if (!geom->triangulationSucceeded || geom->localTriangles.empty()) {
+        // Near-degenerate / self-intersecting: preserve the analytic slow path.
+        return EncodeFillPolygonScanline(points, pointCount, brush, fillRule,
+                                         transform);
+    }
+
+    const float r = brush.r * brush.a;
+    const float g = brush.g * brush.a;
+    const float b = brush.b * brush.a;
+    const float a = brush.a;
+    if (a <= 0.0f) return true;
+
+    {
+        const auto& lt = geom->localTriangles;       // x,y pairs, 3 per tri
+        const uint32_t vc = (uint32_t)(lt.size() / 2);
+        ImpellerDrawBatch batch;
+        batch.vertices.resize(vc);
+        batch.indices.resize(vc);
+        for (uint32_t i = 0; i < vc; ++i) {
+            float x = lt[i * 2], y = lt[i * 2 + 1];
+            TransformPoint(x, y, transform);
+            batch.vertices[i] = { x, y, r, g, b, a };
+            batch.indices[i]  = i;
+        }
+        batch.pipelineType = 0;
+        PushBatch(std::move(batch));
+    }
+    EmitContourFeather(geom->contours, transform, r, g, b, a);
+
+    encodedPathCount_++;
+    return true;
+}
+
+// ============================================================================
+// EncodeFillPolygonScanline — legacy per-call pixel-space scanline fill
+// (UNCHANGED). Fallback for gradient brushes and polygons EncodeFillPolygon's
+// triangulator rejects.
+// ============================================================================
+bool ImpellerD3D12Engine::EncodeFillPolygonScanline(
     const float* points, uint32_t pointCount,
     const EngineBrushData& brush,
     FillRule fillRule,

--- a/src/native/jalium.native.d3d12/src/d3d12_render_target.cpp
+++ b/src/native/jalium.native.d3d12/src/d3d12_render_target.cpp
@@ -1332,8 +1332,9 @@ void D3D12RenderTarget::RenderText(
     ExtractBrushColor(brush, r, g, b, a);
 
     ComPtr<IDWriteTextLayout> layout;
-    if (FAILED(tf->CreateLayout(text, textLength, w, h, &layout))) return;
-    directRenderer_->AddText(layout.Get(), x, y, r, g, b, a);
+    uint64_t layoutKey = 0;
+    if (FAILED(tf->CreateLayout(text, textLength, w, h, &layout, &layoutKey))) return;
+    directRenderer_->AddText(layout.Get(), x, y, r, g, b, a, layoutKey);
 }
 
 // ============================================================================

--- a/src/native/jalium.native.d3d12/src/d3d12_text.cpp
+++ b/src/native/jalium.native.d3d12/src/d3d12_text.cpp
@@ -47,6 +47,7 @@ void D3D12TextFormat::SetAlignment(int32_t alignment) {
     }
 
     format_->SetTextAlignment(textAlignment);
+    InvalidateLayoutCache();
 }
 
 void D3D12TextFormat::SetParagraphAlignment(int32_t alignment) {
@@ -69,6 +70,7 @@ void D3D12TextFormat::SetParagraphAlignment(int32_t alignment) {
     }
 
     format_->SetParagraphAlignment(paragraphAlignment);
+    InvalidateLayoutCache();
 }
 
 void D3D12TextFormat::SetTrimming(int32_t trimming) {
@@ -95,6 +97,7 @@ void D3D12TextFormat::SetTrimming(int32_t trimming) {
     }
 
     format_->SetTrimming(&trimmingOptions, ellipsis.Get());
+    InvalidateLayoutCache();
 }
 
 void D3D12TextFormat::SetWordWrapping(int32_t wrapping) {
@@ -120,6 +123,7 @@ void D3D12TextFormat::SetWordWrapping(int32_t wrapping) {
     }
 
     format_->SetWordWrapping(wordWrapping);
+    InvalidateLayoutCache();
 }
 
 void D3D12TextFormat::SetLineSpacing(int32_t method, float spacing, float baseline) {
@@ -134,17 +138,73 @@ void D3D12TextFormat::SetLineSpacing(int32_t method, float spacing, float baseli
     }
 
     format_->SetLineSpacing(dwMethod, spacing, baseline);
+    InvalidateLayoutCache();
 }
 
 void D3D12TextFormat::SetMaxLines(uint32_t maxLines) {
+    if (maxLines_ == maxLines) return;
     maxLines_ = maxLines;
+    InvalidateLayoutCache();
+}
+
+uint64_t D3D12TextFormat::HashLayoutKey(
+    const wchar_t* text, uint32_t textLength,
+    float maxWidth, float maxHeight) const noexcept
+{
+    uint64_t h = 0xCBF29CE484222325ull;  // FNV-1a 64-bit
+    auto mix = [&h](const void* p, size_t n) {
+        const uint8_t* b = static_cast<const uint8_t*>(p);
+        for (size_t i = 0; i < n; ++i) { h ^= b[i]; h *= 0x100000001B3ull; }
+    };
+    mix(&textLength, sizeof(textLength));
+    if (text && textLength)
+        mix(text, static_cast<size_t>(textLength) * sizeof(wchar_t));
+    mix(&maxWidth, sizeof(maxWidth));
+    mix(&maxHeight, sizeof(maxHeight));
+    mix(&maxLines_, sizeof(maxLines_));
+    return h;
+}
+
+void D3D12TextFormat::InvalidateLayoutCache() noexcept
+{
+    layoutMap_.clear();
+    layoutLru_.clear();
 }
 
 HRESULT D3D12TextFormat::CreateLayout(
     const wchar_t* text, uint32_t textLength,
     float maxWidth, float maxHeight,
-    IDWriteTextLayout** layout)
+    IDWriteTextLayout** layout,
+    uint64_t* outKey)
 {
+    if (outKey) *outKey = 0;  // 0 = uncacheable; set on every success path below
+    if (!layout) return E_POINTER;
+    *layout = nullptr;
+    if (!factory_ || !format_) return E_FAIL;
+
+    const uint64_t key = HashLayoutKey(text, textLength, maxWidth, maxHeight);
+    if (outKey) {
+        // Globally-unique key for the atlas glyph memo: the per-format layout
+        // key disambiguated by THIS format object (different font/size/weight
+        // ⇒ different glyphs for identical text/constraints).
+        uint64_t gk = key;
+        gk ^= (uint64_t)reinterpret_cast<uintptr_t>(this)
+              + 0x9E3779B97F4A7C15ull + (gk << 6) + (gk >> 2);
+        *outKey = gk;
+    }
+    if (auto it = layoutMap_.find(key); it != layoutMap_.end()) {
+        // Hit: promote to MRU and hand back a ref. The cache keeps its own.
+        layoutLru_.splice(layoutLru_.begin(), layoutLru_, it->second);
+        IDWriteTextLayout* cached = it->second->layout.Get();
+        if (cached) {
+            cached->AddRef();
+            *layout = cached;
+            return S_OK;
+        }
+        // Defensive: empty slot — drop and fall through to recreate.
+        layoutMap_.erase(it);
+    }
+
     HRESULT hr = factory_->CreateTextLayout(
         text, textLength, format_.Get(), maxWidth, maxHeight, layout);
 
@@ -168,6 +228,18 @@ HRESULT D3D12TextFormat::CreateLayout(
                     text, textLength, format_.Get(), maxWidth, totalH, layout);
             }
         }
+    }
+
+    if (SUCCEEDED(hr) && *layout) {
+        // Insert final (post-maxLines) layout. ComPtr's raw-pointer ctor
+        // AddRefs, so the cache owns its own ref while *layout keeps the
+        // caller's +1 from CreateTextLayout. Evict LRU tail at capacity.
+        if (layoutLru_.size() >= kLayoutCacheCap) {
+            layoutMap_.erase(layoutLru_.back().key);
+            layoutLru_.pop_back();
+        }
+        layoutLru_.push_front({ key, ComPtr<IDWriteTextLayout>(*layout) });
+        layoutMap_[key] = layoutLru_.begin();
     }
 
     return hr;


### PR DESCRIPTION
## Summary

Follow-up to merged #123 on the same `feat/preview-26.10.2` line. Four commits, all compile-time / rendering correctness + perf work:

- **Xaml SG — compile-time `{Binding}` lowering.** New `BindingMarkupLowering` splits the `{Binding ...}` envelope (brace/quote-aware, a line-for-line mirror of the runtime `SplitParameters`); structured parts flow through `XamlBuilder.SetCompiledBinding` → `MarkupExtensionParser.BuildBindingExtension`, so Converter / Source / RelativeSource / nested markup behave byte-identically to a runtime-parsed binding. `Setter.Value` deliberately stays on the runtime `SetProperty` path — its markup-extension resolution is deferred to setter-apply time and must not evaluate at construction.
- **Xaml SG — Razor control flow + custom xmlns.** Lower `@if/@section/@RenderSection`, `@if/else-if/else` chains to compile-time C#; resolve custom-xmlns element types via `XmlnsTypeResolver` so they no longer fall back to runtime reflection.
- **Controls — hit-test correctness.** Replace the Window cached-subtree hit-test fast path (tested against stale geometry between `InvalidateArrange` and the next frame) with a per-frame memo keyed by `(point, LayoutManager.Generation)` plus `EnsureLayoutValidForInput`, mirroring WPF `MouseDevice.Synchronize` → `ContextLayoutManager.UpdateLayout`. Any measure/arrange bumps `Generation` and self-invalidates the memo.
- **native(d3d12) — transform-independent fill-path geometry cache.** Flatten + triangulate once in geometry-local space, cache keyed by `(start, commands, fillRule, scaleBucket)` (translation/rotation excluded), then per-frame only transform cached vertices instead of re-rasterizing `O(W·H·edges)` on every scale/rotate. Mirrors `VulkanRenderTarget::FillPath`; self-intersecting / multi-subpath outlines fall back to the verbatim scanline path.

> The `jalium.native.demo.memprobe/` diagnostic demo and its `CMakeLists.txt` opt-in hook are intentionally **excluded** from this PR (scratch tooling).

## Test plan

- [ ] `dotnet build` clean; SG analyzer/emit no new diagnostics
- [ ] Razor SG tests green (`RazorSyntaxTests`, `RazorLightweightInterpreterTests`)
- [ ] `{Binding}` with Converter / Source / RelativeSource / nested markup renders identically SG-compiled vs runtime-parsed
- [ ] `Setter.Value="{...}"` still resolves at setter-apply time (not eagerly at construction)
- [ ] Custom-xmlns elements compile to typed C# (no runtime-reflection fallback)
- [ ] Mouse hit-test correct under ScrollViewer scroll / animation (no stale-geometry mis-hits)
- [ ] D3D12 geometry stays crisp and smooth under scroll / zoom / rotate; self-intersecting paths still render via scanline fallback