### PR TITLE
Rename retired WPF-named compatibility files

### DIFF
--- a/src/managed/Jalium.UI.Controls/ValueConverters.cs
+++ b/src/managed/Jalium.UI.Controls/ValueConverters.cs
@@ -6,7 +6,7 @@ using Jalium.UI.Markup;
 namespace Jalium.UI.Controls;
 
 /// <summary>
-/// Converts an alternation index to the corresponding item in <see cref="Values"/>.
+/// Converts an alternation index to the selected item in <see cref="Values"/>.
 /// </summary>
 [ContentProperty(nameof(Values))]
 public class AlternationConverter : IValueConverter

--- a/tests/Jalium.UI.Tests/CanonicalTypeConflictTests.cs
+++ b/tests/Jalium.UI.Tests/CanonicalTypeConflictTests.cs
@@ -4,10 +4,10 @@ using Jalium.UI.Media;
 namespace Jalium.UI.Tests;
 
 /// <summary>
-/// Guards canonical WPF namespace ownership so historical compatibility types cannot
+/// Guards canonical namespace ownership so historical compatibility types cannot
 /// quietly become public again.
 /// </summary>
-public sealed class WpfCanonicalTypeConflictTests
+public sealed class CanonicalTypeConflictTests
 {
     [Fact]
     public void ControlsTypes_AreNotPublishedFromThePrimitivesNamespace()
@@ -41,7 +41,7 @@ public sealed class WpfCanonicalTypeConflictTests
     }
 
     [Fact]
-    public void BlurEffect_NameIsReservedForTheCanonicalWpfElementEffect()
+    public void BlurEffect_NameIsReservedForTheCanonicalElementEffect()
     {
         Type[] exported = typeof(FrameworkElement).Assembly.GetExportedTypes();
 

--- a/tests/Jalium.UI.Tests/CompatibilityAmbiguityTests.cs
+++ b/tests/Jalium.UI.Tests/CompatibilityAmbiguityTests.cs
@@ -3,10 +3,10 @@ using Jalium.UI;
 
 namespace Jalium.UI.Tests;
 
-public sealed class WpfCompatibilityAmbiguityTests
+public sealed class CompatibilityAmbiguityTests
 {
     [Fact]
-    public void RetiredWpfAliasesAreNeitherExportedNorForwarded()
+    public void RetiredCompatibilityAliasesAreNeitherExportedNorForwarded()
     {
         var retiredNames = new HashSet<string>(StringComparer.Ordinal)
         {

--- a/tests/Jalium.UI.Tests/UtilityTypeShapeParityTests.cs
+++ b/tests/Jalium.UI.Tests/UtilityTypeShapeParityTests.cs
@@ -5,12 +5,12 @@ using JaliumCommandManager = Jalium.UI.Input.CommandManager;
 
 namespace Jalium.UI.Tests;
 
-public sealed class WpfUtilityTypeShapeParityTests
+public sealed class UtilityTypeShapeParityTests
 {
     [Fact]
-    public void CommandManagerUsesTheWpfSealedUtilityTypeShape()
+    public void CommandManagerUsesTheCanonicalSealedUtilityTypeShape()
     {
-        AssertWpfUtilityType(
+        AssertCanonicalUtilityType(
             typeof(JaliumCommandManager),
             nameof(JaliumCommandManager.InvalidateRequerySuggested),
             nameof(JaliumCommandManager.RequerySuggested),
@@ -18,24 +18,24 @@ public sealed class WpfUtilityTypeShapeParityTests
     }
 
     [Fact]
-    public void BrushesUsesTheWpfSealedUtilityTypeShape()
+    public void BrushesUsesTheCanonicalSealedUtilityTypeShape()
     {
-        AssertWpfUtilityType(
+        AssertCanonicalUtilityType(
             typeof(JaliumBrushes),
             nameof(JaliumBrushes.Black),
             nameof(JaliumBrushes.Transparent));
     }
 
     [Fact]
-    public void ColorsUsesTheWpfSealedUtilityTypeShape()
+    public void ColorsUsesTheCanonicalSealedUtilityTypeShape()
     {
-        AssertWpfUtilityType(
+        AssertCanonicalUtilityType(
             typeof(JaliumColors),
             nameof(JaliumColors.Black),
             nameof(JaliumColors.Transparent));
     }
 
-    private static void AssertWpfUtilityType(Type type, params string[] requiredStaticMembers)
+    private static void AssertCanonicalUtilityType(Type type, params string[] requiredStaticMembers)
     {
         Assert.True(type.IsPublic, type.FullName);
         Assert.True(type.IsClass, type.FullName);


### PR DESCRIPTION
## What changed

- Rename `WpfValueConverters.cs` to `ValueConverters.cs`.
- Rename the three remaining `Wpf*` compatibility test files to neutral canonical names.
- Rename the affected test classes and methods so the old prefix is not retained in compiled test identifiers.

## Why

PR #159 intended this cleanup, but its squash merge interacted with files introduced on the updated base and left both old and canonical paths on `master`. PR #160 then reverted #159. This PR is rebuilt directly on the latest post-revert `master` and applies only the four naming migrations, without restoring unrelated #159 changes.

## Impact

There is no public API or behavior change. The same converter implementation and parity coverage remain, now under canonical filenames and test identifiers.

## Validation

The validated tree SHA is identical to this PR head tree.

- `dotnet build Jalium.UI.slnx --no-restore -m:1 -p:BuildInParallel=false` — succeeded
- Targeted compatibility tests — 17/17 passed
- Existing tracked `Wpf` filename scan — clean
- `git diff --check` — passed

Known existing warnings remain limited to nullable test inputs and the already-missing `Jalium.UI.DeviceLostHarness` project.