### PR TITLE
fix(style): explicit/implicit Style no longer strips the theme default style

### DIFF
--- a/src/managed/Jalium.UI.Controls/Themes/ThemeManager.cs
+++ b/src/managed/Jalium.UI.Controls/Themes/ThemeManager.cs
@@ -49,6 +49,14 @@ public static class ThemeManager
     private static bool _suppressRefresh;
 
     /// <summary>
+    /// Per-type cache for <see cref="ResolveThemeStyle"/>. Style-stack re-evaluation runs
+    /// for every element on tree attach and resource changes, so the resolver must be cheap;
+    /// entries are invalidated whenever the generic theme dictionary instance is replaced.
+    /// Guarded by itself — resolution happens on the UI thread, but tests may reset in parallel.
+    /// </summary>
+    private static readonly Dictionary<Type, Style?> _themeStyleCache = new();
+
+    /// <summary>
     /// Default brand primary accent (forest emerald, midpoint of the
     /// #207245 -> #1C8043 gradient used for AccentBrush).
     /// </summary>
@@ -63,6 +71,53 @@ public static class ThemeManager
     /// The resource name of the Generic theme file.
     /// </summary>
     public const string GenericThemeResourceName = "Jalium.UI.Controls.Themes.Generic.jalxaml";
+
+    static ThemeManager()
+    {
+        // Give Core a way to resolve theme default styles (the bottom layer of every
+        // element's style stack) without referencing the theme dictionaries directly.
+        // Registered in the static constructor so it is in place before any element
+        // evaluates its style stack; while no theme is loaded it just returns null.
+        FrameworkElement.ThemeStyleResolver = ResolveThemeStyle;
+    }
+
+    /// <summary>
+    /// Resolves the theme default style for an exact element type from the generic
+    /// theme dictionary (the base-type walk happens in FrameworkElement).
+    /// </summary>
+    private static Style? ResolveThemeStyle(Type type)
+    {
+        var dictionary = _genericThemeDictionary;
+        if (dictionary == null)
+            return null;
+
+        lock (_themeStyleCache)
+        {
+            if (_themeStyleCache.TryGetValue(type, out var cached))
+                return cached;
+        }
+
+        var style = dictionary.TryGetValue(type, out var value) ? value as Style : null;
+
+        lock (_themeStyleCache)
+        {
+            _themeStyleCache[type] = style;
+        }
+
+        return style;
+    }
+
+    /// <summary>
+    /// Drops all cached theme-style resolutions. Must be called whenever the generic
+    /// theme dictionary instance changes (theme swap, refresh, test reset).
+    /// </summary>
+    private static void InvalidateThemeStyleCache()
+    {
+        lock (_themeStyleCache)
+        {
+            _themeStyleCache.Clear();
+        }
+    }
 
     /// <summary>
     /// Delegate for loading XAML content from a stream.
@@ -181,6 +236,7 @@ public static class ThemeManager
         }
 
         _genericThemeDictionary = LoadGenericTheme();
+        InvalidateThemeStyleCache();
         if (_genericThemeDictionary != null)
         {
             Jalium.UI.Diagnostics.ResourceDictionaryDiagnostics.RegisterGenericResourceDictionary(
@@ -240,6 +296,7 @@ public static class ThemeManager
                 Jalium.UI.Diagnostics.ResourceDictionaryDiagnostics.RegisterGenericResourceDictionary(
                     refreshedGeneric);
                 ReplaceManagedDictionary(ref _genericThemeDictionary, refreshedGeneric);
+                InvalidateThemeStyleCache();
             }
 
             // Accent derived resources depend on current theme (notably disabled variants).
@@ -417,6 +474,7 @@ public static class ThemeManager
         _typographyDictionary = null;
         _themeVersion = 0;
         _suppressRefresh = false;
+        InvalidateThemeStyleCache();
 
         CurrentTheme = ThemeVariant.Dark;
         CurrentAccentColor = DefaultPrimaryAccentColor;

--- a/src/managed/Jalium.UI.Core/DynamicResourceBinding.cs
+++ b/src/managed/Jalium.UI.Core/DynamicResourceBinding.cs
@@ -138,6 +138,34 @@ internal static class DynamicResourceBindingOperations
         }
     }
 
