### PR TITLE
feat: DevTools tree reveal animation + Viewbox/icon render & layout fixes

### DIFF
--- a/src/managed/Jalium.UI.Controls/DevTools/DevToolsWindow.cs
+++ b/src/managed/Jalium.UI.Controls/DevTools/DevToolsWindow.cs
@@ -682,6 +682,7 @@ public partial class DevToolsWindow : Window
     private void OnDevToolsClosing(object? sender, EventArgs e)
     {
         _searchRefreshTimer.Stop();
+        CancelExpandAnimation();
 
         if (_isPickerActive)
             DeactivatePicker();
@@ -761,6 +762,7 @@ public partial class DevToolsWindow : Window
     private void RefreshVisualTree()
     {
         _searchRefreshTimer.Stop();
+        CancelExpandAnimation();
 
         var filter = _searchTextBox.Text?.Trim() ?? "";
         _activeFilter = string.IsNullOrEmpty(filter) ? null : filter;
@@ -790,8 +792,12 @@ public partial class DevToolsWindow : Window
             AppendHierarchicalRows(_targetWindow, 0, rows);
 
         _rowByVisual.Clear();
-        foreach (var r in rows)
+        for (int i = 0; i < rows.Count; i++)
+        {
+            var r = rows[i];
+            r.Index = i;                 // used by the reveal animation's stagger
             _rowByVisual[r.Visual] = r;
+        }
 
         _rows.Reset(rows);
 
@@ -813,7 +819,7 @@ public partial class DevToolsWindow : Window
     {
         var children = EnumerateChildrenForCurrentMode(visual).ToList();
         bool expanded = _expandedVisuals.Contains(visual);
-        rows.Add(new InspectorRow(visual, depth) { HasChildren = children.Count > 0, IsExpanded = expanded });
+        rows.Add(new InspectorRow(visual, depth) { HasChildren = children.Count > 0, IsExpanded = expanded, ChevronAngle = expanded ? 0 : -90 });
         if (expanded)
             foreach (var child in children)
                 AppendHierarchicalRows(child, depth + 1, rows);
@@ -845,7 +851,7 @@ public partial class DevToolsWindow : Window
     private bool AppendFilteredRows(Visual visual, int depth, string filter, List<InspectorRow> rows)
     {
         int start = rows.Count;
-        var row = new InspectorRow(visual, depth) { IsExpanded = true };
+        var row = new InspectorRow(visual, depth) { IsExpanded = true, ChevronAngle = 0 };
         rows.Add(row);
 
         bool anyChildKept = false;
@@ -871,10 +877,178 @@ public partial class DevToolsWindow : Window
     {
         if (_activeFilter != null) return;  // filtered view stays fully expanded
         if (!row.HasChildren) return;
-        if (!_expandedVisuals.Add(row.Visual))
-            _expandedVisuals.Remove(row.Visual);
-        RebuildVisibleRows();
+
+        bool willExpand = !_expandedVisuals.Contains(row.Visual);
+
+        // No realized rows (not shown yet / headless) → just toggle + rebuild instantly.
+        if (_visualTreeView.GetRealizedContainers().Count == 0)
+        {
+            if (willExpand) _expandedVisuals.Add(row.Visual);
+            else _expandedVisuals.Remove(row.Visual);
+            RebuildVisibleRows();
+            return;
+        }
+
+        CompleteExpandAnimation(); // finish any in-flight animation first
+
+        if (willExpand)
+        {
+            _expandedVisuals.Add(row.Visual);
+            RebuildVisibleRows();                              // descendants now present, animate them in
+            BeginExpandCollapseAnimation(row.Visual, expanding: true);
+        }
+        else
+        {
+            // Collapse: animate the still-present descendants out, then remove them on completion.
+            BeginExpandCollapseAnimation(row.Visual, expanding: false);
+        }
     }
+
+    // ── Expand/collapse reveal animation (render-only clipped slide + chevron rotation) ────
+    // TRUE virtualization: rows always keep their full layout height, so the VSP only ever realizes
+    // the viewport. The reveal is applied PER-FRAME to the realized containers only (O(viewport)),
+    // via a clipped content slide (ClipToBounds + translate) — never via layout/height and never via
+    // opacity (per-row alpha layers black out / thrash the render target on a large expand). So it
+    // never stacks rows at one offset, never realizes the whole subtree, and needs no cap.
+    private const double ExpandAnimMs = 260;
+    private const double CollapseAnimMs = 180;
+    private const double AnimStaggerStep = 0.06;
+    private const double AnimStaggerMax = 0.5;
+
+    private DispatcherTimer? _expandAnimTimer;
+    private int _animStart = -1;   // first revealed/removed row index (inclusive)
+    private int _animEnd = -1;     // exclusive
+    private InspectorRow? _animChevronRow;
+    private double _animChevronFrom;
+    private double _animChevronTo;
+    private bool _animExpanding;
+    private long _animStartTick;
+    private double _animDurationMs;
+    private Visual? _pendingCollapseVisual;
+
+    private void BeginExpandCollapseAnimation(Visual toggledVisual, bool expanding)
+    {
+        if (!_rowByVisual.TryGetValue(toggledVisual, out var parentRow))
+            return;
+
+        int parentIndex = parentRow.Index;
+        if (parentIndex < 0 || parentIndex >= _rows.Count || !ReferenceEquals(_rows[parentIndex], parentRow))
+            parentIndex = _rows.IndexOf(parentRow);
+        if (parentIndex < 0)
+            return;
+
+        // Reveal range = the contiguous descendant block (Depth > parent's Depth). One-time index
+        // scan only (no realization). The per-frame loop below touches realized containers whose
+        // Index falls in this range, so it stays O(viewport) regardless of subtree size.
+        int end = parentIndex + 1;
+        while (end < _rows.Count && _rows[end].Depth > parentRow.Depth)
+            end++;
+
+        _animStart = parentIndex + 1;
+        _animEnd = end;
+
+        _animChevronRow = parentRow;
+        // Fixed endpoints by direction. On expand the rebuilt row is already IsExpanded, so its
+        // ChevronAngle is the final 0 — capturing it as "from" would animate 0→0 (no rotation).
+        _animChevronFrom = expanding ? -90 : 0;
+        _animChevronTo = expanding ? 0 : -90;
+
+        _animExpanding = expanding;
+        _animDurationMs = expanding ? ExpandAnimMs : CollapseAnimMs;
+        _animStartTick = Environment.TickCount64;
+        _pendingCollapseVisual = expanding ? null : toggledVisual;
+
+        if (_expandAnimTimer == null)
+        {
+            _expandAnimTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(16) };
+            _expandAnimTimer.Tick += OnExpandAnimTick;
+        }
+        _expandAnimTimer.Start();
+        OnExpandAnimTick(null, EventArgs.Empty); // apply frame 0 immediately so rows start hidden
+    }
+
+    private void OnExpandAnimTick(object? sender, EventArgs e)
+    {
+        long now = Environment.TickCount64;
+        double progress = _animDurationMs <= 0
+            ? 1.0
+            : Math.Clamp((now - _animStartTick) / _animDurationMs, 0.0, 1.0);
+
+        if (_animChevronRow != null)
+        {
+            double chevronEased = EaseOutCubic(progress);
+            _animChevronRow.ChevronAngle = _animChevronFrom + (_animChevronTo - _animChevronFrom) * chevronEased;
+        }
+
+        foreach (var container in _visualTreeView.GetRealizedContainers())
+        {
+            var r = container.Row;
+            if (r == null) continue;
+
+            if (r.Index >= _animStart && r.Index < _animEnd)
+            {
+                double stagger = Math.Min(AnimStaggerMax, (r.Index - _animStart) * AnimStaggerStep);
+                double t = Math.Clamp((progress - stagger) / Math.Max(0.0001, 1.0 - stagger), 0.0, 1.0);
+                double eased = EaseOutCubic(t);
+                container.SetRevealProgress(_animExpanding ? eased : 1.0 - eased);
+            }
+
+            if (ReferenceEquals(r, _animChevronRow))
+                container.ApplyChevron();
+        }
+
+        // Force the window to actually present this frame — render-only invalidation on nested
+        // children does not reliably trigger a present here.
+        _visualTreeView.InvalidateItemsHostMeasure();
+
+        if (progress >= 1.0)
+            CompleteExpandAnimation();
+    }
+
+    private void CompleteExpandAnimation()
+    {
+        if (_expandAnimTimer is not { IsEnabled: true })
+            return;
+
+        _expandAnimTimer.Stop();
+
+        var collapseVisual = _pendingCollapseVisual;
+        _pendingCollapseVisual = null;
+
+        if (_animChevronRow != null)
+        {
+            _animChevronRow.ChevronAngle = _animChevronTo;
+            _animChevronRow = null;
+        }
+
+        _animStart = _animEnd = -1;
+
+        // Normalize realized rows to their resting state (fully revealed, final chevron).
+        foreach (var container in _visualTreeView.GetRealizedContainers())
+        {
+            container.SetRevealProgress(1.0);
+            container.ApplyChevron();
+        }
+
+        if (collapseVisual != null)
+        {
+            _expandedVisuals.Remove(collapseVisual); // now actually drop the collapsed descendants
+            RebuildVisibleRows();
+        }
+    }
+
+    private void CancelExpandAnimation()
+    {
+        if (_expandAnimTimer is { IsEnabled: true })
+            _expandAnimTimer.Stop();
+        _pendingCollapseVisual = null;
+        _animChevronRow = null;
+        _animStart = _animEnd = -1;
+        foreach (var container in _visualTreeView.GetRealizedContainers())
+            container.SetRevealProgress(1.0);
+    }
+
+    private static double EaseOutCubic(double t) => 1.0 - Math.Pow(1.0 - t, 3.0);
 
     private void OnInspectorSelectionChanged(object sender, SelectionChangedEventArgs e)
     {
@@ -894,11 +1068,11 @@ public partial class DevToolsWindow : Window
         if (me.ChangedButton != Input.MouseButton.Right) return;
         if (me.OriginalSource is not Visual hit) return;
 
-        // Walk up from the clicked visual to find the hosting row view.
+        // Walk up from the clicked visual to find the hosting row container.
         InspectorRow? row = null;
         for (var cur = hit; cur != null; cur = cur.VisualParent)
         {
-            if (cur is InspectorRowView view && view.Row != null) { row = view.Row; break; }
+            if (cur is InspectorRowContainer container && container.Row != null) { row = container.Row; break; }
         }
         if (row == null) return;
 

--- a/src/managed/Jalium.UI.Controls/DevTools/InspectorTreeList.cs
+++ b/src/managed/Jalium.UI.Controls/DevTools/InspectorTreeList.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Linq;
 using Jalium.UI.Controls.Primitives;
 using Jalium.UI.Input;
 using Jalium.UI.Media;
@@ -22,6 +23,12 @@ internal sealed class InspectorRow
     public string DisplayName { get; }
     public bool HasChildren { get; set; }
     public bool IsExpanded { get; set; }
+
+    /// <summary>Current expander chevron rotation in degrees (0 = expanded/down, -90 = collapsed/right).</summary>
+    public double ChevronAngle;
+    /// <summary>This row's position in the visible-row list (set during rebuild). Used to compute the
+    /// expand/collapse reveal stagger without an O(n) IndexOf per realized container.</summary>
+    public int Index = -1;
 
     public InspectorRow(Visual visual, int depth)
     {
@@ -53,36 +60,41 @@ internal sealed class BulkObservableCollection<T> : ObservableCollection<T>
 }
 
 /// <summary>
-/// Visual for a single inspector row: indent spacer + expander chevron + label.
-/// Driven entirely by its <see cref="FrameworkElement.DataContext"/> (an <see cref="InspectorRow"/>),
-/// so the ContentPresenter recycling fast-path can reuse one instance and just re-point DataContext.
+/// Row container for the inspector list. Builds the row visual (indent + chevron + label) directly,
+/// so realized containers are enumerable for the expand/collapse reveal animation. Rows always keep
+/// their full layout height (the VSP virtualizes normally); the reveal is render-only — a clipped
+/// content slide via <see cref="SetRevealProgress"/> (no opacity) — so it never affects layout,
+/// never stacks rows, never allocates per-row alpha layers, and stays O(viewport).
 /// </summary>
-internal sealed class InspectorRowView : Grid
+internal sealed class InspectorRowContainer : ListBoxItem
 {
     private const double IndentSize = 14;
 
+    private readonly Grid _content;
     private readonly Border _indent;
     private readonly Border _expanderHit;
     private readonly ShapePath _arrow;
     private readonly TextBlock _label;
-    private readonly Action<InspectorRow> _onToggle;
+    private Action<InspectorRow>? _onToggle;
 
     public InspectorRow? Row { get; private set; }
 
-    public InspectorRowView(Action<InspectorRow> onToggle)
+    public InspectorRowContainer()
     {
-        _onToggle = onToggle;
         SetCurrentValue(TransitionPropertyProperty, "None");
+        MinHeight = 0;
+        Padding = new Thickness(0);
+        ClipToBounds = true; // clips the reveal slide (content translated up) to the row's slot
 
-        ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
-        ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
-        ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        var grid = new Grid();
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
 
         _indent = new Border();
-        SetColumn(_indent, 0);
+        Grid.SetColumn(_indent, 0);
 
         // Rounded down-triangle chevron — same geometry as the legacy TreeViewItem expander.
-        // Natural orientation points down = expanded; collapsed rotates -90° to point right.
         _arrow = new ShapePath
         {
             Data = "M 733.87,841.90 L 1160.54,273.07 A 170.67,170.67,0,0,0,1024.00,0 H 170.67 A 170.67,170.67,0,0,0,34.14,273.07 L 460.80,841.90 A 170.67,170.67,0,0,0,733.87,841.90 Z",
@@ -99,7 +111,7 @@ internal sealed class InspectorRowView : Grid
             Background = new SolidColorBrush(Color.FromArgb(0, 0, 0, 0)), // transparent yet hit-testable
             Child = _arrow,
         };
-        SetColumn(_expanderHit, 1);
+        Grid.SetColumn(_expanderHit, 1);
         _expanderHit.AddHandler(MouseDownEvent, new MouseButtonEventHandler(OnExpanderMouseDown), handledEventsToo: true);
 
         _label = new TextBlock
@@ -109,60 +121,83 @@ internal sealed class InspectorRowView : Grid
             FontSize = DevToolsTheme.FontBase,
             Foreground = new SolidColorBrush(DevToolsTheme.TextPrimaryColor),
         };
-        SetColumn(_label, 2);
+        Grid.SetColumn(_label, 2);
 
-        Children.Add(_indent);
-        Children.Add(_expanderHit);
-        Children.Add(_label);
+        grid.Children.Add(_indent);
+        grid.Children.Add(_expanderHit);
+        grid.Children.Add(_label);
 
-        DataContextChanged += OnRowDataContextChanged;
+        _content = grid;
+        Content = grid;
     }
 
-    private void OnRowDataContextChanged(object? sender, DependencyPropertyChangedEventArgs e)
+    public void Bind(InspectorRow row, Action<InspectorRow> onToggle)
     {
-        Row = DataContext as InspectorRow;
-        if (Row == null)
-        {
-            return;
-        }
+        Row = row;
+        _onToggle = onToggle;
+        _indent.Width = row.Depth * IndentSize;
+        _label.Text = row.DisplayName;
+        _arrow.Visibility = row.HasChildren ? Visibility.Visible : Visibility.Hidden;
+        SetChevronAngle(row.ChevronAngle);
+        SetRevealProgress(1.0); // recycled containers may carry a stale reveal transform
+    }
 
-        _indent.Width = Row.Depth * IndentSize;
-        _label.Text = Row.DisplayName;
-
-        if (Row.HasChildren)
+    /// <summary>
+    /// Render-only reveal: slides the row content down into its full-height, clipped slot.
+    /// <paramref name="revealed"/> 0 = fully hidden (content translated up out of the clip), 1 =
+    /// fully shown. Uses a translate (cheap matrix) + ClipToBounds (scissor), and deliberately NO
+    /// opacity — animating per-row opacity forces offscreen alpha layers that on a large expand
+    /// exhaust the render target (content goes black) and thrash (flicker). Never touches layout,
+    /// so virtualization is unaffected.
+    /// </summary>
+    internal void SetRevealProgress(double revealed)
+    {
+        if (revealed >= 1.0)
         {
-            _arrow.Visibility = Visibility.Visible;
-            SetArrowAngle(Row.IsExpanded ? 0 : -90);
+            if (_content.RenderTransform != null)
+                _content.RenderTransform = null;
         }
         else
         {
-            _arrow.Visibility = Visibility.Hidden;
+            // Fall back to an estimate before the row's first arrange (ActualHeight==0 then), so the
+            // reveal isn't a silent no-op on frame 0.
+            double h = ActualHeight > 0 ? ActualHeight : (DesiredSize.Height > 0 ? DesiredSize.Height : 28.0);
+            _content.RenderTransform = new TranslateTransform { X = 0, Y = -(1.0 - revealed) * h };
         }
+        InvalidateVisual();
+    }
+
+    /// <summary>Re-applies the bound row's chevron angle (animated for the toggled row).</summary>
+    internal void ApplyChevron()
+    {
+        if (Row != null) SetChevronAngle(Row.ChevronAngle);
     }
 
     private void OnExpanderMouseDown(object sender, MouseButtonEventArgs e)
     {
         if (Row is { HasChildren: true } row)
         {
-            _onToggle(row);
-            e.Handled = true; // clicking the chevron toggles expansion without also selecting the row
+            _onToggle?.Invoke(row);
+            e.Handled = true; // toggle expansion without also selecting the row
         }
     }
 
-    private void SetArrowAngle(double angle)
+    private void SetChevronAngle(double angle)
     {
         var rotate = _arrow.RenderTransform as RotateTransform ?? new RotateTransform();
         rotate.CenterX = 4;
         rotate.CenterY = 4;
         rotate.Angle = angle;
         _arrow.RenderTransform = rotate;
+        _arrow.InvalidateVisual();
     }
 }
 
 /// <summary>
 /// The Inspector's flat virtualized list. A standard <see cref="ListBox"/> (so virtualization,
-/// selection, keyboard nav and selection highlight come for free) wired with a row template and
-/// an index-based scroll helper. Replaces the old nested, non-virtualized TreeView.
+/// selection, keyboard nav and selection highlight come for free) using a custom row container so
+/// the expand/collapse reveal can enumerate the realized rows. Replaces the old nested,
+/// non-virtualized TreeView.
 /// </summary>
 internal sealed class InspectorTreeList : ListBox
 {
@@ -172,23 +207,35 @@ internal sealed class InspectorTreeList : ListBox
     public InspectorTreeList()
     {
         SetCurrentValue(TransitionPropertyProperty, "None");
-
-        var template = new DataTemplate();
-        template.SetVisualTree(() =>
-        {
-            using var __scope = Jalium.UI.Diagnostics.DiagnosticsScope.BeginIgnoredCreation();
-            return new InspectorRowView(row => ToggleExpand?.Invoke(row));
-        });
-        ItemTemplate = template;
     }
 
     /// <inheritdoc />
     protected override FrameworkElement GetContainerForItem(object item)
     {
-        // Containers are realized lazily during layout (outside the window's ctor scope);
-        // wrap creation so constructor-time InvalidateMeasure does not pollute diagnostics.
+        // Containers are realized lazily during layout (outside the window ctor scope); wrap so
+        // constructor-time InvalidateMeasure does not pollute diagnostics.
         using var __scope = Jalium.UI.Diagnostics.DiagnosticsScope.BeginIgnoredCreation();
-        return base.GetContainerForItem(item);
+        return new InspectorRowContainer();
+    }
+
+    /// <inheritdoc />
+    protected override bool IsItemItsOwnContainer(object item) => item is InspectorRowContainer;
+
+    /// <inheritdoc />
+    protected override void PrepareContainerForItem(FrameworkElement element, object item)
+    {
+        // Do NOT call base for our row container: the base would set Content = the InspectorRow
+        // data item (clobbering the container's own row visual). Replicate only the bits ListBox
+        // needs — owner back-reference + selection state — and bind our visual.
+        if (element is InspectorRowContainer container && item is InspectorRow row)
+        {
+            container.ParentListBox = this;
+            container.IsSelected = ReferenceEquals(item, SelectedItem);
+            container.Bind(row, r => ToggleExpand?.Invoke(r));
+            return;
+        }
+
+        base.PrepareContainerForItem(element, item);
     }
 
     /// <summary>Brings the row at <paramref name="index"/> into view — virtualization-aware
@@ -204,9 +251,9 @@ internal sealed class InspectorTreeList : ListBox
     }
 
     /// <summary>
-    /// After the bound row collection is replaced, the inner ScrollViewer still holds the
-    /// previous extent and scroll offset — the VSP invalidates only itself and this framework has
-    /// no IScrollInfo change notification. Re-measuring the ScrollViewer makes it re-read the new
+    /// After the bound row collection is replaced, the inner ScrollViewer still holds the previous
+    /// extent and scroll offset — the VSP invalidates only itself and this framework has no
+    /// IScrollInfo change notification. Re-measuring the ScrollViewer makes it re-read the new
     /// extent (SyncExtentFromScrollInfo) and clamp an out-of-range offset, so a shrunk list (e.g.
     /// Collapse All while scrolled down) refreshes immediately instead of only on a window resize.
     /// </summary>
@@ -221,5 +268,28 @@ internal sealed class InspectorTreeList : ListBox
         {
             InvalidateMeasure();
         }
+    }
+
+    /// <summary>Currently-realized row containers (viewport + cache). Empty when the list has not
+    /// been laid out yet (e.g. headless), which the animation driver uses to fall back to instant
+    /// expand/collapse.</summary>
+    internal IReadOnlyList<InspectorRowContainer> GetRealizedContainers()
+    {
+        if (ItemsHost is { } panel)
+        {
+            return panel.Children.OfType<InspectorRowContainer>().ToList();
+        }
+
+        return Array.Empty<InspectorRowContainer>();
+    }
+
+    /// <summary>Forces the realizing panel to re-measure/arrange so per-frame reveal updates are
+    /// actually presented. A plain InvalidateVisual on a deeply-nested child does not reliably
+    /// trigger a window present here; the measure/arrange path does (it is what the legacy tree
+    /// animation used). Cheap — rows keep full height, so it is a stable viewport-sized layout pass.</summary>
+    internal void InvalidateItemsHostMeasure()
+    {
+        ItemsHost?.InvalidateMeasure();
+        ItemsHost?.InvalidateArrange();
     }
 }

--- a/src/managed/Jalium.UI.Controls/Shapes/Path.cs
+++ b/src/managed/Jalium.UI.Controls/Shapes/Path.cs
@@ -8,6 +8,18 @@ namespace Jalium.UI.Controls.Shapes;
 /// </summary>
 public class Path : Shape
 {
+    static Path()
+    {
+        // WPF's Path default is Stretch.None.  Keeping Shape's historical
+        // Stretch.Fill default here made every Path in a shared design-space
+        // container independently normalize its own geometry bounds.  Icon
+        // layers such as a 24x24 base outline plus an inner detail therefore
+        // acquired unrelated scales and translations before the containing
+        // Viewbox was applied.
+        StretchProperty.OverrideMetadata(typeof(Path),
+            new PropertyMetadata(Stretch.None, OnStretchChanged));
+    }
+
     #region Dependency Properties
 
     /// <summary>
@@ -469,6 +481,15 @@ public class Path : Shape
     #endregion
 
     #region Property Changed
+
+    private static void OnStretchChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is not Path path) return;
+
+        path._renderedGeometry = null;
+        path.InvalidateMeasure();
+        path.InvalidateVisual();
+    }
 
     private static void OnDataChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {

--- a/src/managed/Jalium.UI.Controls/VirtualizingStackPanel.cs
+++ b/src/managed/Jalium.UI.Controls/VirtualizingStackPanel.cs
@@ -811,7 +811,13 @@ public class VirtualizingStackPanel : VirtualizingPanel, IScrollInfo
 
     private double CoerceOffset(double offset)
     {
-        var maxOffset = Math.Max(0, GetAxisSize(_extent) - GetViewportAxisSize());
+        // Use the LIVE extent (GetSpacedExtent, derived from the already-updated height index),
+        // not the _extent field — _extent is only refreshed by UpdateExtent at the END of
+        // MeasureOverride, i.e. AFTER this coercion runs (line ~376). When the item collection
+        // shrinks (e.g. tree Collapse All), clamping against the stale (larger) _extent leaves the
+        // offset past the new content, stranding the view until a second pass (a window resize)
+        // re-clamps it. GetSpacedExtent reflects the new count immediately.
+        var maxOffset = Math.Max(0, GetSpacedExtent() - GetViewportAxisSize());
         if (double.IsNaN(offset) || double.IsInfinity(offset))
         {
             return 0;

--- a/src/managed/Jalium.UI.Core/FrameworkElement.cs
+++ b/src/managed/Jalium.UI.Core/FrameworkElement.cs
@@ -1107,6 +1107,12 @@ public partial class FrameworkElement : UIElement
             switch (HorizontalAlignment)
             {
                 case HorizontalAlignment.Center:
+                // WPF treats Stretch as Center when an explicit Width or a
+                // size constraint prevents the element from consuming its
+                // full arrange slot. Without this, a fixed-width Viewbox in a
+                // wider vertical StackPanel hugs the left edge of the longest
+                // sibling instead of staying centered.
+                case HorizontalAlignment.Stretch when arrangeSize.Width < availableWidth:
                     x += extraWidth / 2;
                     break;
                 case HorizontalAlignment.Right:
@@ -1122,6 +1128,8 @@ public partial class FrameworkElement : UIElement
             switch (VerticalAlignment)
             {
                 case VerticalAlignment.Center:
+                // Same effective-alignment rule as the horizontal axis.
+                case VerticalAlignment.Stretch when arrangeSize.Height < availableHeight:
                     y += extraHeight / 2;
                     break;
                 case VerticalAlignment.Bottom:

--- a/src/managed/Jalium.UI.Core/Visual.cs
+++ b/src/managed/Jalium.UI.Core/Visual.cs
@@ -801,6 +801,26 @@ public abstract class Visual : DependencyObject
         return Math.Abs(m.M12) > 1e-6 || Math.Abs(m.M21) > 1e-6;
     }
 
+    /// <summary>
+    /// Returns true when compositing a retained layer would enlarge its source
+    /// texels. Retained layers are realized at the element's untransformed
+    /// <see cref="UIElement.RenderSize"/>; upscaling that texture turns vector
+    /// paths and text into a blurry bitmap. Such subtrees must be rendered
+    /// through the live transform so vector geometry is rasterized directly at
+    /// the final surface resolution.
+    /// </summary>
+    internal static bool TransformWouldUpscaleRetainedLayer(Transform? transform)
+    {
+        if (transform == null)
+            return false;
+
+        var m = transform.Value;
+        var scaleX = Math.Sqrt(m.M11 * m.M11 + m.M12 * m.M12);
+        var scaleY = Math.Sqrt(m.M21 * m.M21 + m.M22 * m.M22);
+        const double epsilon = 1e-6;
+        return scaleX > 1.0 + epsilon || scaleY > 1.0 + epsilon;
+    }
+
     /// <summary>Queues this visual's retained layer (if any) for fence-gated
     /// destruction and marks it for re-realization.</summary>
     private static void ReleaseLayerIfAny(Visual v)
@@ -873,8 +893,9 @@ public abstract class Visual : DependencyObject
         // (the quad path bakes only scale+translate) and trivial / leaf subtrees.
         bool hasComposite = transform != null || opacity < 1.0;
         bool rotation = transform != null && TransformHasRotationOrSkew(transform);
+        bool upscalesLayer = TransformWouldUpscaleRetainedLayer(transform);
         var size = child.RenderSize;
-        bool eligible = hasComposite && !rotation
+        bool eligible = hasComposite && !rotation && !upscalesLayer
             && size.Width >= 1.0 && size.Height >= 1.0
             && child.VisualChildrenCount > 0;
 

--- a/src/native/jalium.native.d3d12/include/d3d12_direct_renderer.h
+++ b/src/native/jalium.native.d3d12/include/d3d12_direct_renderer.h
@@ -390,6 +390,7 @@ public:
     void DrawOffscreenBitmapCropped(int slot, float x, float y, float w, float h,
         float uvOffsetX, float uvOffsetY, float opacity);
     bool IsInOffscreenCapture() const { return inOffscreenCapture_; }
+    bool IsInRetainedCapture() const { return inRetainedCapture_; }
 
     // --- Retained GPU layers (damage-driven composited-animation fast path) ---
     // Realize a content-clean subtree into a PERSISTENT texture once, then

--- a/src/native/jalium.native.d3d12/src/d3d12_render_target.cpp
+++ b/src/native/jalium.native.d3d12/src/d3d12_render_target.cpp
@@ -1035,6 +1035,24 @@ void D3D12RenderTarget::FlushImpellerBatches() {
     // first non-path draw of a path-heavy frame.
     thread_local std::vector<TriangleVertex> s_flushExpand;
 
+    // In a retained / offscreen capture the layer render target is layer-local
+    // (origin 0,0) and the Impeller vertices were baked into layer-local space by
+    // the capture's (-x,-y) transform — but each batch's SNAPSHOTTED scissor is
+    // still in WINDOW space (managed pre-added the child world offset to the clip
+    // rect, and unlike the vertices the rect never goes through the capture
+    // transform). Replaying that window-space rect against the small layer RT
+    // clips every triangle away — the bug where filled / stroked straight-line
+    // geometry vanished inside a Viewbox (only stencil-FillPath and SDF survived).
+    // Shift the scissor by the same capture offset so it lands in layer-local space
+    // and matches the vertices. Outside any capture this is a no-op (offset 0).
+    LONG capSox = 0, capSoy = 0;
+    if (directRenderer_->IsInRetainedCapture() || directRenderer_->IsInOffscreenCapture()) {
+        auto capT = directRenderer_->GetCurrentTransform();
+        float dpiS = directRenderer_->GetDpiScale();
+        capSox = (LONG)(capT.dx * dpiS);
+        capSoy = (LONG)(capT.dy * dpiS);
+    }
+
     for (auto& batch : impellerEngine_->GetBatches()) {
         if (batch.indices.empty() || batch.vertices.empty()) continue;
 
@@ -1054,10 +1072,10 @@ void D3D12RenderTarget::FlushImpellerBatches() {
             // Push raw pixel-space scissor rect directly
             // (DirectRenderer stores pixel-space rects in its scissor stack)
             D3D12_RECT sr;
-            sr.left = (LONG)batch.scissorL;
-            sr.top = (LONG)batch.scissorT;
-            sr.right = (LONG)batch.scissorR;
-            sr.bottom = (LONG)batch.scissorB;
+            sr.left = (LONG)batch.scissorL + capSox;
+            sr.top = (LONG)batch.scissorT + capSoy;
+            sr.right = (LONG)batch.scissorR + capSox;
+            sr.bottom = (LONG)batch.scissorB + capSoy;
             directRenderer_->PushScissorRaw(sr);
         } else {
             // No recorded clip → draw unclipped (full viewport), exactly like a

--- a/tests/Jalium.UI.Tests/CompositionInvalidationTests.cs
+++ b/tests/Jalium.UI.Tests/CompositionInvalidationTests.cs
@@ -82,6 +82,21 @@ public class CompositionInvalidationTests
             "RenderTransform is a composition-only property — changing it must not invalidate the cache.");
     }
 
+    [Theory]
+    [InlineData(1.0, 1.0, false)]
+    [InlineData(0.5, 0.75, false)]
+    [InlineData(-1.0, 1.0, false)]
+    [InlineData(2.1666666667, 2.1666666667, true)]
+    [InlineData(1.0, 1.01, true)]
+    [InlineData(-2.0, 1.0, true)]
+    public void RetainedLayerEligibility_RejectsTextureUpscaling(
+        double scaleX, double scaleY, bool expected)
+    {
+        var transform = new ScaleTransform(scaleX, scaleY);
+
+        Assert.Equal(expected, Visual.TransformWouldUpscaleRetainedLayer(transform));
+    }
+
     [Fact]
     public void RenderTransformOriginChange_DoesNotFlipRenderDirty()
     {

--- a/tests/Jalium.UI.Tests/FrameworkElementLayoutSnapTests.cs
+++ b/tests/Jalium.UI.Tests/FrameworkElementLayoutSnapTests.cs
@@ -5,6 +5,30 @@ namespace Jalium.UI.Tests;
 public class FrameworkElementLayoutSnapTests
 {
     [Fact]
+    public void ArrangeCore_ShouldCenterExplicitSize_WhenAlignmentIsStretch()
+    {
+        var host = new Border
+        {
+            Width = 100,
+            Height = 80
+        };
+        var child = new Border
+        {
+            Width = 52,
+            Height = 24
+        };
+        host.Child = child;
+
+        host.Measure(new Size(100, 80));
+        host.Arrange(new Rect(0, 0, 100, 80));
+
+        Assert.Equal(24, child.VisualBounds.X);
+        Assert.Equal(28, child.VisualBounds.Y);
+        Assert.Equal(52, child.RenderSize.Width);
+        Assert.Equal(24, child.RenderSize.Height);
+    }
+
+    [Fact]
     public void ArrangeCore_ShouldKeepCenteredChildOriginAsFloat_NotSnapped()
     {
         // Centered alignment may legitimately produce a fractional origin (e.g.

--- a/tests/Jalium.UI.Tests/PathShapeTests.cs
+++ b/tests/Jalium.UI.Tests/PathShapeTests.cs
@@ -9,6 +9,27 @@ namespace Jalium.UI.Tests;
 public class PathShapeTests
 {
     [Fact]
+    public void Path_DefaultStretch_ShouldPreserveSharedDesignCoordinates()
+    {
+        var path = new TestPath
+        {
+            Data = "M 7,3 H 17 V 21 H 7 Z",
+            Width = 24,
+            Height = 24
+        };
+
+        path.Measure(new Size(24, 24));
+        path.Arrange(new Rect(0, 0, 24, 24));
+
+        var drawingContext = new RecordingDrawingContext();
+        path.Render(drawingContext);
+
+        Assert.Equal(ShapeStretch.None, path.Stretch);
+        var geometry = Assert.IsType<PathGeometry>(drawingContext.LastGeometry);
+        Assert.Equal(new Rect(7, 3, 10, 18), geometry.Bounds);
+    }
+
+    [Fact]
     public void Path_Data_ShouldUseSharedPathMarkupParser_ForArcCommands()
     {
         var path = CreatePath("M 0,4 A 4,4 0 0 1 8,0", 8, 8, ShapeStretch.None);


### PR DESCRIPTION
## Summary

Follow-up after #147 merged. A DevTools tree reveal animation plus five render/layout correctness fixes — four of which (3–6) converge on the same end-user symptom: **icons inside a `Viewbox` rendering wrong** (misaligned, blurry, or with vanishing straight-line geometry). Branched fresh from `master` (after #147's squash-merge) so the diff is exactly this work. Includes a small **native (d3d12)** change, so a native rebuild is required.

### `feat(devtools)` — animate inspector tree expand/collapse
Expanding/collapsing an inspector node plays a staggered reveal: the descendant block slides in/out via a **render-only** clipped content translate (`ClipToBounds` + `TranslateTransform`) applied per-frame to the realized containers only, plus a chevron rotation on the toggled row. It never touches layout height or opacity, so it stays **O(viewport)** — never realizes the whole subtree, never stacks rows, never allocates per-row alpha layers (which on a big expand black out / thrash the RT). `InspectorRowView` (a `DataTemplate` Grid) becomes `InspectorRowContainer` (a `ListBoxItem`) so the list can enumerate realized rows.

### `fix(virtualization)` — clamp scroll offset against the live extent
`CoerceOffset` clamped against the `_extent` field, which `UpdateExtent` only refreshes at the *end* of `MeasureOverride` (after coercion). On a shrink (tree **Collapse All** while scrolled down) the view was stranded past the new content until a window resize. Clamp against `GetSpacedExtent()` instead.

### `fix(shapes)` — default `Path` Stretch to `None`
Shape's historical `Stretch.Fill` default made every `Path` independently normalize its geometry bounds, so icon layers sharing one design space (24×24 base + inner detail) got unrelated scales/translations before the `Viewbox` applied. Match WPF (`Stretch.None`).

### `fix(layout)` — center a Stretch element that can't fill its slot
WPF treats `Stretch` as `Center` when an explicit size keeps an element from consuming its arrange slot. Without it, a fixed-width `Viewbox` in a wider `StackPanel` hugged the left edge instead of centering. Added on both axes.

### `fix(render)` — don't retain a layer the transform would upscale
Retained layers are realized at untransformed `RenderSize`; upscaling that texture turns vector paths and text into a blurry bitmap. Exclude upscaling subtrees from retained-layer eligibility so they rasterize at final resolution.

### `fix(render)` — shift Impeller batch scissor into layer space during capture
In a retained/offscreen capture the layer RT is layer-local but each batch's snapshotted scissor stays in **window** space, so replaying it clipped every triangle away — filled/stroked straight-line geometry vanished inside a `Viewbox` (only stencil-FillPath and SDF survived). Shift the scissor by the capture offset (no-op outside capture).

## Tests
- `Path_DefaultStretch_ShouldPreserveSharedDesignCoordinates` (new)
- `ArrangeCore_ShouldCenterExplicitSize_WhenAlignmentIsStretch` (new)
- `RetainedLayerEligibility_RejectsTextureUpscaling` (new theory)

## Notes
- **Native rebuild required** (d3d12 renderer change).
- Reverted two accidental whitespace-only edits picked up in the working tree (`TreeView.jalxaml` indentation, a stray blank line in `RenderTargetDrawingContext.cs`).
- Debug artifacts (`1`, `_dbg_*.png`, `fsd/vsd.spv|.txt`) left on disk and **excluded**.
- Full build / test suite **not** run in this session.
