### PR TITLE
fix: negative Size crash when arranging with stale DesiredSize (theme switch)

### DIFF
--- a/src/managed/Jalium.UI.Controls/ScrollViewer.cs
+++ b/src/managed/Jalium.UI.Controls/ScrollViewer.cs
@@ -2471,13 +2471,17 @@ public partial class ScrollViewer : ContentControl
         UpdateScrollBarMetrics();
     }
 
-    private Size GetContentMargin()
+    private (double Width, double Height) GetContentMargin()
     {
         if (ContentElement is not FrameworkElement frameworkElement)
-            return default(Size);
+            return default;
 
         var margin = frameworkElement.Margin;
-        return new Size(
+        // The per-axis sums can legitimately be negative (negative margins are valid
+        // and shrink the scrollable extent), so they must not round-trip through
+        // Size — its constructor throws on negative dimensions. The extent addition
+        // in SyncExtentFromScrollInfo clamps the combined result to zero.
+        return (
             CoerceFiniteMargin(margin.Left) + CoerceFiniteMargin(margin.Right),
             CoerceFiniteMargin(margin.Top) + CoerceFiniteMargin(margin.Bottom));
     }

--- a/src/managed/Jalium.UI.Core/FrameworkElement.cs
+++ b/src/managed/Jalium.UI.Core/FrameworkElement.cs
@@ -1143,9 +1143,12 @@ public partial class FrameworkElement : UIElement, IFrameworkInputElement, Marku
         var availableWidth = Math.Max(0, finalRect.Width - marginWidth);
         var availableHeight = Math.Max(0, finalRect.Height - marginHeight);
 
-        // Get the desired size (set during Measure)
-        var desiredWidth = DesiredSize.Width - marginWidth;
-        var desiredHeight = DesiredSize.Height - marginHeight;
+        // Get the desired size (set during Measure). DesiredSize can be stale relative
+        // to the current margin (margin changed after the last measure, or the element
+        // was never measured — e.g. a template rebuild arranged before its measure pass),
+        // so the subtraction must clamp to zero like WPF does; Size throws on negatives.
+        var desiredWidth = Math.Max(0, DesiredSize.Width - marginWidth);
+        var desiredHeight = Math.Max(0, DesiredSize.Height - marginHeight);
 
         // Determine arrange size based on alignment
         // When alignment is Stretch, use available size; otherwise use desired size (clamped to available)

--- a/tests/Jalium.UI.Tests/FrameworkElementArrangeClampTests.cs
+++ b/tests/Jalium.UI.Tests/FrameworkElementArrangeClampTests.cs
@@ -1,0 +1,51 @@
+using Jalium.UI.Controls;
+
+namespace Jalium.UI.Tests;
+
+public class FrameworkElementArrangeClampTests
+{
+    [Fact]
+    public void ArrangeCore_ShouldNotThrow_WhenArrangedBeforeMeasure_WithMargin()
+    {
+        // Regression: a theme switch / template rebuild can arrange an element whose
+        // measure pass has not run yet, so DesiredSize is still (0,0). With a
+        // horizontal margin of 9+9 and a non-stretch alignment the desired-minus-margin
+        // subtraction used to produce -18 and throw from the Size constructor
+        // ("Width and Height cannot be negative."). ArrangeCore must clamp instead.
+        var element = new Border
+        {
+            Margin = new Thickness(9, 0, 9, 0),
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top,
+        };
+
+        element.Arrange(new Rect(0, 0, 100, 50));
+
+        Assert.Equal(0, element.RenderSize.Width);
+        Assert.Equal(0, element.RenderSize.Height);
+    }
+
+    [Fact]
+    public void ArrangeCore_ShouldClampStaleDesiredSize_WhenMarginGrewAfterMeasure()
+    {
+        // DesiredSize is captured at measure time with the old margin. Growing the
+        // margin afterwards (style/theme change) makes DesiredSize - margin negative
+        // until the pending re-measure runs; the arrange that happens in between must
+        // clamp rather than throw.
+        var element = new Border
+        {
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top,
+            Width = 10,
+            Height = 10,
+        };
+
+        element.Measure(new Size(100, 50));
+        element.Margin = new Thickness(12, 0, 12, 0);
+
+        element.Arrange(new Rect(0, 0, 100, 50));
+
+        Assert.Equal(10, element.RenderSize.Width);
+        Assert.Equal(10, element.RenderSize.Height);
+    }
+}

--- a/tests/Jalium.UI.Tests/ScrollViewerScrollBarMetricsTests.cs
+++ b/tests/Jalium.UI.Tests/ScrollViewerScrollBarMetricsTests.cs
@@ -57,6 +57,34 @@ public class ScrollViewerScrollBarMetricsTests
     }
 
     [Fact]