+    /// <summary>
+    /// Clears the dynamic-resource subscription on the property only when it belongs to the
+    /// given layer. Used when a higher-priority style setter writes a plain value: a lower
+    /// style layer (theme default style) may hold a live subscription on the same DP whose
+    /// next refresh would overwrite that value. Subscriptions from other layers (e.g. a
+    /// local SetDynamicResource) are left untouched.
+    /// </summary>
+    internal static void ClearDynamicResource(
+        FrameworkElement target,
+        DependencyProperty property,
+        DependencyObject.LayerValueSource layerSource)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(property);
+
+        if (!Subscriptions.TryGetValue(target, out var subscriptions))
+            return;
+
+        if (!subscriptions.TryGetValue(property, out var subscription))
+            return;
+
+        if (subscription.LayerSource != layerSource)
+            return;
+
+        target.ResourcesChanged -= subscription.Handler;
+        subscriptions.Remove(property);
+    }
+
     internal static void PromoteDynamicResourcesToLayer(
         FrameworkElement target,
         DependencyObject.LayerValueSource layerSource)

--- a/src/managed/Jalium.UI.Core/FrameworkElement.cs
+++ b/src/managed/Jalium.UI.Core/FrameworkElement.cs
@@ -363,9 +363,28 @@ public partial class FrameworkElement : UIElement, IFrameworkInputElement, Marku
     internal readonly Dictionary<(FrameworkElement, DependencyProperty), (object? OriginalValue, int ActiveCount, object? SuspendedDynamicResourceKey)> _triggerOriginalValues = new();
 
     /// <summary>
-    /// The implicit style applied to this element based on its type.
+    /// The implicit style applied to this element based on its type. Never references
+    /// the theme default style — that lives in <see cref="_themeStyle"/> so an explicit
+    /// or implicit user style layers ON TOP of the theme defaults instead of replacing them.
     /// </summary>
     private Style? _implicitStyle;
+
+    /// <summary>
+    /// The theme default style (from the framework theme dictionary) currently applied
+    /// as the bottom layer of this element's style stack. WPF parity: an explicit
+    /// <see cref="Style"/> only overrides the properties it sets; everything else —
+    /// most critically the control Template — still comes from the theme default style.
+    /// </summary>
+    private Style? _themeStyle;
+
+    /// <summary>
+    /// Resolves the theme default style for a concrete element type. Injected by
+    /// Jalium.UI.Controls' ThemeManager (Core cannot reference the theme dictionaries
+    /// directly). Returns null when no theme is loaded or the type has no default style.
+    /// The FrameworkElement side walks the base-type chain; the resolver only needs to
+    /// answer for the exact type it is given.
+    /// </summary>
+    internal static Func<Type, Style?>? ThemeStyleResolver { get; set; }
 
     /// <summary>
     /// The element that owns the template in which this element is defined.
@@ -871,10 +890,9 @@ public partial class FrameworkElement : UIElement, IFrameworkInputElement, Marku
                 current.ResourcesChanged.Invoke(current, EventArgs.Empty);
             }
 
-            if (current.Style == null)
-            {
-                current.ReEvaluateImplicitStyle();
-            }
+            // Elements with an explicit Style still carry a theme-default bottom layer,
+            // so they must re-evaluate too (theme swaps replace the theme dictionary).
+            current.ReEvaluateImplicitStyle();
 
             var childCount = current.VisualChildrenCount;
             for (int i = 0; i < childCount; i++)
@@ -1499,29 +1517,7 @@ public partial class FrameworkElement : UIElement, IFrameworkInputElement, Marku
             var oldStyle = e.OldValue as Style;
             var newStyle = e.NewValue as Style;
 
