### PR TITLE
test(render-thread): sync SetShapeType into whole-frame recorder guard

### DIFF
--- a/tests/Jalium.UI.Tests/RenderThread/RecordingRenderSink.cs
+++ b/tests/Jalium.UI.Tests/RenderThread/RecordingRenderSink.cs
@@ -120,6 +120,9 @@ internal sealed class RecordingRenderSink : DrawingContext,
     public override void DrawLiquidGlass(LiquidGlassParameters parameters) =>
         Events.Add($"DrawLiquidGlass {R(parameters.Rectangle)}");
 
+    public override void SetShapeType(int type, float exponent) =>
+        Events.Add($"SetShapeType {type} n={F(exponent)}");
+
     public override void PushTransform(Transform transform) =>
         Events.Add($"PushTransform {M(transform)}");
 

--- a/tests/Jalium.UI.Tests/RenderThread/WholeFrameRecorderTests.cs
+++ b/tests/Jalium.UI.Tests/RenderThread/WholeFrameRecorderTests.cs
@@ -121,6 +121,43 @@ public sealed class WholeFrameRecorderTests : System.IDisposable
     }
 
     [Fact]
+    public void WholeFrameCapture_SuperEllipseShapeType_RoundTripsInDrawOrder()
+    {
+        // A SuperEllipse Border brackets its rounded-rect fill with
+        // SetShapeType(1, n) … SetShapeType(0, 4) (Border.OnRender). The
+        // whole-frame recorder must capture and replay that state op in draw
+        // order, or the render-thread path would silently degrade the squircle
+        // to an ordinary rounded rectangle.
+        var root = new Border
+        {
+            Width = 100,
+            Height = 100,
+            Background = new SolidColorBrush { Color = Color.FromArgb(255, 30, 60, 90) },
+            CornerRadius = new CornerRadius(20),
+            Shape = BorderShape.SuperEllipse,
+        };
+        root.Measure(new Size(200, 200));
+        root.Arrange(new Rect(0, 0, 200, 200));
+
+        var direct = new RecordingRenderSink();
+        root.Render(direct);
+
+        var host = new MediaRenderCacheHost();
+        var recorder = host.CreateFrameRecorder()!;
+        root.Render(recorder);
+        var drawing = (Drawing)host.FinishRecord(recorder);
+
+        Assert.True(drawing.IsFullyRecordable);
+
+        var replay = new RecordingRenderSink();
+        host.Replay(drawing, replay);
+
+        Assert.Equal(direct.Events, replay.Events);
+        Assert.Contains(replay.Events, e => e.StartsWith("SetShapeType 1"));
+        Assert.Contains(replay.Events, e => e.StartsWith("SetShapeType 0"));
+    }
+
+    [Fact]
     public void WholeFrameCapture_PushPopBalanced_AndOffsetsRoundTrip()
     {
         var root = BuildTree();
@@ -223,6 +260,7 @@ public sealed class WholeFrameRecorderTests : System.IDisposable
             nameof(DrawingContext.Pop),
             nameof(DrawingContext.PushEffect),
             nameof(DrawingContext.PopEffect),
+            nameof(DrawingContext.SetShapeType),
             nameof(DrawingContext.Close),
         };
 


### PR DESCRIPTION
The EveryRtdcOverrideOfDrawingContext_HasARecordableCommand guard failed because its `recordable` allowlist was not kept in sync when the SetShapeType op (SuperEllipse/squircle state) was added to the recorder pipeline. The record/replay plumbing itself already exists on master (DrawCommandKind.SetShapeType, SetShapeTypeCmd, DrawingRecorder override, DrawingReplayer case) — only the test-side allowlist lagged.

- Add nameof(DrawingContext.SetShapeType) to the guard allowlist.
- Teach RecordingRenderSink to observe SetShapeType so a record→replay divergence is actually visible (base was a no-op).
- Add WholeFrameCapture_SuperEllipseShapeType_RoundTripsInDrawOrder: a SuperEllipse Border brackets its fill with SetShapeType(1,n)…(0,4); assert the direct-render and record→replay streams match token-for-token and both SetShapeType ops survive in draw order.

No product code changes; tests only. WholeFrameRecorder suite: 14/14 green.