### PR TITLE
fix(android): defer remote HTTP client initialization

### DIFF
--- a/src/managed/Jalium.UI.Controls/Application.cs
+++ b/src/managed/Jalium.UI.Controls/Application.cs
@@ -1130,7 +1130,12 @@ public partial class Application : Jalium.UI.Threading.DispatcherObject, IQueryA
 
     private const string ComponentSeparator = ";component/";
     private static readonly CookieContainer s_cookieContainer = new();
-    private static readonly HttpClient s_remoteClient = CreateRemoteClient();
+    // Generated XAML module initializers assign the loader hooks below before the
+    // Android NativeAOT host has attached Java.Interop to the VM. Constructing an
+    // HttpClientHandler here would eagerly instantiate AndroidMessageHandler, which
+    // queries Android.OS.Build.VERSION and fails because no JniRuntime exists yet.
+    // Keep the handler lazy so type initialization remains platform-neutral.
+    private static readonly Lazy<HttpClient> s_remoteClient = new(CreateRemoteClient);
 
     /// <summary>
     /// Runtime hook installed by Jalium.UI.Xaml for loading XAML into an existing object.
@@ -1257,7 +1262,7 @@ public partial class Application : Jalium.UI.Threading.DispatcherObject, IQueryA
                 nameof(uriRemote));
         }
 
-        using var response = s_remoteClient.GetAsync(uriRemote, HttpCompletionOption.ResponseHeadersRead)
+        using var response = s_remoteClient.Value.GetAsync(uriRemote, HttpCompletionOption.ResponseHeadersRead)
             .GetAwaiter()
             .GetResult();
         if (response.StatusCode == HttpStatusCode.NotFound)

--- a/tests/Jalium.UI.Tests/ApplicationResourceNavigationParityTests.cs
+++ b/tests/Jalium.UI.Tests/ApplicationResourceNavigationParityTests.cs
@@ -14,6 +14,17 @@ namespace Jalium.UI.Tests;
 public sealed class ApplicationResourceNavigationParityTests
 {
     [Fact]
+    public void ApplicationTypeInitialization_DoesNotCreateRemoteHttpHandler()
+    {
+        var field = typeof(Application).GetField(
+            "s_remoteClient",
+            BindingFlags.NonPublic | BindingFlags.Static);
+
+        var remoteClient = Assert.IsType<Lazy<HttpClient>>(field!.GetValue(null));
+        Assert.False(remoteClient.IsValueCreated);
+    }
+
+    [Fact]
     public void Application_ExposesCanonicalResourceAndNavigationContracts()
     {
         Assert.Equal(typeof(StreamResourceInfo),


### PR DESCRIPTION
## Summary

- Defer creation of the shared remote-resource HttpClient until the first remote request.
- Prevent generated XAML module initializers from touching Android Java.Interop before the VM is attached.
- Add a regression test proving Application type initialization does not create the remote HTTP handler.

## Validation

- `dotnet test tests\Jalium.UI.Tests\Jalium.UI.Tests.csproj -c Release --filter FullyQualifiedName~ApplicationResourceNavigationParityTests`: 7/7 passed.
- Gallery Android x64 NativeAOT APK installed and launched successfully on an API 24 emulator; no fatal or unhandled startup logs.

## Consumer

Pinned by Jalium UI Gallery v1.1.0 (`799e0c05b8d4ef29a4e02ae086521086e53c0c46`).