-            // Remove implicit style if explicit style is being set
-            if (e.NewValue != null && element._implicitStyle != null)
-            {
-                element._implicitStyle.Remove(element);
-                element._implicitStyle = null;
-            }
-
-            // Remove old style
-            if (oldStyle != null)
-            {
-                oldStyle.Remove(element);
-            }
-
-            // Apply new style
-            if (newStyle != null)
-            {
-                newStyle.Apply(element);
-            }
-            else
-            {
-                // If explicit style is cleared, try to apply implicit style
-                element.ApplyImplicitStyleIfNeeded();
-            }
+            element.UpdateStyleStack(oldStyle, newStyle);
 
             element.OnStyleChanged(oldStyle, newStyle);
         }
@@ -1706,65 +1702,121 @@ public partial class FrameworkElement : UIElement, IFrameworkInputElement, Marku
 
 
     /// <summary>
-    /// Applies an implicit style to this element if no explicit style is set.
+    /// Applies the style stack to this element if it hasn't been initialized yet.
     /// Called from OnVisualParentChanged and also by Window.Show() to handle
     /// elements created before the theme was loaded.
     /// </summary>
     internal void ApplyImplicitStyleIfNeeded()
     {
-        // Explicit style set — nothing to do.
-        if (Style != null)
+        // Fast path: the style stack was already initialized once. Re-evaluation
+        // after tree/resource changes is handled by ReEvaluateImplicitStyle().
+        if (_themeStyle != null || _implicitStyle != null)
             return;
 
-        // Already have an implicit style — skip first-time application.
-        // Re-evaluation after tree changes is handled by ReEvaluateImplicitStyle().
-        if (_implicitStyle != null)
-            return;
-
-        var implicitStyle = LookupImplicitStyle();
-        if (implicitStyle != null)
-        {
-            _implicitStyle = implicitStyle;
-            implicitStyle.Apply(this);
-            InvalidateVisual();
-        }
+        UpdateStyleStack(Style, Style);
     }
 
     /// <summary>
-    /// Re-evaluates the implicit style for this element after a tree change.
+    /// Re-evaluates the style stack for this element after a tree or resource change.
     /// If a closer-scope implicit style is now available (e.g., user-defined style
-    /// in Window.Resources after the subtree was connected), it replaces the
-    /// previously applied style (e.g., theme style from Application.Resources).
+    /// in Window.Resources after the subtree was connected), it replaces the previous
+    /// top-layer style; the theme default style is re-resolved as the bottom layer.
     /// </summary>
     private void ReEvaluateImplicitStyle()
     {
-        if (Style != null)
-            return;
+        UpdateStyleStack(Style, Style);
+    }
 
