### PR TITLE
Fix #133 by adding Windows ARM64 support

### DIFF
--- a/src/managed/Jalium.UI.Interop/Jalium.UI.Interop.csproj
+++ b/src/managed/Jalium.UI.Interop/Jalium.UI.Interop.csproj
@@ -1,6 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!-- Default to win-x64 to preserve existing CI behavior; override by setting
+         JaliumNativePackRid (e.g. dotnet pack -p:JaliumNativePackRid=win-arm64). -->
+    <JaliumNativePackRid Condition="'$(JaliumNativePackRid)' == ''">win-x64</JaliumNativePackRid>
     <RootNamespace>Jalium.UI.Interop</RootNamespace>
     <AssemblyName>Jalium.UI.Interop</AssemblyName>
     <Description>Native interop layer for Jalium.UI framework providing P/Invoke definitions and native libraries.</Description>
@@ -30,11 +33,11 @@
        static-link wiring nor the dynamic DLLs and trip DllNotFoundException at
        runtime. -->
   <ItemGroup Condition="'$(Configuration)' == 'Debug' and '$(UseJaliumNativeAot)' != 'true'">
-    <Content Include="..\..\native\bin\native\Debug\jalium.native.core.dll" Link="jalium.native.core.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/win-x64/native" />
-    <Content Include="..\..\native\bin\native\Debug\jalium.native.d3d12.dll" Link="jalium.native.d3d12.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/win-x64/native" />
-    <Content Include="..\..\native\bin\native\Debug\jalium.native.vulkan.dll" Link="jalium.native.vulkan.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/win-x64/native" Condition="Exists('..\..\native\bin\native\Debug\jalium.native.vulkan.dll')" />
-    <Content Include="..\..\native\bin\native\Debug\jalium.native.software.dll" Link="jalium.native.software.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/win-x64/native" Condition="Exists('..\..\native\bin\native\Debug\jalium.native.software.dll')" />
-    <Content Include="..\..\native\bin\native\Debug\jalium.native.browser.dll" Link="jalium.native.browser.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/win-x64/native" />
+    <Content Include="..\..\native\bin\native\Debug\jalium.native.core.dll" Link="jalium.native.core.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/$(JaliumNativePackRid)/native" />
+    <Content Include="..\..\native\bin\native\Debug\jalium.native.d3d12.dll" Link="jalium.native.d3d12.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/$(JaliumNativePackRid)/native" />
+    <Content Include="..\..\native\bin\native\Debug\jalium.native.vulkan.dll" Link="jalium.native.vulkan.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/$(JaliumNativePackRid)/native" Condition="Exists('..\..\native\bin\native\Debug\jalium.native.vulkan.dll')" />
+    <Content Include="..\..\native\bin\native\Debug\jalium.native.software.dll" Link="jalium.native.software.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/$(JaliumNativePackRid)/native" Condition="Exists('..\..\native\bin\native\Debug\jalium.native.software.dll')" />
+    <Content Include="..\..\native\bin\native\Debug\jalium.native.browser.dll" Link="jalium.native.browser.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/$(JaliumNativePackRid)/native" />
     <!-- Media native (image/video/camera via Windows MF + WIC). NativeMediaInitializer
          loads jalium.native.media.dll lazily on first BitmapImage/VideoElement/etc. use,
          so missing the DLL turns into a runtime DllNotFoundException at the first
@@ -44,20 +47,21 @@
          The .core companion is the cross-platform C-ABI layer that .windows links
          against — it must be next to .dll on disk or LoadLibrary fails with
          "or one of its dependencies" before reaching the real entry points. -->
