### PR TITLE
test(render-thread): sync SetShapeType into whole-frame recorder guard

### DIFF
--- a/tests/Jalium.UI.Tests/RenderThread/RecordingRenderSink.cs
+++ b/tests/Jalium.UI.Tests/RenderThread/RecordingRenderSink.cs
@@ -120,6 +120,9 @@ internal sealed class RecordingRenderSink : DrawingContext,
     public override void DrawLiquidGlass(LiquidGlassParameters parameters) =>
         Events.Add($"DrawLiquidGlass {R(parameters.Rectangle)}");
 
+    public override void SetShapeType(int type, float exponent) =>
+        Events.Add($"SetShapeType {type} n={F(exponent)}");
+
     public override void PushTransform(Transform transform) =>
         Events.Add($"PushTransform {M(transform)}");
 

--- a/tests/Jalium.UI.Tests/RenderThread/WholeFrameRecorderTests.cs
+++ b/tests/Jalium.UI.Tests/RenderThread/WholeFrameRecorderTests.cs
@@ -121,6 +121,43 @@ public sealed class WholeFrameRecorderTests : System.IDisposable
     }
 
     [Fact]
+    public void WholeFrameCapture_SuperEllipseShapeType_RoundTripsInDrawOrder()
+    {
+        // A SuperEllipse Border brackets its rounded-rect fill with
+        // SetShapeType(1, n) … SetShapeType(0, 4) (Border.OnRender). The
+        // whole-frame recorder must capture and replay that state op in draw
+        // order, or the render-thread path would silently degrade the squircle
+        // to an ordinary rounded rectangle.
+        var root = new Border
+        {
+            Width = 100,
+            Height = 100,
+            Background = new SolidColorBrush { Color = Color.FromArgb(255, 30, 60, 90) },
+            CornerRadius = new CornerRadius(20),
+            Shape = BorderShape.SuperEllipse,
+        };
+        root.Measure(new Size(200, 200));
+        root.Arrange(new Rect(0, 0, 200, 200));
+
+        var direct = new RecordingRenderSink();
+        root.Render(direct);
+
+        var host = new MediaRenderCacheHost();
+        var recorder = host.CreateFrameRecorder()!;
+        root.Render(recorder);
+        var drawing = (Drawing)host.FinishRecord(recorder);
+
+        Assert.True(drawing.IsFullyRecordable);
+
+        var replay = new RecordingRenderSink();
+        host.Replay(drawing, replay);
+
+        Assert.Equal(direct.Events, replay.Events);
+        Assert.Contains(replay.Events, e => e.StartsWith("SetShapeType 1"));
+        Assert.Contains(replay.Events, e => e.StartsWith("SetShapeType 0"));
+    }
+
+    [Fact]
     public void WholeFrameCapture_PushPopBalanced_AndOffsetsRoundTrip()
     {
         var root = BuildTree();
@@ -223,6 +260,7 @@ public sealed class WholeFrameRecorderTests : System.IDisposable
             nameof(DrawingContext.Pop),
             nameof(DrawingContext.PushEffect),
             nameof(DrawingContext.PopEffect),
+            nameof(DrawingContext.SetShapeType),
             nameof(DrawingContext.Close),
         };
 


### PR DESCRIPTION
## What

The `WholeFrameRecorderTests.EveryRtdcOverrideOfDrawingContext_HasARecordableCommand` guard was failing deterministically:

```
RenderTargetDrawingContext overrides DrawingContext method(s) with no recordable
DrawCommand — extend DrawCommandKind + the recorder/replayer, or the whole-frame
(render-thread) path will silently drop them: SetShapeType
```

This PR fixes the failing test and adds behavioral coverage for the `SetShapeType` record→replay path.

## Why

`SetShapeType` (the SuperEllipse / squircle shape-state op) is **already fully wired** through the whole-frame recorder pipeline on `master`:

| Stage | Location |
|---|---|
| Enum | `DrawCommandKind.SetShapeType` (`DrawCommand.cs`) |
| Factory | `DrawCommand.SetShapeTypeCmd(type, exponent)` — V0=type, V1=exponent |
| Record | `DrawingRecorder.SetShapeType` override enqueues it (no bounds contribution) |
| Replay | `DrawingReplayer` `case SetShapeType` re-applies in draw order |
| Producer | `Border.OnRender` SuperEllipse branch: `SetShapeType(1, n)` … fill … `SetShapeType(0, 4)` |

The **only** gap was the test's own `recordable` allowlist, which the guard's comment explicitly requires to be kept in sync as the schema grows. The op was added without updating the allowlist, so the reflection-based guard flagged it.

## Changes (tests only — no product code touched)

1. **`WholeFrameRecorderTests.cs`** — add `nameof(DrawingContext.SetShapeType)` to the guard allowlist.
2. **`RecordingRenderSink.cs`** — override `SetShapeType` to record an observable event (base was a no-op, so a record→replay divergence would otherwise be invisible to the token-stream comparison).
3. **`WholeFrameRecorderTests.cs`** — new `WholeFrameCapture_SuperEllipseShapeType_RoundTripsInDrawOrder`: builds a `BorderShape.SuperEllipse` Border, renders it both directly and through record→replay, and asserts the two draw-command streams match token-for-token **and** that both `SetShapeType(1, n)` and `SetShapeType(0, 4)` survive in draw order.

## Reviewer notes

- Not just an allowlist rubber-stamp: the new round-trip test proves the underlying record/replay plumbing actually reproduces the squircle state in order. If recording, replay, or ordering regressed, `Assert.Equal(direct.Events, replay.Events)` would fail.
- No changes under `src/` — product behavior is unchanged.
- Verification: `dotnet test tests/Jalium.UI.Tests --filter FullyQualifiedName~WholeFrameRecorder` → **14 passed, 0 failed** (13 pre-existing + 1 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)