-        var newImplicit = LookupImplicitStyle();
-        if (newImplicit == null)
+    /// <summary>
+    /// Recomputes and re-applies this element's two-layer style stack:
+    /// theme default style (bottom) + explicit-or-implicit style (top).
+    /// The top layer is applied last so its setters win for the properties it sets,
+    /// while everything else (most critically the control Template) still falls back
+    /// to the theme default style — WPF's Style/ThemeStyle split.
+    /// </summary>
+    /// <param name="oldExplicit">The explicit Style before this update (for Style changes).</param>
+    /// <param name="newExplicit">The explicit Style after this update. For non-Style-change
+    /// re-evaluation both parameters are the current explicit Style.</param>
+    private void UpdateStyleStack(Style? oldExplicit, Style? newExplicit)
+    {
+        var newTheme = LookupThemeStyle();
+
+        // The implicit style only participates when no explicit style is set (WPF parity),
+        // and never duplicates the theme layer (LookupImplicitStyle can surface the theme
+        // style itself via the application resource chain).
+        Style? newImplicit = null;
+        if (newExplicit == null)
         {
-            if (_implicitStyle != null)
-            {
-                _implicitStyle.Remove(this);
-                _implicitStyle = null;
-                InvalidateVisual();
-            }
-            return;
+            var found = LookupImplicitStyle();
+            newImplicit = ReferenceEquals(found, newTheme) ? null : found;
         }
 
-        if (ReferenceEquals(_implicitStyle, newImplicit))
-            return; // Same style — no change needed.
+        // An explicit Style can literally be the theme style object (e.g. captured via
+        // a typed StaticResource). The theme layer already applies it — applying the
+        // same Style twice would double-attach its triggers and leak their handlers.
+        // Normalize both the old and new top the same way so the unchanged-check and
+        // the unwind below see what was actually applied.
+        var oldTop = oldExplicit ?? _implicitStyle;
+        if (ReferenceEquals(oldTop, _themeStyle))
+            oldTop = null;
 
-        // Different (closer-scope) implicit style found — swap.
-        if (_implicitStyle != null)
+        var newTop = newExplicit ?? newImplicit;
+        if (ReferenceEquals(newTop, newTheme))
+            newTop = null;
+
+        if (ReferenceEquals(_themeStyle, newTheme) && ReferenceEquals(oldTop, newTop))
+            return; // Stack unchanged.
+
+        // Unwind in LIFO order. Both layers write the same StyleSetter value layer, so
+        // removing the top style also clears any overlapping properties the theme style
+        // set — the theme layer must be re-applied afterwards, not just left in place.
+        oldTop?.Remove(this);
+        if (!ReferenceEquals(_themeStyle, oldTop))
         {
-            _implicitStyle.Remove(this);
+            _themeStyle?.Remove(this);
         }
 
+        _themeStyle = newTheme;
         _implicitStyle = newImplicit;
-        newImplicit.Apply(this);
+
+        newTheme?.Apply(this);
+        newTop?.Apply(this);
+
         InvalidateVisual();
+    }
+
+    /// <summary>
+    /// Looks up the theme default style for this element through the injected
+    /// <see cref="ThemeStyleResolver"/> — first by <see cref="DefaultStyleKey"/>
+    /// (WPF's ThemeStyle lookup key when it is a type), then by walking up the
+    /// type hierarchy. <see cref="OverridesDefaultStyle"/> opts out entirely,
+    /// mirroring WPF.
+    /// </summary>
+    private Style? LookupThemeStyle()
+    {
+        var resolver = ThemeStyleResolver;
+        if (resolver == null)
+            return null;
+
+        if (OverridesDefaultStyle)
+            return null;
+
+        if (DefaultStyleKey is Type keyType)
+        {
+            var keyed = resolver(keyType);
+            if (keyed != null && IsStyleApplicable(keyed))
+                return keyed;
+        }
+
+        var currentType = GetType();
+        while (currentType != null && currentType != typeof(FrameworkElement))
+        {
+            var style = resolver(currentType);
+            if (style != null && IsStyleApplicable(style))
+                return style;
+            currentType = currentType.BaseType;
+        }
+        return null;
     }
 
     /// <summary>

--- a/src/managed/Jalium.UI.Core/Style.cs
+++ b/src/managed/Jalium.UI.Core/Style.cs
@@ -589,6 +589,14 @@ public class Setter : SetterBase, ISupportInitialize
             return;
         }
 
+        // 走到这里说明本 setter 要写"非 dynamic-resource"的值。下层样式（典型为主题默认
+        // 样式，它与本样式共用 StyleSetter 层）可能已在同一 DP 上建立 {ThemeResource}
+        // 订阅——不清掉的话，下一次资源刷新会把主题值重新灌进层里，覆盖我们即将写入的值。
+        // 订阅若来自 local SetDynamicResource 则层不匹配、不受影响（且 local 值存在时
+        // 上面的 HasLocalValue 早已短路）。
+        DynamicResourceBindingOperations.ClearDynamicResource(
+            target, actualProperty, DependencyObject.LayerValueSource.StyleSetter);
+
         // Setter.Value 可以是一个 BindingBase（典型场景：jalxaml 里写
         // <Setter Property="Foo" Value="{TemplateBinding Bar}" /> 或 RelativeSource Binding）。
         // 之前会把整个 BindingBase 当成属性值塞进 layer，OnRender 时强转成 Brush 等