-    <Content Include="..\..\native\bin\native\Debug\jalium.native.media.dll" Link="jalium.native.media.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/win-x64/native" Condition="Exists('..\..\native\bin\native\Debug\jalium.native.media.dll')" />
-    <Content Include="..\..\native\bin\native\Debug\jalium.native.media.core.dll" Link="jalium.native.media.core.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/win-x64/native" Condition="Exists('..\..\native\bin\native\Debug\jalium.native.media.core.dll')" />
-    <Content Include="..\..\native\jalium.native.browser\redist\WebView2Loader.dll" Link="WebView2Loader.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/win-x64/native" />
+    <Content Include="..\..\native\bin\native\Debug\jalium.native.media.dll" Link="jalium.native.media.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/$(JaliumNativePackRid)/native" Condition="Exists('..\..\native\bin\native\Debug\jalium.native.media.dll')" />
+    <Content Include="..\..\native\bin\native\Debug\jalium.native.media.core.dll" Link="jalium.native.media.core.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/$(JaliumNativePackRid)/native" Condition="Exists('..\..\native\bin\native\Debug\jalium.native.media.core.dll')" />
+    <Content Include="..\..\native\jalium.native.browser\redist\WebView2Loader.dll" Link="WebView2Loader.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/$(JaliumNativePackRid)/native" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)' == 'Release' and '$(UseJaliumNativeAot)' != 'true'">
-    <Content Include="..\..\native\bin\native\Release\jalium.native.core.dll" Link="jalium.native.core.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/win-x64/native" />
-    <Content Include="..\..\native\bin\native\Release\jalium.native.d3d12.dll" Link="jalium.native.d3d12.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/win-x64/native" />
-    <Content Include="..\..\native\bin\native\Release\jalium.native.vulkan.dll" Link="jalium.native.vulkan.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/win-x64/native" Condition="Exists('..\..\native\bin\native\Release\jalium.native.vulkan.dll')" />
-    <Content Include="..\..\native\bin\native\Release\jalium.native.software.dll" Link="jalium.native.software.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/win-x64/native" Condition="Exists('..\..\native\bin\native\Release\jalium.native.software.dll')" />
-    <Content Include="..\..\native\bin\native\Release\jalium.native.browser.dll" Link="jalium.native.browser.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/win-x64/native" />
-    <Content Include="..\..\native\bin\native\Release\jalium.native.media.dll" Link="jalium.native.media.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/win-x64/native" Condition="Exists('..\..\native\bin\native\Release\jalium.native.media.dll')" />
-    <Content Include="..\..\native\bin\native\Release\jalium.native.media.core.dll" Link="jalium.native.media.core.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/win-x64/native" Condition="Exists('..\..\native\bin\native\Release\jalium.native.media.core.dll')" />
-    <Content Include="..\..\native\jalium.native.browser\redist\WebView2Loader.dll" Link="WebView2Loader.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/win-x64/native" />
+    <Content Include="..\..\native\bin\native\Release\jalium.native.core.dll" Link="jalium.native.core.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/$(JaliumNativePackRid)/native" />
+    <Content Include="..\..\native\bin\native\Release\jalium.native.d3d12.dll" Link="jalium.native.d3d12.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/$(JaliumNativePackRid)/native" />
+    <Content Include="..\..\native\bin\native\Release\jalium.native.vulkan.dll" Link="jalium.native.vulkan.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/$(JaliumNativePackRid)/native" Condition="Exists('..\..\native\bin\native\Release\jalium.native.vulkan.dll')" />
+    <Content Include="..\..\native\bin\native\Release\jalium.native.software.dll" Link="jalium.native.software.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/$(JaliumNativePackRid)/native" Condition="Exists('..\..\native\bin\native\Release\jalium.native.software.dll')" />
+    <Content Include="..\..\native\bin\native\Release\jalium.native.platform.dll" Link="jalium.native.platform.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/$(JaliumNativePackRid)/native" Condition="Exists('..\..\native\bin\native\Release\jalium.native.platform.dll')" />
+    <Content Include="..\..\native\bin\native\Release\jalium.native.browser.dll" Link="jalium.native.browser.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/$(JaliumNativePackRid)/native" />
+    <Content Include="..\..\native\bin\native\Release\jalium.native.media.dll" Link="jalium.native.media.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/$(JaliumNativePackRid)/native" Condition="Exists('..\..\native\bin\native\Release\jalium.native.media.dll')" />
+    <Content Include="..\..\native\bin\native\Release\jalium.native.media.core.dll" Link="jalium.native.media.core.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/$(JaliumNativePackRid)/native" Condition="Exists('..\..\native\bin\native\Release\jalium.native.media.core.dll')" />
+    <Content Include="..\..\native\jalium.native.browser\redist\WebView2Loader.dll" Link="WebView2Loader.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" Pack="true" PackagePath="runtimes/$(JaliumNativePackRid)/native" />
   </ItemGroup>
 
   <!-- Ensure native DLLs are copied to output on package restore -->

--- a/src/managed/Jalium.UI.Interop/build/Jalium.UI.Interop.targets
+++ b/src/managed/Jalium.UI.Interop/build/Jalium.UI.Interop.targets
@@ -1,34 +1,57 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup Condition="'$(UseJaliumNativeAot)' != 'true'">
-    <None Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\jalium.native.core.dll"
+  <PropertyGroup>
+    <_JaliumInteropNativeDir Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\win-arm64\native')">$(MSBuildThisFileDirectory)..\runtimes\win-arm64\native</_JaliumInteropNativeDir>
+    <_JaliumInteropNativeDir Condition="'$(_JaliumInteropNativeDir)' == '' and Exists('$(MSBuildThisFileDirectory)..\runtimes\win-x64\native')">$(MSBuildThisFileDirectory)..\runtimes\win-x64\native</_JaliumInteropNativeDir>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(UseJaliumNativeAot)' != 'true' and '$(_JaliumInteropNativeDir)' != ''">
+    <None Include="$(_JaliumInteropNativeDir)\jalium.native.core.dll"
           Link="jalium.native.core.dll"
           CopyToOutputDirectory="PreserveNewest"
