### PR TITLE
test(android): update 26.10.8 NuGet consumer hosting API

### DIFF
--- a/tests/Jalium.UI.NuGetTest.Android/MainActivity.cs
+++ b/tests/Jalium.UI.NuGetTest.Android/MainActivity.cs
@@ -15,10 +15,8 @@ namespace Jalium.UI.NuGetTest.Android;
     Theme = "@android:style/Theme.NoTitleBar.Fullscreen")]
 public class MainActivity : JaliumActivity
 {
-    protected override Application CreateApplication()
+    protected override JaliumApp CreateHostedApp()
     {
-        var app = new Application();
-
         var window = new Window
         {
             Title = "NuGet Package Test - Android",
@@ -53,7 +51,9 @@ public class MainActivity : JaliumActivity
         });
 
         window.Content = root;
-        app.MainWindow = window;
-        return app;
+
+        var builder = AppBuilder.CreateBuilder();
+        builder.ConfigureApplication(app => app.MainWindow = window);
+        return builder.Build();
     }
 }


### PR DESCRIPTION
## Summary

- update the Android NuGet consumer smoke app from the retired `CreateApplication()` override to the current `CreateHostedApp()` hosting API
- keep the release gate compiling against the actual `Jalium.UI.Android` 26.10.8 package

## Validation

- restored all dependencies from the isolated 26.10.8 local NuGet feed
- `dotnet build tests/Jalium.UI.NuGetTest.Android/Jalium.UI.NuGetTest.Android.csproj -c Release`: succeeded for both Android ABIs (0 errors)
- [Linux CI run #70](https://github.com/VeryJokerJal/Jalium.UI/actions/runs/30526202941): glibc x64/arm64, musl x64/arm64, combined package closure, platform integration, and NativeAOT consumers passed