--- a/tests/Jalium.UI.Tests/ImplicitStyleWpfBehaviorTests.cs
+++ b/tests/Jalium.UI.Tests/ImplicitStyleWpfBehaviorTests.cs
@@ -6,6 +6,13 @@ using Jalium.UI.Media;
 
 namespace Jalium.UI.Tests;
 
+/// <summary>
+/// WPF parity: a user Style — explicit or implicit, with or without BasedOn — layers ON TOP
+/// of the theme default style. Properties the user style does not set (most critically the
+/// control Template) keep falling back to the theme defaults, so styling a control never
+/// makes it lose its visual tree. (Regression: Calculator-template buttons vanished because
+/// an explicit Style removed the theme style including its Template setter.)
+/// </summary>
 [Collection("Application")]
 public class ImplicitStyleWpfBehaviorTests
 {
@@ -19,16 +26,16 @@ public class ImplicitStyleWpfBehaviorTests
     }
 
     [Fact]
-    public void ImplicitStyle_OverrideWithoutBasedOn_ShouldNotKeepDefaultTemplate()
+    public void ImplicitStyle_OverrideWithoutBasedOn_KeepsThemeTemplate()
     {
         ResetApplicationState();
         var app = new Application();
 
         try
         {
+            var overrideBackground = new SolidColorBrush(Color.FromRgb(0x11, 0x22, 0x33));
             var overrideStyle = new Style(typeof(ComboBox));
-            overrideStyle.Setters.Add(new Setter(Control.BackgroundProperty, new SolidColorBrush(Color.FromRgb(0x11, 0x22, 0x33))));
-            overrideStyle.Setters.Add(new Setter(Control.ForegroundProperty, new SolidColorBrush(Color.FromRgb(0xEE, 0xEE, 0xEE))));
+            overrideStyle.Setters.Add(new Setter(Control.BackgroundProperty, overrideBackground));
             app.Resources[typeof(ComboBox)] = overrideStyle;
 
             var host = new StackPanel { Width = 400, Height = 200 };
@@ -39,7 +46,72 @@ public class ImplicitStyleWpfBehaviorTests
             host.Arrange(new Rect(0, 0, 400, 200));
 
             Assert.Null(overrideStyle.BasedOn);
-            Assert.Null(comboBox.Template);
+            // The user style's own setter wins…
+            Assert.Same(overrideBackground, comboBox.Background);
+            // …but the theme default style still supplies everything the user style
+            // does not set — the control keeps its default Template and renders.
+            Assert.NotNull(comboBox.Template);
+        }
+        finally
+        {
+            ResetApplicationState();
+        }
+    }
+
+    [Fact]
+    public void ExplicitStyle_WithoutTemplateSetter_KeepsThemeTemplate()
+    {
+        ResetApplicationState();
+        var app = new Application();
+
+        try
+        {
+            var styled = new Button { Content = "styled" };
+            styled.Style = new Style(typeof(Button)); // empty style — no setters at all
+
+            var host = new StackPanel { Width = 400, Height = 200 };
+            host.Children.Add(styled);
+
+            host.Measure(new Size(400, 200));
+            host.Arrange(new Rect(0, 0, 400, 200));
+
+            // An explicit Style must not strip the theme default template.
+            Assert.NotNull(styled.Template);
+        }
+        finally
+        {
+            ResetApplicationState();
+        }
+    }
+
+    [Fact]
+    public void ExplicitStyle_SetterOverridesThemeSetter_OthersFallBack()
+    {
+        ResetApplicationState();
+        var app = new Application();
+
+        try
+        {
+            var explicitBackground = new SolidColorBrush(Color.FromRgb(0x17, 0x28, 0x3D));
+            var style = new Style(typeof(Button));
+            style.Setters.Add(new Setter(Control.BackgroundProperty, explicitBackground));
+
+            var styled = new Button { Content = "styled", Style = style };
+            var plain = new Button { Content = "plain" };
+
+            var host = new StackPanel { Width = 400, Height = 200 };
+            host.Children.Add(styled);
+            host.Children.Add(plain);
+
+            host.Measure(new Size(400, 200));
+            host.Arrange(new Rect(0, 0, 400, 200));
+
+            // Explicit style setter beats the theme setter for the property it sets…
+            Assert.Same(explicitBackground, styled.Background);
+            // …while unset properties match the theme-styled control exactly.
+            Assert.NotNull(styled.Template);
+            Assert.Same(plain.Template, styled.Template);
+            Assert.Equal(plain.MinHeight, styled.MinHeight);
         }
         finally
         {


### PR DESCRIPTION
## 问题

给任何控件设置显式 `Style`（哪怕是零 setter 的空 Style）都会让该控件**彻底不渲染**。根因在 `FrameworkElement.OnStyleChanged`：设置显式 Style 时把已应用的隐式样式（即主题默认样式）整个 `Remove`。主题样式携带控件的 `Template` setter——它一被移除，控件就没有可视树了。

用户可见后果：JaliumUI.Calculator 模板里所有带 `Style="{StaticResource ...}"` 的按钮全部消失（nuget.org 正品 26.10.6 上可复现）。同一根因还有第二个入口：用户在 `Window.Resources` 放一个无 `BasedOn` 的隐式样式，closer-scope 重评估会把主题样式顶掉，同样丢模板。

## 修复（WPF parity：Style / ThemeStyle 分层）

`FrameworkElement` 维护两层样式栈：

- **底层 `_themeStyle`**：主题默认样式，经新增的 `ThemeStyleResolver` 钩子由 `ThemeManager` 解析（带 per-type 缓存；`DefaultStyleKey` 优先、`OverridesDefaultStyle` 退出，与 #156 的 WPF parity 语义对齐）。
- **顶层**：显式 `Style` 或（无显式时的）隐式样式。

顶层后应用——它设置的属性覆盖主题值；它没设置的（最关键是 `Template`）继续从主题层兜底。`OnStyleChanged` / `ApplyImplicitStyleIfNeeded` / `ReEvaluateImplicitStyle` 统一收敛到 `UpdateStyleStack`，含同对象归一化防御（显式 Style 恰为主题样式对象时不重复 attach trigger）。

配套修复：`Setter.Apply` 写普通值前，退掉同一 DP 上 **StyleSetter 层**的既有 `{ThemeResource}` 订阅——否则主题刷新会把主题值重新灌回同层、覆盖显式值（local 层的动态资源订阅不受影响）。

## 测试

`ImplicitStyle_OverrideWithoutBasedOn_ShouldNotKeepDefaultTemplate` 断言的正是这次的 bug 行为（隐式覆盖后 `Template == null`），与真实 WPF 相反，已改写为 `..._KeepsThemeTemplate` 并新增两个用例锁定修正语义（显式 Style 保留模板 / 显式 setter 覆盖主题 setter 且其余回退）。

- `FullyQualifiedName~Style|Theme|Trigger` 过滤集：**255/255 通过**（本分支基于最新 master）。
- 端到端：Calculator 模板在 d3d12 / vulkan / software 三后端按钮网格完整渲染，鼠标点击 7+8=15 全链路正常（本地 pack 全套包验证，含新构建 native）。

## 已知行为偏差（有意为之，非本 PR 范围）

主题样式的 `Style.Triggers`（hover/pressed）现在对带显式 Style 的控件也会挂载：hover 时 StyleTrigger 层的主题 hover 色会临时覆盖显式背景。WPF 中 ThemeStyle trigger 位于更低优先级层，被 Style setter 压住。如需完全对齐需要把层模型拆出独立的 ThemeStyle trigger/setter 层，留待后续。

🤖 Generated with [Claude Code](https://claude.com/claude-code)