+    public void ScrollViewer_WithNegativeContentMargin_ShouldNotThrowAndShrinkExtent()
+    {
+        // Regression: GetContentMargin used to funnel the per-axis margin sums
+        // through the Size constructor, which throws on negatives. A content
+        // element with e.g. Margin="-9,0,-9,0" (horizontal sum -18) crashed the
+        // layout pass instead of shrinking the scrollable extent.
+        var content = new StackPanel
+        {
+            Margin = new Thickness(-9, 0, -9, 0)
+        };
+        content.Children.Add(new Border { Height = 120 });
+        content.Children.Add(new Border { Height = 120 });
+
+        var viewer = new ScrollViewer
+        {
+            Content = content,
+            Width = 160,
+            Height = 160,
+            VerticalScrollBarVisibility = ScrollBarVisibility.Auto
+        };
+
+        viewer.Measure(new Size(160, 160));
+        viewer.Arrange(new Rect(0, 0, 160, 160));
+
+        Assert.Equal(240, viewer.ExtentHeight, precision: 3);
+    }
+
+    [Fact]
     public void ConfigureScrollBar_NonFiniteMetrics_ShouldClampToSafeDefaults()
     {
         var scrollBar = new ScrollBar


### PR DESCRIPTION
## 问题

Jalium.UI.Gallery 多次快速点击主题切换 / 切换 component 页面后崩溃：

```
System.ArgumentException: Width and Height cannot be negative.
   at Jalium.UI.Size..ctor(...) Primitives.cs:289
   at Jalium.UI.FrameworkElement.ArrangeCore(Rect finalRect) FrameworkElement.cs:1160
   at Jalium.UI.UIElement.Arrange(...)
   at Jalium.UI.Controls.Border.ArrangeOverride(...)
   ...
```

调试器实测入参 `width = -18, height = 0`。

## 根因

`ArrangeCore` 中 `availableWidth` 的减法有 `Math.Max(0, ...)` 钳制，但 **`desiredWidth = DesiredSize.Width - marginWidth` 没有**。当元素的 `DesiredSize` 相对当前 `Margin` 过期时（主题切换触发模板重建，新建的模板子树在 measure pass 之外被急切构建、尚未测量即被 Arrange；或 measure 之后 Style/主题把 Margin 改大），差值即为负；非 Stretch 对齐走 `Math.Min(desiredWidth, availableWidth)` 分支，负值直入 `new Size` 抛异常。

`-18/0` 的精确来源：Gallery 首页设备按钮 `Padding = new Thickness(9, 0, 9, 0)`，经 Button 模板 `Margin="{TemplateBinding Padding}"` 成为 ContentPresenter 的 Margin（水平和 18、垂直和 0），`HorizontalContentAlignment` 默认 Center（非 Stretch）；未测量时 `0 − 18 = −18`、`0 − 0 = 0`。"多次点击才崩"对应命中"模板重建后、补测完成前"的窄时序窗口。

## 修复

1. **FrameworkElement.ArrangeCore**：desired − margin 两处减法加 `Math.Max(0, ...)`（与 WPF 行为一致，与同函数上方 available 的钳制对称）。
2. **ScrollViewer.GetContentMargin**（排查中发现的同类缺陷，顺带加固）：负 margin 是合法用法（缩小可滚动 extent），但此处把可为负的"边距和"塞进了会在负值上抛异常的 `Size`。改为返回命名元组；唯一调用点 `SyncExtentFromScrollInfo` 的 extent 加法已有归零钳制，行为不变。

## 验证

- 修复前：自动化重放"快速交替切主题/切组件"，18 次点击内必崩（stderr 捕获完整栈）。
- 修复后：同序列加倍（36 击）进程存活、stderr 零输出。
- 新增 4 个回归测试（arrange-before-measure、measure 后 margin 变大、负内容 margin 缩 extent），全部通过。
- 布局相关测试套（Layout/Arrange/Measure/StackPanel/Grid 等 168 项）全绿无回归。