-          Visible="false" />
-    <None Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\jalium.native.d3d12.dll"
+          Visible="false"
+          Condition="Exists('$(_JaliumInteropNativeDir)\jalium.native.core.dll')" />
+    <None Include="$(_JaliumInteropNativeDir)\jalium.native.d3d12.dll"
           Link="jalium.native.d3d12.dll"
           CopyToOutputDirectory="PreserveNewest"
-          Visible="false" />
-    <None Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\jalium.native.vulkan.dll"
+          Visible="false"
+          Condition="Exists('$(_JaliumInteropNativeDir)\jalium.native.d3d12.dll')" />
+    <None Include="$(_JaliumInteropNativeDir)\jalium.native.vulkan.dll"
           Link="jalium.native.vulkan.dll"
           CopyToOutputDirectory="PreserveNewest"
           Visible="false"
-          Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\jalium.native.vulkan.dll')" />
-    <None Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\jalium.native.software.dll"
+          Condition="Exists('$(_JaliumInteropNativeDir)\jalium.native.vulkan.dll')" />
+    <None Include="$(_JaliumInteropNativeDir)\jalium.native.software.dll"
           Link="jalium.native.software.dll"
           CopyToOutputDirectory="PreserveNewest"
           Visible="false"
-          Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\jalium.native.software.dll')" />
-    <None Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\jalium.native.browser.dll"
+          Condition="Exists('$(_JaliumInteropNativeDir)\jalium.native.software.dll')" />
+    <None Include="$(_JaliumInteropNativeDir)\jalium.native.platform.dll"
+          Link="jalium.native.platform.dll"
+          CopyToOutputDirectory="PreserveNewest"
+          Visible="false"
+          Condition="Exists('$(_JaliumInteropNativeDir)\jalium.native.platform.dll')" />
+    <None Include="$(_JaliumInteropNativeDir)\jalium.native.browser.dll"
           Link="jalium.native.browser.dll"
           CopyToOutputDirectory="PreserveNewest"
-          Visible="false" />
+          Visible="false"
+          Condition="Exists('$(_JaliumInteropNativeDir)\jalium.native.browser.dll')" />
+    <None Include="$(_JaliumInteropNativeDir)\jalium.native.media.dll"
+          Link="jalium.native.media.dll"
+          CopyToOutputDirectory="PreserveNewest"
+          Visible="false"
+          Condition="Exists('$(_JaliumInteropNativeDir)\jalium.native.media.dll')" />
+    <None Include="$(_JaliumInteropNativeDir)\jalium.native.media.core.dll"
+          Link="jalium.native.media.core.dll"
+          CopyToOutputDirectory="PreserveNewest"
+          Visible="false"
+          Condition="Exists('$(_JaliumInteropNativeDir)\jalium.native.media.core.dll')" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\WebView2Loader.dll"
+  <ItemGroup Condition="'$(_JaliumInteropNativeDir)' != ''">
+    <None Include="$(_JaliumInteropNativeDir)\WebView2Loader.dll"
           Link="WebView2Loader.dll"
           CopyToOutputDirectory="PreserveNewest"
-          Visible="false" />
+          Visible="false"
+          Condition="Exists('$(_JaliumInteropNativeDir)\WebView2Loader.dll')" />
   </ItemGroup>
 </Project>

--- a/src/managed/Jalium.UI.Interop/buildTransitive/Jalium.UI.Interop.targets
+++ b/src/managed/Jalium.UI.Interop/buildTransitive/Jalium.UI.Interop.targets
@@ -1,31 +1,56 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\jalium.native.core.dll"
+  <!-- Auto-select the RID-specific native payload at the consumer.
+       Whichever runtimes/<rid>/native folder ships in the package gets copied. -->
+  <PropertyGroup>
+    <_JaliumInteropNativeDir Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\win-arm64\native')">$(MSBuildThisFileDirectory)..\runtimes\win-arm64\native</_JaliumInteropNativeDir>
+    <_JaliumInteropNativeDir Condition="'$(_JaliumInteropNativeDir)' == '' and Exists('$(MSBuildThisFileDirectory)..\runtimes\win-x64\native')">$(MSBuildThisFileDirectory)..\runtimes\win-x64\native</_JaliumInteropNativeDir>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(_JaliumInteropNativeDir)' != ''">
+    <None Include="$(_JaliumInteropNativeDir)\jalium.native.core.dll"
           Link="jalium.native.core.dll"
           CopyToOutputDirectory="PreserveNewest"
-          Visible="false" />
-    <None Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\jalium.native.d3d12.dll"
+          Visible="false"
+          Condition="Exists('$(_JaliumInteropNativeDir)\jalium.native.core.dll')" />
+    <None Include="$(_JaliumInteropNativeDir)\jalium.native.d3d12.dll"
           Link="jalium.native.d3d12.dll"
           CopyToOutputDirectory="PreserveNewest"
-          Visible="false" />
-    <None Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\jalium.native.vulkan.dll"
+          Visible="false"
+          Condition="Exists('$(_JaliumInteropNativeDir)\jalium.native.d3d12.dll')" />
+    <None Include="$(_JaliumInteropNativeDir)\jalium.native.vulkan.dll"
           Link="jalium.native.vulkan.dll"
           CopyToOutputDirectory="PreserveNewest"
           Visible="false"
-          Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\jalium.native.vulkan.dll')" />
-    <None Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\jalium.native.software.dll"
+          Condition="Exists('$(_JaliumInteropNativeDir)\jalium.native.vulkan.dll')" />
+    <None Include="$(_JaliumInteropNativeDir)\jalium.native.software.dll"
           Link="jalium.native.software.dll"
           CopyToOutputDirectory="PreserveNewest"
           Visible="false"
-          Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\jalium.native.software.dll')" />
-    <None Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\jalium.native.browser.dll"
+          Condition="Exists('$(_JaliumInteropNativeDir)\jalium.native.software.dll')" />
+    <None Include="$(_JaliumInteropNativeDir)\jalium.native.platform.dll"
+          Link="jalium.native.platform.dll"
+          CopyToOutputDirectory="PreserveNewest"
+          Visible="false"
+          Condition="Exists('$(_JaliumInteropNativeDir)\jalium.native.platform.dll')" />
+    <None Include="$(_JaliumInteropNativeDir)\jalium.native.browser.dll"
           Link="jalium.native.browser.dll"
           CopyToOutputDirectory="PreserveNewest"
-          Visible="false" />
-    <None Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\WebView2Loader.dll"
+          Visible="false"
+          Condition="Exists('$(_JaliumInteropNativeDir)\jalium.native.browser.dll')" />
+    <None Include="$(_JaliumInteropNativeDir)\jalium.native.media.dll"
+          Link="jalium.native.media.dll"
+          CopyToOutputDirectory="PreserveNewest"
+          Visible="false"
+          Condition="Exists('$(_JaliumInteropNativeDir)\jalium.native.media.dll')" />
+    <None Include="$(_JaliumInteropNativeDir)\jalium.native.media.core.dll"
+          Link="jalium.native.media.core.dll"
+          CopyToOutputDirectory="PreserveNewest"
+          Visible="false"
+          Condition="Exists('$(_JaliumInteropNativeDir)\jalium.native.media.core.dll')" />
+    <None Include="$(_JaliumInteropNativeDir)\WebView2Loader.dll"
           Link="WebView2Loader.dll"
           CopyToOutputDirectory="PreserveNewest"
-          Visible="false" />
+          Visible="false"
+          Condition="Exists('$(_JaliumInteropNativeDir)\WebView2Loader.dll')" />
   </ItemGroup>
 </Project>

--- a/src/native/jalium.native.media.core/src/audio/decoder_mp3.cpp
+++ b/src/native/jalium.native.media.core/src/audio/decoder_mp3.cpp
@@ -6,6 +6,13 @@
 
 #define MINIMP3_FLOAT_OUTPUT
 #define MINIMP3_IMPLEMENTATION
+// minimp3 1.x uses x86 SSE-style `__m128 = {f,f,f,f}` brace-initializers in its
+// MINIMP3_FLOAT_OUTPUT SIMD path. On ARM64 MSVC the f4 typedef becomes
+// float32x4_t which does not accept brace-init (C2078). Disable SIMD on ARM64
+// only; x64/x86 stay on SSE.
+#if defined(_M_ARM64) || defined(__aarch64__)
+#define MINIMP3_NO_SIMD
+#endif
 #include "minimp3_ex.h"
 
 #define JALIUM_MEDIA_EXPORTS


### PR DESCRIPTION
- Parameterized paths so that x64 and arm64 resolution can go side by side.
- Changed minimp3 configuration to be ARM64 compatible.

WebView2 issue remains even after this pull request. See #136.